### PR TITLE
Use detail views for charge/discharge templates

### DIFF
--- a/CellManager/CellManager/Models/TestProfile/ChargeProfile.cs
+++ b/CellManager/CellManager/Models/TestProfile/ChargeProfile.cs
@@ -72,9 +72,9 @@ namespace CellManager.Models.TestProfile
 
         public string PreviewText => ChargeMode switch
         {
-            ChargeMode.ChargeByCapacity => $"Current: {ChargeCurrent} A, Cutoff: {ChargeCutoffVoltage} V, Capacity: {ChargeCapacityMah} mAh",
-            ChargeMode.ChargeByTime => $"Current: {ChargeCurrent} A, Cutoff: {ChargeCutoffVoltage} V, Time: {ChargeTime}",
-            _ => $"Current: {ChargeCurrent} A, Cutoff: {ChargeCutoffVoltage} V, Cutoff Current: {CutoffCurrent} A",
+            ChargeMode.ChargeByCapacity => $"Current: {ChargeCurrent} A, Voltage: {ChargeCutoffVoltage} V, Cutoff Current: {CutoffCurrent} A, Capacity: {ChargeCapacityMah} mAh",
+            ChargeMode.ChargeByTime => $"Current: {ChargeCurrent} A, Voltage: {ChargeCutoffVoltage} V, Cutoff Current: {CutoffCurrent} A, Time: {ChargeTime}",
+            _ => $"Current: {ChargeCurrent} A, Voltage: {ChargeCutoffVoltage} V, Cutoff Current: {CutoffCurrent} A",
         };
     }
 

--- a/CellManager/CellManager/Views/TestSetup/ChargeProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/ChargeProfileDetailView.xaml
@@ -13,6 +13,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
@@ -20,7 +21,7 @@
         </Grid.ColumnDefinitions>
 
         <Grid.Resources>
-            <Style x:Key="CapacityVisibilityStyle" TargetType="UIElement">
+            <Style x:Key="CapacityVisibilityStyle" TargetType="FrameworkElement">
                 <Setter Property="Visibility" Value="Collapsed"/>
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding ChargeMode}" Value="{x:Static tp:ChargeMode.ChargeByCapacity}">
@@ -28,7 +29,7 @@
                     </DataTrigger>
                 </Style.Triggers>
             </Style>
-            <Style x:Key="TimeVisibilityStyle" TargetType="UIElement">
+            <Style x:Key="TimeVisibilityStyle" TargetType="FrameworkElement">
                 <Setter Property="Visibility" Value="Collapsed"/>
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding ChargeMode}" Value="{x:Static tp:ChargeMode.ChargeByTime}">
@@ -36,37 +37,32 @@
                     </DataTrigger>
                 </Style.Triggers>
             </Style>
-            <Style x:Key="CutoffCurrentVisibilityStyle" TargetType="UIElement">
-                <Setter Property="Visibility" Value="Collapsed"/>
-                <Style.Triggers>
-                    <DataTrigger Binding="{Binding ChargeMode}" Value="{x:Static tp:ChargeMode.FullCharge}">
-                        <Setter Property="Visibility" Value="Visible"/>
-                    </DataTrigger>
-                </Style.Triggers>
-            </Style>
         </Grid.Resources>
 
-        <TextBlock Grid.Row="0" Grid.Column="0" Text="Mode" Margin="4" VerticalAlignment="Center"/>
-        <ComboBox Grid.Row="0" Grid.Column="1" Margin="4" SelectedValue="{Binding ChargeMode, UpdateSourceTrigger=PropertyChanged}" SelectedValuePath="Tag">
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="Name" Margin="4" VerticalAlignment="Center"/>
+        <TextBox Grid.Row="0" Grid.Column="1" Margin="4" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
+
+        <TextBlock Grid.Row="1" Grid.Column="0" Text="Mode" Margin="4" VerticalAlignment="Center"/>
+        <ComboBox Grid.Row="1" Grid.Column="1" Margin="4" SelectedValue="{Binding ChargeMode, UpdateSourceTrigger=PropertyChanged}" SelectedValuePath="Tag">
             <ComboBoxItem Content="Charge by capacity" Tag="{x:Static tp:ChargeMode.ChargeByCapacity}"/>
             <ComboBoxItem Content="Charge by time" Tag="{x:Static tp:ChargeMode.ChargeByTime}"/>
             <ComboBoxItem Content="Full charge" Tag="{x:Static tp:ChargeMode.FullCharge}"/>
         </ComboBox>
