### PR TITLE
Restore CellLibrary ListView header

### DIFF
--- a/CellManager/CellManager/Views/CellLibary/CellLibraryView.xaml
+++ b/CellManager/CellManager/Views/CellLibary/CellLibraryView.xaml
@@ -78,7 +78,7 @@
             <Button Content="Create Cell Library" Style="{StaticResource PrimaryActionButton}"  Padding="5"  Width="200" Height="40" Command="{Binding NewCellCommand}"/>
         </StackPanel>
 
-        <ListView Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" x:Name="lv_cells" ItemsSource="{Binding FilteredCells}" Margin="5" SizeChanged="ListView_SizeChanged" BorderThickness="1" BorderBrush="Black" >
+        <ListView Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" x:Name="lv_cells" ItemsSource="{Binding FilteredCells}" Margin="5" SizeChanged="ListView_SizeChanged">
 
             <ListView.Resources>
                 <!-- GridViewColumnHeader 스타일을 Items 컬렉션과 분리하여 정의 -->
@@ -90,6 +90,16 @@
                     <Setter Property="Padding" Value="5"/>
                 </Style>
             </ListView.Resources>
+
+            <ListView.Template>
+                <ControlTemplate TargetType="ListView">
+                    <Border BorderBrush="#E5E7EB" BorderThickness="1" SnapsToDevicePixels="True">
+                        <ScrollViewer Focusable="False" Template="{DynamicResource GridViewScrollViewer}">
+                            <ItemsPresenter />
+                        </ScrollViewer>
+                    </Border>
+                </ControlTemplate>
+            </ListView.Template>
 
             <!-- Row 높이와 MaterialDesign MinHeight 설정 -->
             <ListView.ItemContainerStyle>

--- a/CellManager/CellManager/Views/CellLibary/CellLibraryView.xaml
+++ b/CellManager/CellManager/Views/CellLibary/CellLibraryView.xaml
@@ -94,7 +94,8 @@
             <ListView.Template>
                 <ControlTemplate TargetType="ListView">
                     <Border BorderBrush="#E5E7EB" BorderThickness="1" SnapsToDevicePixels="True">
-                        <ScrollViewer Focusable="False" Template="{DynamicResource GridViewScrollViewer}">
+                        <ScrollViewer Focusable="False"
+                                      Style="{DynamicResource {x:Static GridView.GridViewScrollViewerStyleKey}}">
                             <ItemsPresenter />
                         </ScrollViewer>
                     </Border>


### PR DESCRIPTION
## Summary
- restore GridView headers in CellLibrary ListView by using GridViewScrollViewer template

## Testing
- ⚠️ `dotnet test CellManager/CellManager.sln` *(dotnet not installed; apt-get update hung during installation attempt)*

------
https://chatgpt.com/codex/tasks/task_e_68ba919a90cc8323899b9bafd5034a15