### PR TITLE
Show summary previews for test profiles

### DIFF
--- a/CellManager/CellManager/Models/TestProfile/ChargeProfile.cs
+++ b/CellManager/CellManager/Models/TestProfile/ChargeProfile.cs
@@ -12,8 +12,18 @@ namespace CellManager.Models.TestProfile
 
         public string DisplayNameAndId => $"ID: {Id} - {Name}";
 
-        [ObservableProperty] private double _chargeCurrent;
-        [ObservableProperty] private double _chargeCutoffVoltage;
-        [ObservableProperty] private double _cutoffCurrent;
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private double _chargeCurrent;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private double _chargeCutoffVoltage;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private double _cutoffCurrent;
+
+        public string PreviewText => $"Current: {ChargeCurrent} A, Cutoff: {ChargeCutoffVoltage} V, Cutoff Current: {CutoffCurrent} A";
     }
 }

--- a/CellManager/CellManager/Models/TestProfile/DischargeProfile.cs
+++ b/CellManager/CellManager/Models/TestProfile/DischargeProfile.cs
@@ -12,9 +12,22 @@ namespace CellManager.Models.TestProfile
 
         public string DisplayNameAndId => $"ID: {Id} - {Name}";
 
-        [ObservableProperty] private string _dischargeMode;
-        [ObservableProperty] private double _dischargeCurrent;
-        [ObservableProperty] private double _dischargeCutoffVoltage;
-        [ObservableProperty] private double _dischargeCapacityMah;
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private string _dischargeMode;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private double _dischargeCurrent;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private double _dischargeCutoffVoltage;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private double _dischargeCapacityMah;
+
+        public string PreviewText => $"Mode: {DischargeMode}, Current: {DischargeCurrent} A, Cutoff: {DischargeCutoffVoltage} V, Capacity: {DischargeCapacityMah} mAh";
     }
 }

--- a/CellManager/CellManager/Models/TestProfile/ECMPulseProfile.cs
+++ b/CellManager/CellManager/Models/TestProfile/ECMPulseProfile.cs
@@ -12,9 +12,22 @@ namespace CellManager.Models.TestProfile
 
         public string DisplayNameAndId => $"ID: {Id} - {Name}";
 
-        [ObservableProperty] private double _pulseCurrent;
-        [ObservableProperty] private double _pulseDuration;
-        [ObservableProperty] private double _resetTimeAfterPulse;
-        [ObservableProperty] private double _samplingRateMs;
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private double _pulseCurrent;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private double _pulseDuration;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private double _resetTimeAfterPulse;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private double _samplingRateMs;
+
+        public string PreviewText => $"Current: {PulseCurrent} A, Duration: {PulseDuration} ms, Reset: {ResetTimeAfterPulse} ms, Sample: {SamplingRateMs} ms";
     }
 }

--- a/CellManager/CellManager/Models/TestProfile/OCVProfile.cs
+++ b/CellManager/CellManager/Models/TestProfile/OCVProfile.cs
@@ -12,10 +12,26 @@ namespace CellManager.Models.TestProfile
 
         public string DisplayNameAndId => $"ID: {Id} - {Name}";
 
-        [ObservableProperty] private double _qmax;
-        [ObservableProperty] private double _socStepPercent;
-        [ObservableProperty] private double _dischargeCurrent_OCV;
-        [ObservableProperty] private double _restTime_OCV;
-        [ObservableProperty] private double _dischargeCutoffVoltage_OCV;
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private double _qmax;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private double _socStepPercent;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private double _dischargeCurrent_OCV;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private double _restTime_OCV;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private double _dischargeCutoffVoltage_OCV;
+
+        public string PreviewText => $"Qmax: {Qmax}, SOC Step: {SocStepPercent} %, Current: {DischargeCurrent_OCV} A, Rest: {RestTime_OCV} s, Cutoff: {DischargeCutoffVoltage_OCV} V";
     }
 }

--- a/CellManager/CellManager/Models/TestProfile/RestProfile.cs
+++ b/CellManager/CellManager/Models/TestProfile/RestProfile.cs
@@ -12,6 +12,10 @@ namespace CellManager.Models.TestProfile
 
         public string DisplayNameAndId => $"ID: {Id} - {Name}";
 