+        
+        <TextBlock Grid.Row="2" Grid.Column="0" Text="Charge Current (A)" Margin="4" VerticalAlignment="Center"/>
+        <TextBox Grid.Row="2" Grid.Column="1" Margin="4" Text="{Binding ChargeCurrent, UpdateSourceTrigger=PropertyChanged}"/>
 
-        <TextBlock Grid.Row="1" Grid.Column="0" Text="Charge Current (A)" Margin="4" VerticalAlignment="Center"/>
-        <TextBox Grid.Row="1" Grid.Column="1" Margin="4" Text="{Binding ChargeCurrent, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Grid.Row="3" Grid.Column="0" Text="Charge Voltage (V)" Margin="4" VerticalAlignment="Center"/>
+        <TextBox Grid.Row="3" Grid.Column="1" Margin="4" Text="{Binding ChargeCutoffVoltage, UpdateSourceTrigger=PropertyChanged}"/>
 
-        <TextBlock Grid.Row="2" Grid.Column="0" Text="Cutoff Voltage (V)" Margin="4" VerticalAlignment="Center"/>
-        <TextBox Grid.Row="2" Grid.Column="1" Margin="4" Text="{Binding ChargeCutoffVoltage, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Grid.Row="4" Grid.Column="0" Text="Cutoff Current (A)" Margin="4" VerticalAlignment="Center"/>
+        <TextBox Grid.Row="4" Grid.Column="1" Margin="4" Text="{Binding CutoffCurrent, UpdateSourceTrigger=PropertyChanged}"/>
 
-        <TextBlock Grid.Row="3" Grid.Column="0" Text="Cutoff Current (A)" Margin="4" VerticalAlignment="Center" Style="{StaticResource CutoffCurrentVisibilityStyle}"/>
-        <TextBox Grid.Row="3" Grid.Column="1" Margin="4" Text="{Binding CutoffCurrent, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource CutoffCurrentVisibilityStyle}"/>
+        <TextBlock Grid.Row="5" Grid.Column="0" Text="Capacity (mAh)" Margin="4" VerticalAlignment="Center" Style="{StaticResource CapacityVisibilityStyle}"/>
+        <TextBox Grid.Row="5" Grid.Column="1" Margin="4" Text="{Binding ChargeCapacityMah, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource CapacityVisibilityStyle}"/>
 
-        <TextBlock Grid.Row="4" Grid.Column="0" Text="Capacity (mAh)" Margin="4" VerticalAlignment="Center" Style="{StaticResource CapacityVisibilityStyle}"/>
-        <TextBox Grid.Row="4" Grid.Column="1" Margin="4" Text="{Binding ChargeCapacityMah, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource CapacityVisibilityStyle}"/>
-
-        <TextBlock Grid.Row="5" Grid.Column="0" Text="Charge Time" Margin="4" VerticalAlignment="Center" Style="{StaticResource TimeVisibilityStyle}"/>
-        <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal" Margin="4" Style="{StaticResource TimeVisibilityStyle}">
+        <TextBlock Grid.Row="6" Grid.Column="0" Text="Charge Time" Margin="4" VerticalAlignment="Center" Style="{StaticResource TimeVisibilityStyle}"/>
+        <StackPanel Grid.Row="6" Grid.Column="1" Orientation="Horizontal" Margin="4" Style="{StaticResource TimeVisibilityStyle}">
             <TextBox Width="40" Text="{Binding ChargeHours, UpdateSourceTrigger=PropertyChanged}"/>
             <TextBlock Text=":" Margin="2" VerticalAlignment="Center"/>
             <TextBox Width="40" Text="{Binding ChargeMinutes, UpdateSourceTrigger=PropertyChanged}"/>

