### PR TITLE
Style profile detail views with headers and dividers

### DIFF
--- a/CellManager/CellManager/Views/TestSetup/ChargeProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/ChargeProfileDetailView.xaml
@@ -5,70 +5,95 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:tp="clr-namespace:CellManager.Models.TestProfile"
              mc:Ignorable="d" d:DesignHeight="200" d:DesignWidth="400">
-    <Grid Margin="8">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto"/>
-            <ColumnDefinition Width="*"/>
-        </Grid.ColumnDefinitions>
+    <GroupBox Header="Charge Profile" Margin="8">
+        <Grid Margin="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
 
-        <Grid.Resources>
-            <Style x:Key="CapacityVisibilityStyle" TargetType="FrameworkElement">
-                <Setter Property="Visibility" Value="Collapsed"/>
-                <Style.Triggers>
-                    <DataTrigger Binding="{Binding ChargeMode}" Value="{x:Static tp:ChargeMode.ChargeByCapacity}">
-                        <Setter Property="Visibility" Value="Visible"/>
-                    </DataTrigger>
-                </Style.Triggers>
-            </Style>
-            <Style x:Key="TimeVisibilityStyle" TargetType="FrameworkElement">
-                <Setter Property="Visibility" Value="Collapsed"/>
-                <Style.Triggers>
-                    <DataTrigger Binding="{Binding ChargeMode}" Value="{x:Static tp:ChargeMode.ChargeByTime}">
-                        <Setter Property="Visibility" Value="Visible"/>
-                    </DataTrigger>
-                </Style.Triggers>
-            </Style>
-        </Grid.Resources>
+            <Grid.Resources>
+                <Style x:Key="CapacityVisibilityStyle" TargetType="FrameworkElement">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding ChargeMode}" Value="{x:Static tp:ChargeMode.ChargeByCapacity}">
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+                <Style x:Key="TimeVisibilityStyle" TargetType="FrameworkElement">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding ChargeMode}" Value="{x:Static tp:ChargeMode.ChargeByTime}">
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Grid.Resources>
 
