### PR TITLE
Add column separators to cell library list

### DIFF
--- a/CellManager/CellManager/Views/CellLibary/CellLibraryView.xaml
+++ b/CellManager/CellManager/Views/CellLibary/CellLibraryView.xaml
@@ -109,6 +109,13 @@
                     <Setter Property="BorderThickness" Value="1"/>
                     <Setter Property="Padding" Value="5"/>
                 </Style>
+                <!-- 각 셀의 우측 경계선 스타일 -->
+                <Style x:Key="CellRightBorder" TargetType="Border">
+                    <Setter Property="BorderBrush" Value="#E0E0E0"/>
+                    <Setter Property="BorderThickness" Value="0,0,1,0"/>
+                    <Setter Property="SnapsToDevicePixels" Value="True"/>
+                    <Setter Property="Padding" Value="5"/>
+                </Style>
             </ListView.Resources>
 
             <ListView.Template>
@@ -232,37 +239,82 @@
                     <GridViewColumn Header="Select">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
-                                <ToggleButton IsChecked="{Binding IsActive}"
-                                              Command="{Binding DataContext.SelectCellCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
-                                              CommandParameter="{Binding}"
-                                              Style="{StaticResource MaterialDesignSwitchSecondaryToggleButton}"
-                                              ToolTip="MaterialDesignSwitchSecondaryToggleButton"/>
+                                <Border Style="{StaticResource CellRightBorder}" Padding="0">
+                                    <ToggleButton IsChecked="{Binding IsActive}"
+                                                  Command="{Binding DataContext.SelectCellCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
+                                                  CommandParameter="{Binding}"
+                                                  Style="{StaticResource MaterialDesignSwitchSecondaryToggleButton}"
+                                                  ToolTip="MaterialDesignSwitchSecondaryToggleButton"/>
+                                </Border>
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
+
                     <!-- Cell Name -->
-                    <GridViewColumn Header="Cell name" 
-                                    DisplayMemberBinding="{Binding ModelName}"/>
+                    <GridViewColumn Header="Cell name">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <Border Style="{StaticResource CellRightBorder}">
+                                    <TextBlock Text="{Binding ModelName}" VerticalAlignment="Center"/>
+                                </Border>
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
 
                     <!-- Serial Number -->
-                    <GridViewColumn Header="Serial Number" 
-                                    DisplayMemberBinding="{Binding SerialNumber}"/>
+                    <GridViewColumn Header="Serial Number">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <Border Style="{StaticResource CellRightBorder}">
+                                    <TextBlock Text="{Binding SerialNumber}" VerticalAlignment="Center"/>
+                                </Border>
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
 
                     <!-- Part Number -->
-                    <GridViewColumn Header="Part Number" 
-                                    DisplayMemberBinding="{Binding PartNumber}"/>
+                    <GridViewColumn Header="Part Number">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <Border Style="{StaticResource CellRightBorder}">
+                                    <TextBlock Text="{Binding PartNumber}" VerticalAlignment="Center"/>
+                                </Border>
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
 
                     <!-- Update Date -->
-                    <GridViewColumn Header="Update Date" Width="180"
-                                    DisplayMemberBinding="{Binding LastUpdated, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}"/>
+                    <GridViewColumn Header="Update Date" Width="180">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <Border Style="{StaticResource CellRightBorder}">
+                                    <TextBlock Text="{Binding LastUpdated, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" VerticalAlignment="Center"/>
+                                </Border>
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
 
                     <!-- Cell Type -->
-                    <GridViewColumn Header="Cell Type" 
-                                    DisplayMemberBinding="{Binding CellType}"/>
+                    <GridViewColumn Header="Cell Type">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <Border Style="{StaticResource CellRightBorder}">
+                                    <TextBlock Text="{Binding CellType}" VerticalAlignment="Center"/>
+                                </Border>
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
 
                     <!-- Manufacturer -->
-                    <GridViewColumn Header="Cell Manufacturer"
-                                    DisplayMemberBinding="{Binding Manufacturer}"/>
+                    <GridViewColumn Header="Cell Manufacturer">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <Border Style="{StaticResource CellRightBorder}" BorderThickness="0">
+                                    <TextBlock Text="{Binding Manufacturer}" VerticalAlignment="Center"/>
+                                </Border>
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
 
                 </GridView>
             </ListView.View>


### PR DESCRIPTION
## Summary
- add reusable border style to draw vertical grid lines
- wrap each GridView column cell with border and suppress final column border

## Testing
- `/root/.dotnet/dotnet test CellManager/CellManager.sln -p:EnableWindowsTargeting=true`

------
https://chatgpt.com/codex/tasks/task_e_68baa951e274832389d1e6b95d0a8687