### PR TITLE
Display key profile info in TestSetup list

### DIFF
--- a/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
@@ -166,6 +166,15 @@
                 </Grid>
             </StackPanel>
         </DataTemplate>
+
+        <!-- Shared style for profile list items -->
+        <Style x:Key="ProfileListItemStyle" TargetType="ListBoxItem">
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Padding" Value="4"/>
+            <Setter Property="Margin" Value="0,0,0,4"/>
+            <Setter Property="MinHeight" Value="40"/>
+        </Style>
     </UserControl.Resources>
 
     <Grid>
@@ -199,7 +208,16 @@
                         </StackPanel>
                         <ListBox ItemsSource="{Binding ChargeProfiles}"
                                  SelectedItem="{Binding SelectedChargeProfile, Mode=TwoWay}"
-                                 DisplayMemberPath="DisplayNameAndId"/>
+                                 ItemContainerStyle="{StaticResource ProfileListItemStyle}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding DisplayNameAndId}" FontWeight="Bold"/>
+                                        <TextBlock Text="{Binding ChargeCurrent, StringFormat='Charge Current: {0} A'}" FontSize="11" Margin="0,2,0,0"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
                     </DockPanel>
                 </TabItem>
                 <TabItem Header="Discharge">
@@ -210,7 +228,22 @@
                         </StackPanel>
                         <ListBox ItemsSource="{Binding DischargeProfiles}"
                                  SelectedItem="{Binding SelectedDischargeProfile, Mode=TwoWay}"
-                                 DisplayMemberPath="DisplayNameAndId"/>
+                                 ItemContainerStyle="{StaticResource ProfileListItemStyle}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding DisplayNameAndId}" FontWeight="Bold"/>
+                                        <TextBlock FontSize="11" Margin="0,2,0,0">
+                                            <Run Text="Mode: "/>
+                                            <Run Text="{Binding DischargeMode}"/>
+                                            <Run Text=", Current: "/>
+                                            <Run Text="{Binding DischargeCurrent}"/>
+                                            <Run Text=" A"/>
+                                        </TextBlock>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
                     </DockPanel>
                 </TabItem>
                 <TabItem Header="ECM">
@@ -221,7 +254,16 @@
                         </StackPanel>
                         <ListBox ItemsSource="{Binding EcmPulseProfiles}"
                                  SelectedItem="{Binding SelectedEcmPulseProfile, Mode=TwoWay}"
-                                 DisplayMemberPath="DisplayNameAndId"/>
+                                 ItemContainerStyle="{StaticResource ProfileListItemStyle}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding DisplayNameAndId}" FontWeight="Bold"/>
+                                        <TextBlock Text="{Binding PulseDuration, StringFormat='Pulse Duration: {0} ms'}" FontSize="11" Margin="0,2,0,0"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
                     </DockPanel>
                 </TabItem>
                 <TabItem Header="OCV">
@@ -232,7 +274,16 @@
                         </StackPanel>
                         <ListBox ItemsSource="{Binding OcvProfiles}"
                                  SelectedItem="{Binding SelectedOcvProfile, Mode=TwoWay}"
-                                 DisplayMemberPath="DisplayNameAndId"/>
+                                 ItemContainerStyle="{StaticResource ProfileListItemStyle}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding DisplayNameAndId}" FontWeight="Bold"/>
+                                        <TextBlock Text="{Binding Qmax, StringFormat='Qmax: {0}'}" FontSize="11" Margin="0,2,0,0"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
                     </DockPanel>
                 </TabItem>
                 <TabItem Header="Rest">
@@ -243,7 +294,16 @@
                         </StackPanel>
                         <ListBox ItemsSource="{Binding RestProfiles}"
                                  SelectedItem="{Binding SelectedRestProfile, Mode=TwoWay}"
-                                 DisplayMemberPath="DisplayNameAndId"/>
+                                 ItemContainerStyle="{StaticResource ProfileListItemStyle}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding DisplayNameAndId}" FontWeight="Bold"/>
+                                        <TextBlock Text="{Binding RestTime, StringFormat='Rest Time: {0} s'}" FontSize="11" Margin="0,2,0,0"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
                     </DockPanel>
                 </TabItem>
             </TabControl>


### PR DESCRIPTION
## Summary
- Replace `DisplayMemberPath` in TestSetup profile lists with custom `ItemTemplate`s showing ID, name and a key property.
- Add shared ListBoxItem style for consistent spacing and alignment.

## Testing
- `dotnet test` *(warnings about missing e_sqlite3, but 6 tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fe8c5b788323ae7db9bb41aa72bc