-        <TextBlock Grid.Row="0" Grid.Column="0" Text="Name" Margin="4" VerticalAlignment="Center"/>
-        <TextBox Grid.Row="0" Grid.Column="1" Margin="4" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Name" Margin="4" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="0" Grid.Column="1" Margin="4" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
+            <Border Grid.Row="1" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="1" Grid.Column="0" Text="Mode" Margin="4" VerticalAlignment="Center"/>
-        <ComboBox Grid.Row="1" Grid.Column="1" Margin="4" SelectedValue="{Binding ChargeMode, UpdateSourceTrigger=PropertyChanged}" SelectedValuePath="Tag">
-            <ComboBoxItem Content="Charge by capacity" Tag="{x:Static tp:ChargeMode.ChargeByCapacity}"/>
-            <ComboBoxItem Content="Charge by time" Tag="{x:Static tp:ChargeMode.ChargeByTime}"/>
-            <ComboBoxItem Content="Full charge" Tag="{x:Static tp:ChargeMode.FullCharge}"/>
-        </ComboBox>
-        
-        <TextBlock Grid.Row="2" Grid.Column="0" Text="Charge Current (A)" Margin="4" VerticalAlignment="Center"/>
-        <TextBox Grid.Row="2" Grid.Column="1" Margin="4" Text="{Binding ChargeCurrent, UpdateSourceTrigger=PropertyChanged}"/>
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Mode" Margin="4" VerticalAlignment="Center"/>
+            <ComboBox Grid.Row="2" Grid.Column="1" Margin="4" SelectedValue="{Binding ChargeMode, UpdateSourceTrigger=PropertyChanged}" SelectedValuePath="Tag">
+                <ComboBoxItem Content="Charge by capacity" Tag="{x:Static tp:ChargeMode.ChargeByCapacity}"/>
+                <ComboBoxItem Content="Charge by time" Tag="{x:Static tp:ChargeMode.ChargeByTime}"/>
+                <ComboBoxItem Content="Full charge" Tag="{x:Static tp:ChargeMode.FullCharge}"/>
+            </ComboBox>
+            <Border Grid.Row="3" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="3" Grid.Column="0" Text="Charge Voltage (V)" Margin="4" VerticalAlignment="Center"/>
-        <TextBox Grid.Row="3" Grid.Column="1" Margin="4" Text="{Binding ChargeCutoffVoltage, UpdateSourceTrigger=PropertyChanged}"/>
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Charge Current (A)" Margin="4" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="4" Grid.Column="1" Margin="4" Text="{Binding ChargeCurrent, UpdateSourceTrigger=PropertyChanged}"/>
+            <Border Grid.Row="5" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="4" Grid.Column="0" Text="Cutoff Current (A)" Margin="4" VerticalAlignment="Center"/>
-        <TextBox Grid.Row="4" Grid.Column="1" Margin="4" Text="{Binding CutoffCurrent, UpdateSourceTrigger=PropertyChanged}"/>
+            <TextBlock Grid.Row="6" Grid.Column="0" Text="Charge Voltage (V)" Margin="4" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="6" Grid.Column="1" Margin="4" Text="{Binding ChargeCutoffVoltage, UpdateSourceTrigger=PropertyChanged}"/>
+            <Border Grid.Row="7" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="5" Grid.Column="0" Text="Capacity (mAh)" Margin="4" VerticalAlignment="Center" Style="{StaticResource CapacityVisibilityStyle}"/>
-        <TextBox Grid.Row="5" Grid.Column="1" Margin="4" Text="{Binding ChargeCapacityMah, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource CapacityVisibilityStyle}"/>
+            <TextBlock Grid.Row="8" Grid.Column="0" Text="Cutoff Current (A)" Margin="4" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="8" Grid.Column="1" Margin="4" Text="{Binding CutoffCurrent, UpdateSourceTrigger=PropertyChanged}"/>
+            <Border Grid.Row="9" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="6" Grid.Column="0" Text="Charge Time" Margin="4" VerticalAlignment="Center" Style="{StaticResource TimeVisibilityStyle}"/>
-        <StackPanel Grid.Row="6" Grid.Column="1" Orientation="Horizontal" Margin="4" Style="{StaticResource TimeVisibilityStyle}">
-            <TextBox Width="40" Text="{Binding ChargeHours, UpdateSourceTrigger=PropertyChanged}"/>
-            <TextBlock Text=":" Margin="2" VerticalAlignment="Center"/>
-            <TextBox Width="40" Text="{Binding ChargeMinutes, UpdateSourceTrigger=PropertyChanged}"/>
-            <TextBlock Text=":" Margin="2" VerticalAlignment="Center"/>
-            <TextBox Width="40" Text="{Binding ChargeSeconds, UpdateSourceTrigger=PropertyChanged}"/>
-        </StackPanel>
-    </Grid>
+            <TextBlock Grid.Row="10" Grid.Column="0" Text="Capacity (mAh)" Margin="4" VerticalAlignment="Center" Style="{StaticResource CapacityVisibilityStyle}"/>
+            <TextBox Grid.Row="10" Grid.Column="1" Margin="4" Text="{Binding ChargeCapacityMah, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource CapacityVisibilityStyle}"/>
+            <Border Grid.Row="11" Grid.ColumnSpan="2" Margin="0,4">
+                <Border.Style>
+                    <Style TargetType="Border" BasedOn="{StaticResource HDivider}">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding ChargeMode}" Value="{x:Static tp:ChargeMode.ChargeByCapacity}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+            </Border>
+
+            <TextBlock Grid.Row="12" Grid.Column="0" Text="Charge Time" Margin="4" VerticalAlignment="Center" Style="{StaticResource TimeVisibilityStyle}"/>
+            <StackPanel Grid.Row="12" Grid.Column="1" Orientation="Horizontal" Margin="4" Style="{StaticResource TimeVisibilityStyle}">
+                <TextBox Width="40" Text="{Binding ChargeHours, UpdateSourceTrigger=PropertyChanged}"/>
+                <TextBlock Text=":" Margin="2" VerticalAlignment="Center"/>
+                <TextBox Width="40" Text="{Binding ChargeMinutes, UpdateSourceTrigger=PropertyChanged}"/>
+                <TextBlock Text=":" Margin="2" VerticalAlignment="Center"/>
+                <TextBox Width="40" Text="{Binding ChargeSeconds, UpdateSourceTrigger=PropertyChanged}"/>
+            </StackPanel>
+        </Grid>
+    </GroupBox>
 </UserControl>
 

--- a/CellManager/CellManager/Views/TestSetup/DischargeProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/DischargeProfileDetailView.xaml
@@ -5,89 +5,112 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:tp="clr-namespace:CellManager.Models.TestProfile"
              mc:Ignorable="d" d:DesignHeight="200" d:DesignWidth="400">
-    <Grid Margin="8">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto"/>
-            <ColumnDefinition Width="*"/>
-        </Grid.ColumnDefinitions>
+    <GroupBox Header="Discharge Profile" Margin="8">
+        <Grid Margin="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
 