-        [ObservableProperty] private double _restTime;
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private double _restTime;
+
+        public string PreviewText => $"Rest Time: {RestTime} s";
     }
 }

--- a/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
@@ -213,7 +213,11 @@
                                 <DataTemplate>
                                     <StackPanel>
                                         <TextBlock Text="{Binding DisplayNameAndId}" FontWeight="Bold"/>
-                                        <TextBlock Text="{Binding ChargeCurrent, StringFormat='Charge Current: {0} A'}" FontSize="11" Margin="0,2,0,0"/>
+                                        <TextBlock Text="{Binding PreviewText}"
+                                                   FontSize="11"
+                                                   Margin="0,2,0,0"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   ToolTip="{Binding PreviewText}"/>
                                     </StackPanel>
                                 </DataTemplate>
                             </ListBox.ItemTemplate>
@@ -233,13 +237,11 @@
                                 <DataTemplate>
                                     <StackPanel>
                                         <TextBlock Text="{Binding DisplayNameAndId}" FontWeight="Bold"/>
-                                        <TextBlock FontSize="11" Margin="0,2,0,0">
-                                            <Run Text="Mode: "/>
-                                            <Run Text="{Binding DischargeMode}"/>
-                                            <Run Text=", Current: "/>
-                                            <Run Text="{Binding DischargeCurrent}"/>
-                                            <Run Text=" A"/>
-                                        </TextBlock>
+                                        <TextBlock Text="{Binding PreviewText}"
+                                                   FontSize="11"
+                                                   Margin="0,2,0,0"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   ToolTip="{Binding PreviewText}"/>
                                     </StackPanel>
                                 </DataTemplate>
                             </ListBox.ItemTemplate>
@@ -259,7 +261,11 @@
                                 <DataTemplate>
                                     <StackPanel>
                                         <TextBlock Text="{Binding DisplayNameAndId}" FontWeight="Bold"/>
-                                        <TextBlock Text="{Binding PulseDuration, StringFormat='Pulse Duration: {0} ms'}" FontSize="11" Margin="0,2,0,0"/>
+                                        <TextBlock Text="{Binding PreviewText}"
+                                                   FontSize="11"
+                                                   Margin="0,2,0,0"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   ToolTip="{Binding PreviewText}"/>
                                     </StackPanel>
                                 </DataTemplate>
                             </ListBox.ItemTemplate>
@@ -279,7 +285,11 @@
                                 <DataTemplate>
                                     <StackPanel>
                                         <TextBlock Text="{Binding DisplayNameAndId}" FontWeight="Bold"/>
-                                        <TextBlock Text="{Binding Qmax, StringFormat='Qmax: {0}'}" FontSize="11" Margin="0,2,0,0"/>
+                                        <TextBlock Text="{Binding PreviewText}"
+                                                   FontSize="11"
+                                                   Margin="0,2,0,0"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   ToolTip="{Binding PreviewText}"/>
                                     </StackPanel>
                                 </DataTemplate>
                             </ListBox.ItemTemplate>
@@ -299,7 +309,11 @@
                                 <DataTemplate>
                                     <StackPanel>
                                         <TextBlock Text="{Binding DisplayNameAndId}" FontWeight="Bold"/>
-                                        <TextBlock Text="{Binding RestTime, StringFormat='Rest Time: {0} s'}" FontSize="11" Margin="0,2,0,0"/>
+                                        <TextBlock Text="{Binding PreviewText}"
+                                                   FontSize="11"
+                                                   Margin="0,2,0,0"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   ToolTip="{Binding PreviewText}"/>
                                     </StackPanel>
                                 </DataTemplate>
                             </ListBox.ItemTemplate>


### PR DESCRIPTION
## Summary
- Add `PreviewText` computed property to all test profile models for quick summary of key settings.
- Display consolidated preview text in test setup list views with trimming and tooltip for long entries.

## Testing
- `dotnet test CellManager/CellManager.sln` *(fails: Unable to load shared library 'e_sqlite3' or one of its dependencies, tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68b788b48f7483239a647457fadf1228