### PR TITLE
Add time-based discharge profile options

### DIFF
--- a/CellManager/CellManager/Models/TestProfile/DischargeProfile.cs
+++ b/CellManager/CellManager/Models/TestProfile/DischargeProfile.cs
@@ -1,7 +1,15 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using System;
 
 namespace CellManager.Models.TestProfile
 {
+    public enum DischargeMode
+    {
+        DischargeByCapacity,
+        DischargeByTime,
+        FullDischarge
+    }
+
     public partial class DischargeProfile : ObservableObject
     {
         [ObservableProperty] private int _id;
@@ -14,7 +22,7 @@ namespace CellManager.Models.TestProfile
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(PreviewText))]
-        private string _dischargeMode;
+        private DischargeMode _dischargeMode;
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(PreviewText))]
@@ -26,8 +34,24 @@ namespace CellManager.Models.TestProfile
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(PreviewText))]
-        private double _dischargeCapacityMah;
+        private TimeSpan _dischargeTime;
 
-        public string PreviewText => $"Mode: {DischargeMode}, Current: {DischargeCurrent} A, Cutoff: {DischargeCutoffVoltage} V, Capacity: {DischargeCapacityMah} mAh";
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(PreviewText))]
+        private double? _dischargeCapacityMah;
+
+        public string PreviewText
+        {
+            get
+            {
+                var modeText = DischargeMode switch
+                {
+                    DischargeMode.DischargeByCapacity => $"Capacity: {DischargeCapacityMah} mAh",
+                    DischargeMode.DischargeByTime => $"Time: {DischargeTime}",
+                    _ => "Full discharge"
+                };
+                return $"Mode: {DischargeMode}, Current: {DischargeCurrent} A, Cutoff: {DischargeCutoffVoltage} V, {modeText}";
+            }
+        }
     }
 }

--- a/CellManager/CellManager/Services/SQLiteDischargeProfileRepository.cs
+++ b/CellManager/CellManager/Services/SQLiteDischargeProfileRepository.cs
@@ -29,17 +29,36 @@ namespace CellManager.Services
                     DischargeMode TEXT,
                     DischargeCurrent REAL,
                     DischargeCutoffVoltage REAL,
-                    DischargeCapacityMah REAL
+                    DischargeCapacityMah REAL,
+                    DischargeTimeSeconds REAL
                 );";
             using var cmd = new SQLiteCommand(sql, conn);
             cmd.ExecuteNonQuery();
+
+            // Migration: ensure DischargeTimeSeconds column exists
+            using var pragma = new SQLiteCommand("PRAGMA table_info(DischargeProfiles);", conn);
+            using var reader = pragma.ExecuteReader();
+            var hasTime = false;
+            while (reader.Read())
+            {
+                if (string.Equals(Convert.ToString(reader["name"]), "DischargeTimeSeconds", StringComparison.OrdinalIgnoreCase))
+                {
+                    hasTime = true;
+                    break;
+                }
+            }
+            if (!hasTime)
+            {
+                using var alter = new SQLiteCommand("ALTER TABLE DischargeProfiles ADD COLUMN DischargeTimeSeconds REAL;", conn);
+                alter.ExecuteNonQuery();
+            }
         }
         public ObservableCollection<DischargeProfile> Load(int cellId)
         {
             var list = new ObservableCollection<DischargeProfile>();
             using var conn = new SQLiteConnection($"Data Source={_dbPath};Version=3;");
             conn.Open();
-            var sql = "SELECT Id, Name, DischargeMode, DischargeCurrent, DischargeCutoffVoltage, DischargeCapacityMah FROM DischargeProfiles WHERE CellId=@CellId ORDER BY Name;";
+            var sql = "SELECT Id, Name, DischargeMode, DischargeCurrent, DischargeCutoffVoltage, DischargeCapacityMah, DischargeTimeSeconds FROM DischargeProfiles WHERE CellId=@CellId ORDER BY Name;";
             using var cmd = new SQLiteCommand(sql, conn);
             cmd.Parameters.AddWithValue("@CellId", cellId);
             using var r = cmd.ExecuteReader();
@@ -49,10 +68,11 @@ namespace CellManager.Services
                 {
                     Id = Convert.ToInt32(r["Id"]),
                     Name = Convert.ToString(r["Name"]),
-                    DischargeMode = r["DischargeMode"] as string,
+                    DischargeMode = Enum.TryParse<DischargeMode>(Convert.ToString(r["DischargeMode"]), out var mode) ? mode : DischargeMode.FullDischarge,
                     DischargeCurrent = r["DischargeCurrent"] == DBNull.Value ? 0 : Convert.ToDouble(r["DischargeCurrent"]),
                     DischargeCutoffVoltage = r["DischargeCutoffVoltage"] == DBNull.Value ? 0 : Convert.ToDouble(r["DischargeCutoffVoltage"]),
-                    DischargeCapacityMah = r["DischargeCapacityMah"] == DBNull.Value ? 0 : Convert.ToDouble(r["DischargeCapacityMah"])
+                    DischargeCapacityMah = r["DischargeCapacityMah"] == DBNull.Value ? null : (double?)Convert.ToDouble(r["DischargeCapacityMah"]),
+                    DischargeTime = r["DischargeTimeSeconds"] == DBNull.Value ? TimeSpan.Zero : TimeSpan.FromSeconds(Convert.ToDouble(r["DischargeTimeSeconds"]))
                 });
             }
             return list;