-        <TextBlock Text="Name" Margin="4"/>
-        <TextBox Grid.Column="1" Margin="4" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
+            <TextBlock Grid.Row="0" Text="Name" Margin="4"/>
+            <TextBox Grid.Row="0" Grid.Column="1" Margin="4" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
+            <Border Grid.Row="1" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="1" Text="Discharge Current (A)" Margin="4"/>
-        <TextBox Grid.Row="1" Grid.Column="1" Margin="4" Text="{Binding DischargeCurrent, UpdateSourceTrigger=PropertyChanged}"/>
+            <TextBlock Grid.Row="2" Text="Discharge Current (A)" Margin="4"/>
+            <TextBox Grid.Row="2" Grid.Column="1" Margin="4" Text="{Binding DischargeCurrent, UpdateSourceTrigger=PropertyChanged}"/>
+            <Border Grid.Row="3" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="2" Text="Cutoff Voltage (V)" Margin="4"/>
-        <TextBox Grid.Row="2" Grid.Column="1" Margin="4" Text="{Binding DischargeCutoffVoltage, UpdateSourceTrigger=PropertyChanged}"/>
+            <TextBlock Grid.Row="4" Text="Cutoff Voltage (V)" Margin="4"/>
+            <TextBox Grid.Row="4" Grid.Column="1" Margin="4" Text="{Binding DischargeCutoffVoltage, UpdateSourceTrigger=PropertyChanged}"/>
+            <Border Grid.Row="5" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="3" Text="Mode" Margin="4"/>
-        <ComboBox Grid.Row="3" Grid.Column="1" Margin="4" SelectedValue="{Binding DischargeMode, UpdateSourceTrigger=PropertyChanged}" SelectedValuePath="Tag">
-            <ComboBoxItem Content="Discharge by capacity" Tag="{x:Static tp:DischargeMode.DischargeByCapacity}"/>
-            <ComboBoxItem Content="Discharge by time" Tag="{x:Static tp:DischargeMode.DischargeByTime}"/>
-            <ComboBoxItem Content="Full discharge" Tag="{x:Static tp:DischargeMode.FullDischarge}"/>
-        </ComboBox>
+            <TextBlock Grid.Row="6" Text="Mode" Margin="4"/>
+            <ComboBox Grid.Row="6" Grid.Column="1" Margin="4" SelectedValue="{Binding DischargeMode, UpdateSourceTrigger=PropertyChanged}" SelectedValuePath="Tag">
+                <ComboBoxItem Content="Discharge by capacity" Tag="{x:Static tp:DischargeMode.DischargeByCapacity}"/>
+                <ComboBoxItem Content="Discharge by time" Tag="{x:Static tp:DischargeMode.DischargeByTime}"/>
+                <ComboBoxItem Content="Full discharge" Tag="{x:Static tp:DischargeMode.FullDischarge}"/>
+            </ComboBox>
+            <Border Grid.Row="7" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="4" Text="Capacity (mAh)" Margin="4">
-            <TextBlock.Style>
-                <Style TargetType="TextBlock">
-                    <Setter Property="Visibility" Value="Collapsed"/>
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding DischargeMode}" Value="{x:Static tp:DischargeMode.DischargeByCapacity}">
-                            <Setter Property="Visibility" Value="Visible"/>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </TextBlock.Style>
-        </TextBlock>
-        <TextBox Grid.Row="4" Grid.Column="1" Margin="4" Text="{Binding DischargeCapacityMah, UpdateSourceTrigger=PropertyChanged}">
-            <TextBox.Style>
-                <Style TargetType="TextBox">
-                    <Setter Property="Visibility" Value="Collapsed"/>
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding DischargeMode}" Value="{x:Static tp:DischargeMode.DischargeByCapacity}">
-                            <Setter Property="Visibility" Value="Visible"/>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </TextBox.Style>
-        </TextBox>
+            <TextBlock Grid.Row="8" Text="Capacity (mAh)" Margin="4">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding DischargeMode}" Value="{x:Static tp:DischargeMode.DischargeByCapacity}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
+            <TextBox Grid.Row="8" Grid.Column="1" Margin="4" Text="{Binding DischargeCapacityMah, UpdateSourceTrigger=PropertyChanged}">
+                <TextBox.Style>
+                    <Style TargetType="TextBox">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding DischargeMode}" Value="{x:Static tp:DischargeMode.DischargeByCapacity}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBox.Style>
+            </TextBox>
+            <Border Grid.Row="9" Grid.ColumnSpan="2" Margin="0,4">
+                <Border.Style>
+                    <Style TargetType="Border" BasedOn="{StaticResource HDivider}">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding DischargeMode}" Value="{x:Static tp:DischargeMode.DischargeByCapacity}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+            </Border>
 
