### PR TITLE
Add discharge mode selection and conditional time inputs

### DIFF
--- a/CellManager/CellManager/Models/TestProfile/DischargeProfile.cs
+++ b/CellManager/CellManager/Models/TestProfile/DischargeProfile.cs
@@ -37,6 +37,15 @@ namespace CellManager.Models.TestProfile
         private TimeSpan _dischargeTime;
 
         [ObservableProperty]
+        private int _dischargeHours;
+
+        [ObservableProperty]
+        private int _dischargeMinutes;
+
+        [ObservableProperty]
+        private int _dischargeSeconds;
+
+        [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(PreviewText))]
         private double? _dischargeCapacityMah;
 
@@ -52,6 +61,22 @@ namespace CellManager.Models.TestProfile
                 };
                 return $"Mode: {DischargeMode}, Current: {DischargeCurrent} A, Cutoff: {DischargeCutoffVoltage} V, {modeText}";
             }
+        }
+
+        partial void OnDischargeHoursChanged(int value) => UpdateDischargeTime();
+        partial void OnDischargeMinutesChanged(int value) => UpdateDischargeTime();
+        partial void OnDischargeSecondsChanged(int value) => UpdateDischargeTime();
+
+        partial void OnDischargeTimeChanged(TimeSpan value)
+        {
+            SetProperty(ref _dischargeHours, value.Hours, nameof(DischargeHours));
+            SetProperty(ref _dischargeMinutes, value.Minutes, nameof(DischargeMinutes));
+            SetProperty(ref _dischargeSeconds, value.Seconds, nameof(DischargeSeconds));
+        }
+
+        private void UpdateDischargeTime()
+        {
+            DischargeTime = new TimeSpan(DischargeHours, DischargeMinutes, DischargeSeconds);
         }
     }
 }

--- a/CellManager/CellManager/Views/TestSetup/DischargeProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/DischargeProfileDetailView.xaml
@@ -1,8 +1,9 @@
-﻿<UserControl x:Class="CellManager.Views.TestSetup.DischargeProfileDetailView"
+<UserControl x:Class="CellManager.Views.TestSetup.DischargeProfileDetailView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:tp="clr-namespace:CellManager.Models.TestProfile"
              mc:Ignorable="d" d:DesignHeight="200" d:DesignWidth="400">
     <Grid Margin="8">
         <Grid.RowDefinitions>
@@ -23,13 +24,66 @@
         <TextBlock Grid.Row="1" Text="Cutoff Voltage (V)" Margin="4"/>
         <TextBox Grid.Row="1" Grid.Column="1" Margin="4" Text="{Binding DischargeCutoffVoltage, UpdateSourceTrigger=PropertyChanged}"/>
 
-        <TextBlock Grid.Row="2" Text="Capacity Limit (mAh)" Margin="4"/>
-        <TextBox Grid.Row="2" Grid.Column="1" Margin="4" Text="{Binding DischargeCapacityMah, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Grid.Row="2" Text="Mode" Margin="4"/>
+        <ComboBox Grid.Row="2" Grid.Column="1" Margin="4" SelectedValue="{Binding DischargeMode, UpdateSourceTrigger=PropertyChanged}" SelectedValuePath="Tag">
+            <ComboBoxItem Content="Discharge by capacity" Tag="{x:Static tp:DischargeMode.DischargeByCapacity}"/>
+            <ComboBoxItem Content="Discharge by time" Tag="{x:Static tp:DischargeMode.DischargeByTime}"/>
+            <ComboBoxItem Content="Full discharge" Tag="{x:Static tp:DischargeMode.FullDischarge}"/>
+        </ComboBox>
 
-        <TextBlock Grid.Row="3" Text="Discharge Time" Margin="4"/>
-        <TextBox Grid.Row="3" Grid.Column="1" Margin="4" Text="{Binding DischargeTime, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Grid.Row="3" Text="Capacity Limit (mAh)" Margin="4">
+            <TextBlock.Style>
+                <Style TargetType="TextBlock">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding DischargeMode}" Value="{x:Static tp:DischargeMode.DischargeByCapacity}">
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBlock.Style>
+        </TextBlock>
+        <TextBox Grid.Row="3" Grid.Column="1" Margin="4" Text="{Binding DischargeCapacityMah, UpdateSourceTrigger=PropertyChanged}">
+            <TextBox.Style>
+                <Style TargetType="TextBox">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding DischargeMode}" Value="{x:Static tp:DischargeMode.DischargeByCapacity}">
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBox.Style>
+        </TextBox>
 
-        <TextBlock Grid.Row="4" Text="Mode" Margin="4"/>
-        <TextBox Grid.Row="4" Grid.Column="1" Margin="4" Text="{Binding DischargeMode, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Grid.Row="4" Text="Discharge Time" Margin="4">
+            <TextBlock.Style>
+                <Style TargetType="TextBlock">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding DischargeMode}" Value="{x:Static tp:DischargeMode.DischargeByTime}">
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBlock.Style>
+        </TextBlock>
+        <StackPanel Grid.Row="4" Grid.Column="1" Orientation="Horizontal" Margin="4">
+            <StackPanel.Style>
+                <Style TargetType="StackPanel">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding DischargeMode}" Value="{x:Static tp:DischargeMode.DischargeByTime}">
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </StackPanel.Style>
+            <TextBox Width="40" Text="{Binding DischargeHours, UpdateSourceTrigger=PropertyChanged}"/>
+            <TextBlock Text=":" VerticalAlignment="Center" Margin="2,0"/>
+            <TextBox Width="40" Text="{Binding DischargeMinutes, UpdateSourceTrigger=PropertyChanged}"/>
+            <TextBlock Text=":" VerticalAlignment="Center" Margin="2,0"/>
+            <TextBox Width="40" Text="{Binding DischargeSeconds, UpdateSourceTrigger=PropertyChanged}"/>
+        </StackPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- Add `DischargeHours`, `DischargeMinutes`, and `DischargeSeconds` properties to `DischargeProfile` and keep them synchronized with `DischargeTime`.
- Replace discharge mode text box with combo box, and add conditional capacity and time editors in `DischargeProfileDetailView`.

## Testing
- `dotnet test` *(fails: missing e_sqlite3 library but tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68b94278091883239b4113817cb2ff7b