### PR TITLE
Use chip for cell activity and allow deselection

### DIFF
--- a/CellManager/CellManager/ViewModels/CellLibraryViewModel.cs
+++ b/CellManager/CellManager/ViewModels/CellLibraryViewModel.cs
@@ -214,15 +214,25 @@ namespace CellManager.ViewModels
         {
             if (EditingCell != null) return; // New 중에는 실수로 리스트 선택 바뀌지 않게 잠금
             if (cell == null) return;
-            SelectedCell = cell;
-            cell.IsActive = true; // 선택된 셀은 활성화 표시
-            // 다른 셀들은 비활성화
-            foreach (var c in CellModels)
+
+            if (SelectedCell == cell && cell.IsActive)
             {
-                if (c.Id != cell.Id && c.IsActive)
-                    c.IsActive = false;
+                SelectedCell = null;
+                cell.IsActive = false;
+                WeakReferenceMessenger.Default.Send(new CellSelectedMessage(null));
             }
-            WeakReferenceMessenger.Default.Send(new CellSelectedMessage(cell));
+            else
+            {
+                SelectedCell = cell;
+                cell.IsActive = true; // 선택된 셀은 활성화 표시
+                // 다른 셀들은 비활성화
+                foreach (var c in CellModels)
+                {
+                    if (c.Id != cell.Id && c.IsActive)
+                        c.IsActive = false;
+                }
+                WeakReferenceMessenger.Default.Send(new CellSelectedMessage(cell));
+            }
             FilteredCells.Refresh();
         }
 

--- a/CellManager/CellManager/Views/CellLibary/CellLibraryView.xaml
+++ b/CellManager/CellManager/Views/CellLibary/CellLibraryView.xaml
@@ -174,27 +174,27 @@
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
 
-                    <!-- Select Button -->
-                    <GridViewColumn >
+                    <!-- Select Badge -->
+                    <GridViewColumn>
                         <GridViewColumnHeader Content="Activity" HorizontalAlignment="Stretch" Padding="5"/>
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
-                                <Button  Command="{Binding DataContext.SelectCellCommand, RelativeSource={RelativeSource AncestorType=ListView}}" MinWidth="100"
-                    CommandParameter="{Binding}" materialDesign:ButtonProgressAssist.IsIndeterminate="True" materialDesign:ButtonProgressAssist.IsIndicatorVisible="{Binding IsActive}" materialDesign:ButtonProgressAssist.Value="-1">
-                                    <Button.Style>
-                                        <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignRaisedButton}">
-                                            <Setter Property="Background" Value="LightGray"/>
-                                            <Setter Property="BorderBrush" Value="LightGray"/>
+                                <materialDesign:Chip Command="{Binding DataContext.SelectCellCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
+                                                    CommandParameter="{Binding}" MinWidth="80">
+                                    <materialDesign:Chip.Style>
+                                        <Style TargetType="{x:Type materialDesign:Chip}" BasedOn="{StaticResource MaterialDesignActionChip}">
                                             <Setter Property="Content" Value="Inactive"/>
+                                            <Setter Property="Background" Value="LightGray"/>
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding IsActive}" Value="True">
                                                     <Setter Property="Content" Value="Active"/>
                                                     <Setter Property="Background" Value="#221DB5"/>
+                                                    <Setter Property="Foreground" Value="White"/>
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>
-                                    </Button.Style>
-                                </Button>
+                                    </materialDesign:Chip.Style>
+                                </materialDesign:Chip>
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>


### PR DESCRIPTION
## Summary
- replace Activity button with Material Design chip styled for active/inactive state
- allow clicking the selected chip again to clear selection

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ba3a02bf008323bdc7907bea1cb147