-        <TextBlock Grid.Row="5" Text="Discharge Time" Margin="4">
-            <TextBlock.Style>
-                <Style TargetType="TextBlock">
-                    <Setter Property="Visibility" Value="Collapsed"/>
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding DischargeMode}" Value="{x:Static tp:DischargeMode.DischargeByTime}">
-                            <Setter Property="Visibility" Value="Visible"/>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </TextBlock.Style>
-        </TextBlock>
-        <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal" Margin="4">
-            <StackPanel.Style>
-                <Style TargetType="StackPanel">
-                    <Setter Property="Visibility" Value="Collapsed"/>
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding DischargeMode}" Value="{x:Static tp:DischargeMode.DischargeByTime}">
-                            <Setter Property="Visibility" Value="Visible"/>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </StackPanel.Style>
-            <TextBox Width="40" Text="{Binding DischargeHours, UpdateSourceTrigger=PropertyChanged}"/>
-            <TextBlock Text=":" VerticalAlignment="Center" Margin="2,0"/>
-            <TextBox Width="40" Text="{Binding DischargeMinutes, UpdateSourceTrigger=PropertyChanged}"/>
-            <TextBlock Text=":" VerticalAlignment="Center" Margin="2,0"/>
-            <TextBox Width="40" Text="{Binding DischargeSeconds, UpdateSourceTrigger=PropertyChanged}"/>
-        </StackPanel>
-    </Grid>
+            <TextBlock Grid.Row="10" Text="Discharge Time" Margin="4">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding DischargeMode}" Value="{x:Static tp:DischargeMode.DischargeByTime}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
+            <StackPanel Grid.Row="10" Grid.Column="1" Orientation="Horizontal" Margin="4">
+                <StackPanel.Style>
+                    <Style TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding DischargeMode}" Value="{x:Static tp:DischargeMode.DischargeByTime}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Style>
+                <TextBox Width="40" Text="{Binding DischargeHours, UpdateSourceTrigger=PropertyChanged}"/>
+                <TextBlock Text=":" VerticalAlignment="Center" Margin="2,0"/>
+                <TextBox Width="40" Text="{Binding DischargeMinutes, UpdateSourceTrigger=PropertyChanged}"/>
+                <TextBlock Text=":" VerticalAlignment="Center" Margin="2,0"/>
+                <TextBox Width="40" Text="{Binding DischargeSeconds, UpdateSourceTrigger=PropertyChanged}"/>
+            </StackPanel>
+        </Grid>
+    </GroupBox>
 </UserControl>

--- a/CellManager/CellManager/Views/TestSetup/RestProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/RestProfileDetailView.xaml
@@ -1,0 +1,27 @@
+<UserControl x:Class="CellManager.Views.TestSetup.RestProfileDetailView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignHeight="200" d:DesignWidth="400">
+    <GroupBox Header="Rest Profile" Margin="8">
+        <Grid Margin="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Name" Margin="4" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="0" Grid.Column="1" Margin="4" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
+            <Border Grid.Row="1" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Rest Time (s)" Margin="4" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="2" Grid.Column="1" Margin="4" Text="{Binding RestTime, UpdateSourceTrigger=PropertyChanged}"/>
+        </Grid>
+    </GroupBox>
+</UserControl>

--- a/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
@@ -92,25 +92,7 @@
         </DataTemplate>
 
         <DataTemplate DataType="{x:Type tp:RestProfile}">
-            <StackPanel Margin="8">
-                <TextBlock Text="Rest Profile" FontWeight="Bold" Margin="0,0,0,8"/>
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition SharedSizeGroup="LabelColumn"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock Text="Name" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"/>
-                    <TextBox Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Grid.Row="0" Grid.Column="1"/>
-
-                    <TextBlock Text="Rest Time (s)" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
-                    <TextBox Text="{Binding RestTime, UpdateSourceTrigger=PropertyChanged}" Grid.Row="1" Grid.Column="1"/>
-                </Grid>
-            </StackPanel>
+            <views:RestProfileDetailView />
         </DataTemplate>
 
         <!-- Shared style for profile list items -->


### PR DESCRIPTION
## Summary
- Wrap charge and discharge profile editors in grouped cards with headers
- Introduce RestProfileDetailView and link RestProfile template to it
- Add HDivider borders between profile fields for clearer separation

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b95b02980c8323b16c2afcb2c616b5