--- a/CellManager/CellManager/Views/TestSetup/DischargeProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/DischargeProfileDetailView.xaml
@@ -12,26 +12,30 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition/>
-            <ColumnDefinition/>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
-        <TextBlock Text="Discharge Current (A)" Margin="4"/>
-        <TextBox Grid.Column="1" Margin="4" Text="{Binding DischargeCurrent, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Text="Name" Margin="4"/>
+        <TextBox Grid.Column="1" Margin="4" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
 
-        <TextBlock Grid.Row="1" Text="Cutoff Voltage (V)" Margin="4"/>
-        <TextBox Grid.Row="1" Grid.Column="1" Margin="4" Text="{Binding DischargeCutoffVoltage, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Grid.Row="1" Text="Discharge Current (A)" Margin="4"/>
+        <TextBox Grid.Row="1" Grid.Column="1" Margin="4" Text="{Binding DischargeCurrent, UpdateSourceTrigger=PropertyChanged}"/>
 
-        <TextBlock Grid.Row="2" Text="Mode" Margin="4"/>
-        <ComboBox Grid.Row="2" Grid.Column="1" Margin="4" SelectedValue="{Binding DischargeMode, UpdateSourceTrigger=PropertyChanged}" SelectedValuePath="Tag">
+        <TextBlock Grid.Row="2" Text="Cutoff Voltage (V)" Margin="4"/>
+        <TextBox Grid.Row="2" Grid.Column="1" Margin="4" Text="{Binding DischargeCutoffVoltage, UpdateSourceTrigger=PropertyChanged}"/>
+
+        <TextBlock Grid.Row="3" Text="Mode" Margin="4"/>
+        <ComboBox Grid.Row="3" Grid.Column="1" Margin="4" SelectedValue="{Binding DischargeMode, UpdateSourceTrigger=PropertyChanged}" SelectedValuePath="Tag">
             <ComboBoxItem Content="Discharge by capacity" Tag="{x:Static tp:DischargeMode.DischargeByCapacity}"/>
             <ComboBoxItem Content="Discharge by time" Tag="{x:Static tp:DischargeMode.DischargeByTime}"/>
             <ComboBoxItem Content="Full discharge" Tag="{x:Static tp:DischargeMode.FullDischarge}"/>
         </ComboBox>
 
-        <TextBlock Grid.Row="3" Text="Capacity Limit (mAh)" Margin="4">
+        <TextBlock Grid.Row="4" Text="Capacity (mAh)" Margin="4">
             <TextBlock.Style>
                 <Style TargetType="TextBlock">
                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -43,7 +47,7 @@
                 </Style>
             </TextBlock.Style>
         </TextBlock>
-        <TextBox Grid.Row="3" Grid.Column="1" Margin="4" Text="{Binding DischargeCapacityMah, UpdateSourceTrigger=PropertyChanged}">
+        <TextBox Grid.Row="4" Grid.Column="1" Margin="4" Text="{Binding DischargeCapacityMah, UpdateSourceTrigger=PropertyChanged}">
             <TextBox.Style>
                 <Style TargetType="TextBox">
                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -56,7 +60,7 @@
             </TextBox.Style>
         </TextBox>
 
-        <TextBlock Grid.Row="4" Text="Discharge Time" Margin="4">
+        <TextBlock Grid.Row="5" Text="Discharge Time" Margin="4">
             <TextBlock.Style>
                 <Style TargetType="TextBlock">
                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -68,7 +72,7 @@
                 </Style>
             </TextBlock.Style>
         </TextBlock>
-        <StackPanel Grid.Row="4" Grid.Column="1" Orientation="Horizontal" Margin="4">
+        <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal" Margin="4">
             <StackPanel.Style>
                 <Style TargetType="StackPanel">
                     <Setter Property="Visibility" Value="Collapsed"/>