@@ -63,29 +83,31 @@ namespace CellManager.Services
             conn.Open();
             if (p.Id == 0)
             {
-                var sql = @"INSERT INTO DischargeProfiles(CellId, Name, DischargeMode, DischargeCurrent, DischargeCutoffVoltage, DischargeCapacityMah)
-                            VALUES (@CellId, @Name, @Mode, @Cur, @CutV, @Cap);
+                var sql = @"INSERT INTO DischargeProfiles(CellId, Name, DischargeMode, DischargeCurrent, DischargeCutoffVoltage, DischargeCapacityMah, DischargeTimeSeconds)
+                            VALUES (@CellId, @Name, @Mode, @Cur, @CutV, @Cap, @Time);
                             SELECT last_insert_rowid();";
                 using var cmd = new SQLiteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@CellId", cellId);
                 cmd.Parameters.AddWithValue("@Name", p.Name ?? "New Discharge");
-                cmd.Parameters.AddWithValue("@Mode", (object?)p.DischargeMode ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("@Mode", p.DischargeMode.ToString());
                 cmd.Parameters.AddWithValue("@Cur", (object?)p.DischargeCurrent ?? DBNull.Value);
                 cmd.Parameters.AddWithValue("@CutV", (object?)p.DischargeCutoffVoltage ?? DBNull.Value);
                 cmd.Parameters.AddWithValue("@Cap", (object?)p.DischargeCapacityMah ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("@Time", p.DischargeTime == TimeSpan.Zero ? (object)DBNull.Value : p.DischargeTime.TotalSeconds);
                 p.Id = Convert.ToInt32(cmd.ExecuteScalar());
             }
             else
             {
                 var sql = @"UPDATE DischargeProfiles SET Name=@Name, DischargeMode=@Mode, DischargeCurrent=@Cur,
-                            DischargeCutoffVoltage=@CutV, DischargeCapacityMah=@Cap WHERE Id=@Id;";
+                            DischargeCutoffVoltage=@CutV, DischargeCapacityMah=@Cap, DischargeTimeSeconds=@Time WHERE Id=@Id;";
                 using var cmd = new SQLiteCommand(sql, conn);
                 cmd.Parameters.AddWithValue("@Id", p.Id);
                 cmd.Parameters.AddWithValue("@Name", p.Name ?? "Discharge");
-                cmd.Parameters.AddWithValue("@Mode", (object?)p.DischargeMode ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("@Mode", p.DischargeMode.ToString());
                 cmd.Parameters.AddWithValue("@Cur", (object?)p.DischargeCurrent ?? DBNull.Value);
                 cmd.Parameters.AddWithValue("@CutV", (object?)p.DischargeCutoffVoltage ?? DBNull.Value);
                 cmd.Parameters.AddWithValue("@Cap", (object?)p.DischargeCapacityMah ?? DBNull.Value);
+                cmd.Parameters.AddWithValue("@Time", p.DischargeTime == TimeSpan.Zero ? (object)DBNull.Value : p.DischargeTime.TotalSeconds);
                 cmd.ExecuteNonQuery();
             }
         }

--- a/CellManager/CellManager/Views/TestSetup/DischargeProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/DischargeProfileDetailView.xaml
@@ -5,6 +5,18 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignHeight="200" d:DesignWidth="400">
     <Grid Margin="8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition/>
+        </Grid.ColumnDefinitions>
+
         <TextBlock Text="Discharge Current (A)" Margin="4"/>
         <TextBox Grid.Column="1" Margin="4" Text="{Binding DischargeCurrent, UpdateSourceTrigger=PropertyChanged}"/>
 
@@ -13,5 +25,11 @@
 
         <TextBlock Grid.Row="2" Text="Capacity Limit (mAh)" Margin="4"/>
         <TextBox Grid.Row="2" Grid.Column="1" Margin="4" Text="{Binding DischargeCapacityMah, UpdateSourceTrigger=PropertyChanged}"/>
+
+        <TextBlock Grid.Row="3" Text="Discharge Time" Margin="4"/>
+        <TextBox Grid.Row="3" Grid.Column="1" Margin="4" Text="{Binding DischargeTime, UpdateSourceTrigger=PropertyChanged}"/>
+
+        <TextBlock Grid.Row="4" Text="Mode" Margin="4"/>
+        <TextBox Grid.Row="4" Grid.Column="1" Margin="4" Text="{Binding DischargeMode, UpdateSourceTrigger=PropertyChanged}"/>
     </Grid>
 </UserControl>

--- a/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
@@ -50,6 +50,7 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition SharedSizeGroup="LabelColumn"/>
@@ -70,6 +71,9 @@
 
                     <TextBlock Text="Capacity (mAh)" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
                     <TextBox Text="{Binding DischargeCapacityMah, UpdateSourceTrigger=PropertyChanged}" Grid.Row="4" Grid.Column="1"/>
+
+                    <TextBlock Text="Discharge Time" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
+                    <TextBox Text="{Binding DischargeTime, UpdateSourceTrigger=PropertyChanged}" Grid.Row="5" Grid.Column="1"/>
                 </Grid>
             </StackPanel>
         </DataTemplate>


### PR DESCRIPTION
## Summary
- replace discharge profile mode string with enum
- support time-based discharge limit and optional capacity limit
- persist new mode and discharge time in SQLite with migration

## Testing
- `dotnet test ../CellManager.Tests/CellManager.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b93f78bf5883239b2b1873661f215c