--- a/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
@@ -3,79 +3,20 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-              xmlns:vm="clr-namespace:CellManager.ViewModels"
-              xmlns:tp="clr-namespace:CellManager.Models.TestProfile"
-              mc:Ignorable="d"
-              Grid.IsSharedSizeScope="True">
+             xmlns:vm="clr-namespace:CellManager.ViewModels"
+             xmlns:tp="clr-namespace:CellManager.Models.TestProfile"
+             xmlns:views="clr-namespace:CellManager.Views.TestSetup"
+             mc:Ignorable="d"
+             Grid.IsSharedSizeScope="True">
 
     <UserControl.Resources>
         <!-- Editor templates: auto-switched by CurrentEditor instance type -->
         <DataTemplate DataType="{x:Type tp:ChargeProfile}">
-            <StackPanel Margin="8" >
-                <TextBlock Text="Charge Profile" FontWeight="Bold" Margin="0,0,0,8"/>
-                <Grid Margin="0,4,0,0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition SharedSizeGroup="LabelColumn"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock Text="Name" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
-                    <TextBox Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Grid.Row="0" Grid.Column="1"/>
-
-                    <TextBlock Text="Charge Current (A)" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
-                    <TextBox Text="{Binding ChargeCurrent, UpdateSourceTrigger=PropertyChanged}" Grid.Row="1" Grid.Column="1"/>
-
-                    <TextBlock Text="Cutoff Voltage (V)" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
-                    <TextBox Text="{Binding ChargeCutoffVoltage, UpdateSourceTrigger=PropertyChanged}" Grid.Row="2" Grid.Column="1"/>
-
-                    <TextBlock Text="Cutoff Current (A)" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
-                    <TextBox Text="{Binding CutoffCurrent, UpdateSourceTrigger=PropertyChanged}" Grid.Row="3" Grid.Column="1"/>
-                </Grid>
-            </StackPanel>
+            <views:ChargeProfileDetailView />
         </DataTemplate>
 
         <DataTemplate DataType="{x:Type tp:DischargeProfile}">
-            <StackPanel Margin="8">
-                <TextBlock Text="Discharge Profile" FontWeight="Bold" Margin="0,0,0,8"/>
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition SharedSizeGroup="LabelColumn"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock Text="Name" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
-                    <TextBox Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Grid.Row="0" Grid.Column="1"/>
-
-                    <TextBlock Text="Mode" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
-                    <TextBox Text="{Binding DischargeMode, UpdateSourceTrigger=PropertyChanged}" Grid.Row="1" Grid.Column="1"/>
-
-                    <TextBlock Text="Current (A)" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
-                    <TextBox Text="{Binding DischargeCurrent, UpdateSourceTrigger=PropertyChanged}" Grid.Row="2" Grid.Column="1"/>
-
-                    <TextBlock Text="Cutoff Voltage (V)" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
-                    <TextBox Text="{Binding DischargeCutoffVoltage, UpdateSourceTrigger=PropertyChanged}" Grid.Row="3" Grid.Column="1"/>
-
-                    <TextBlock Text="Capacity (mAh)" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
-                    <TextBox Text="{Binding DischargeCapacityMah, UpdateSourceTrigger=PropertyChanged}" Grid.Row="4" Grid.Column="1"/>
-
-                    <TextBlock Text="Discharge Time" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
-                    <TextBox Text="{Binding DischargeTime, UpdateSourceTrigger=PropertyChanged}" Grid.Row="5" Grid.Column="1"/>
-                </Grid>
-            </StackPanel>
+            <views:DischargeProfileDetailView />
         </DataTemplate>
 
         <DataTemplate DataType="{x:Type tp:ECMPulseProfile}">
@@ -83,6 +24,7 @@
                 <TextBlock Text="ECM Pulse Profile" FontWeight="Bold" Margin="0,0,0,8"/>
                 <Grid>
                     <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>


### PR DESCRIPTION
## Summary
- restore Name input and always-visible parameters in charge/discharge detail views
- keep mode-specific capacity/time inputs
- include cutoff current in charge profile previews

## Testing
- `dotnet test` *(fails: unable to load shared library 'e_sqlite3', but 6 tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b93df84fac83239b5a6354eb1cf84b