### PR TITLE
Refactor test setup view design

### DIFF
--- a/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
@@ -11,51 +11,6 @@
              Grid.IsSharedSizeScope="True">
 
     <UserControl.Resources>
-        <!-- Icon resources and image button style reused from Cell Library design -->
-        <BitmapImage x:Key="IconNew"    UriSource="pack://application:,,,/Image/new.png"/>
-        <BitmapImage x:Key="IconDelete" UriSource="pack://application:,,,/Image/delete.png"/>
-
-        <!-- 이미지 버튼 스타일 -->
-        <Style x:Key="ImageButton" TargetType="Button">
-            <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Cursor" Value="Hand"/>
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="Button">
-                        <Grid>
-                            <!-- 버튼 이미지 -->
-                            <Image x:Name="Img" Source="{TemplateBinding Tag}"
-                                   Stretch="Uniform"
-                                   RenderOptions.BitmapScalingMode="HighQuality"/>
-                        </Grid>
-
-                        <ControlTemplate.Triggers>
-                            <!-- Hover 효과: 약간 밝게 -->
-                            <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Img" Property="Opacity" Value="0.8"/>
-                            </Trigger>
-
-                            <!-- 클릭 효과: Scale 줄이기 -->
-                            <Trigger Property="IsPressed" Value="True">
-                                <Setter TargetName="Img" Property="RenderTransformOrigin" Value="0.5,0.5"/>
-                                <Setter TargetName="Img" Property="RenderTransform">
-                                    <Setter.Value>
-                                        <ScaleTransform ScaleX="0.9" ScaleY="0.9"/>
-                                    </Setter.Value>
-                                </Setter>
-                            </Trigger>
-
-                            <!-- 비활성화 효과: 흐리게 -->
-                            <Trigger Property="IsEnabled" Value="False">
-                                <Setter TargetName="Img" Property="Opacity" Value="0.4"/>
-                            </Trigger>
-                        </ControlTemplate.Triggers>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-
         <!-- Editor templates: auto-switched by CurrentEditor instance type -->
         <DataTemplate DataType="{x:Type tp:ChargeProfile}">
             <views:ChargeProfileDetailView />
@@ -168,16 +123,22 @@
                 <TabControl >
                     <TabItem Header="Charge">
                         <DockPanel>
-                              <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6">
-                                  <Button Style="{StaticResource ImageButton}"
+                              <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6" HorizontalAlignment="Right">
+                                  <Button Style="{StaticResource PrimaryActionButton}"
                                           Command="{Binding AddChargeProfileCommand}"
-                                          Tag="{StaticResource IconNew}"
-                                          Margin="0,0,6,0"
-                                          ToolTip="New"/>
-                                  <Button Style="{StaticResource ImageButton}"
-                                          Command="{Binding DeleteChargeProfileCommand}"
-                                          Tag="{StaticResource IconDelete}"
-                                          ToolTip="Delete"/>
+                                          Margin="0,0,10,0">
+                                      <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                          <materialDesign:PackIcon Kind="LibraryAdd" Width="18" Height="18"/>
+                                          <TextBlock Text=" Add"/>
+                                      </StackPanel>
+                                  </Button>
+                                  <Button Style="{StaticResource PrimaryActionButton}"
+                                          Command="{Binding DeleteChargeProfileCommand}">
+                                      <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                          <materialDesign:PackIcon Kind="Delete" Width="18" Height="18"/>
+                                          <TextBlock Text=" Delete"/>
+                                      </StackPanel>
+                                  </Button>
                               </StackPanel>
                             <ListBox Style="{StaticResource DenseListBox}"
                                  ItemsSource="{Binding ChargeProfiles}"
@@ -200,16 +161,22 @@
                     </TabItem>
                     <TabItem Header="Discharge">
                         <DockPanel>
-                              <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6">
-                                  <Button Style="{StaticResource ImageButton}"
+                              <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6" HorizontalAlignment="Right">
+                                  <Button Style="{StaticResource PrimaryActionButton}"
                                           Command="{Binding AddDischargeProfileCommand}"
-                                          Tag="{StaticResource IconNew}"
-                                          Margin="0,0,6,0"
-                                          ToolTip="New"/>
-                                  <Button Style="{StaticResource ImageButton}"
-                                          Command="{Binding DeleteDischargeProfileCommand}"
-                                          Tag="{StaticResource IconDelete}"
-                                          ToolTip="Delete"/>
+                                          Margin="0,0,10,0">
+                                      <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                          <materialDesign:PackIcon Kind="LibraryAdd" Width="18" Height="18"/>
+                                          <TextBlock Text=" Add"/>
+                                      </StackPanel>
+                                  </Button>
+                                  <Button Style="{StaticResource PrimaryActionButton}"
+                                          Command="{Binding DeleteDischargeProfileCommand}">
+                                      <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                          <materialDesign:PackIcon Kind="Delete" Width="18" Height="18"/>
+                                          <TextBlock Text=" Delete"/>
+                                      </StackPanel>
+                                  </Button>
                               </StackPanel>
                             <ListBox Style="{StaticResource DenseListBox}"
                                  ItemsSource="{Binding DischargeProfiles}"
@@ -232,16 +199,22 @@
                     </TabItem>
                     <TabItem Header="Rest">
                         <DockPanel>
-                              <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6">
-                                  <Button Style="{StaticResource ImageButton}"
+                              <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6" HorizontalAlignment="Right">
+                                  <Button Style="{StaticResource PrimaryActionButton}"
                                           Command="{Binding AddRestProfileCommand}"
-                                          Tag="{StaticResource IconNew}"
-                                          Margin="0,0,6,0"
-                                          ToolTip="New"/>
-                                  <Button Style="{StaticResource ImageButton}"
-                                          Command="{Binding DeleteRestProfileCommand}"
-                                          Tag="{StaticResource IconDelete}"
-                                          ToolTip="Delete"/>
+                                          Margin="0,0,10,0">
+                                      <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                          <materialDesign:PackIcon Kind="LibraryAdd" Width="18" Height="18"/>
+                                          <TextBlock Text=" Add"/>
+                                      </StackPanel>
+                                  </Button>
+                                  <Button Style="{StaticResource PrimaryActionButton}"
+                                          Command="{Binding DeleteRestProfileCommand}">
+                                      <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                          <materialDesign:PackIcon Kind="Delete" Width="18" Height="18"/>
+                                          <TextBlock Text=" Delete"/>
+                                      </StackPanel>
+                                  </Button>
                               </StackPanel>
                             <ListBox Style="{StaticResource DenseListBox}"
                                  ItemsSource="{Binding RestProfiles}"
@@ -264,16 +237,22 @@
                     </TabItem>
                     <TabItem Header="OCV">
                         <DockPanel>
-                              <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6">
-                                  <Button Style="{StaticResource ImageButton}"
+                              <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6" HorizontalAlignment="Right">
+                                  <Button Style="{StaticResource PrimaryActionButton}"
                                           Command="{Binding AddOcvProfileCommand}"
-                                          Tag="{StaticResource IconNew}"
-                                          Margin="0,0,6,0"
-                                          ToolTip="New"/>
-                                  <Button Style="{StaticResource ImageButton}"
-                                          Command="{Binding DeleteOcvProfileCommand}"
-                                          Tag="{StaticResource IconDelete}"
-                                          ToolTip="Delete"/>
+                                          Margin="0,0,10,0">
+                                      <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                          <materialDesign:PackIcon Kind="LibraryAdd" Width="18" Height="18"/>
+                                          <TextBlock Text=" Add"/>
+                                      </StackPanel>
+                                  </Button>
+                                  <Button Style="{StaticResource PrimaryActionButton}"
+                                          Command="{Binding DeleteOcvProfileCommand}">
+                                      <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                          <materialDesign:PackIcon Kind="Delete" Width="18" Height="18"/>
+                                          <TextBlock Text=" Delete"/>
+                                      </StackPanel>
+                                  </Button>
                               </StackPanel>
                             <ListBox Style="{StaticResource DenseListBox}"
                                  ItemsSource="{Binding OcvProfiles}"
@@ -296,16 +275,22 @@
                     </TabItem>
                     <TabItem Header="ECM">
                         <DockPanel>
-                              <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6">
-                                  <Button Style="{StaticResource ImageButton}"
+                              <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6" HorizontalAlignment="Right">
+                                  <Button Style="{StaticResource PrimaryActionButton}"
                                           Command="{Binding AddEcmProfileCommand}"
-                                          Tag="{StaticResource IconNew}"
-                                          Margin="0,0,6,0"
-                                          ToolTip="New"/>
-                                  <Button Style="{StaticResource ImageButton}"
-                                          Command="{Binding DeleteEcmProfileCommand}"
-                                          Tag="{StaticResource IconDelete}"
-                                          ToolTip="Delete"/>
+                                          Margin="0,0,10,0">
+                                      <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                          <materialDesign:PackIcon Kind="LibraryAdd" Width="18" Height="18"/>
+                                          <TextBlock Text=" Add"/>
+                                      </StackPanel>
+                                  </Button>
+                                  <Button Style="{StaticResource PrimaryActionButton}"
+                                          Command="{Binding DeleteEcmProfileCommand}">
+                                      <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                          <materialDesign:PackIcon Kind="Delete" Width="18" Height="18"/>
+                                          <TextBlock Text=" Delete"/>
+                                      </StackPanel>
+                                  </Button>
                               </StackPanel>
                             <ListBox Style="{StaticResource DenseListBox}"
                                  ItemsSource="{Binding EcmPulseProfiles}"
@@ -333,15 +318,23 @@
         <!-- RIGHT: Auto-switched editor + Save -->
         <materialDesign:Card Grid.Row="1" Grid.Column="2">
             <DockPanel>
-                  <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Margin="0,0,0,8">
+                  <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Margin="0,0,0,8" HorizontalAlignment="Right">
                       <TextBlock Text="Editor" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,12,0"/>
                       <Button Style="{StaticResource PrimaryActionButton}"
-                              Content="Save"
                               Command="{Binding SaveCurrentCommand}"
-                              Margin="0,0,6,0"/>
-                      <Button Style="{StaticResource MaterialDesignFlatButton}"
-                              Content="Delete"
-                              Command="{Binding DeleteCurrentCommand}" />
+                              Margin="0,0,10,0">
+                          <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <materialDesign:PackIcon Kind="ContentSave" Width="18" Height="18"/>
+                              <TextBlock Text=" Save"/>
+                          </StackPanel>
+                      </Button>
+                      <Button Style="{StaticResource PrimaryActionButton}"
+                              Command="{Binding DeleteCurrentCommand}">
+                          <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <materialDesign:PackIcon Kind="Delete" Width="18" Height="18"/>
+                              <TextBlock Text=" Delete"/>
+                          </StackPanel>
+                      </Button>
                   </StackPanel>
 
                 <ContentControl Content="{Binding CurrentEditor}"/>

--- a/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
@@ -141,14 +141,6 @@
             <views:RestProfileDetailView />
         </DataTemplate>
 
-        <!-- Shared style for profile list items -->
-        <Style x:Key="ProfileListItemStyle" TargetType="ListBoxItem">
-            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-            <Setter Property="VerticalContentAlignment" Value="Center"/>
-            <Setter Property="Padding" Value="4"/>
-            <Setter Property="Margin" Value="0,0,0,4"/>
-            <Setter Property="MinHeight" Value="40"/>
-        </Style>
     </UserControl.Resources>
 
     <Grid>
@@ -161,7 +153,7 @@
             <ColumnDefinition Width="10"/>
             <ColumnDefinition Width="400"/>
         </Grid.ColumnDefinitions>
-        <StatusBar Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" BorderThickness="1" Padding="5" Margin="0,0,0,8">
+        <StatusBar Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3">
             <WrapPanel>
                 <TextBlock Text="{Binding SelectedCell.DisplayNameAndId}" Margin="0,0,16,4"/>
                 <TextBlock Text="{Binding SelectedCell.LastUpdated, StringFormat='Updated: {0:yyyy-MM-dd HH:mm:ss}'}" Margin="0,0,16,4"/>
@@ -171,7 +163,7 @@
             </WrapPanel>
         </StatusBar>
         <!-- LEFT: Profile Libraries -->
-        <materialDesign:Card Margin="16" Padding="8" Grid.Row="1"  Grid.Column="0" Background="#FAFAFA" BorderThickness="1" BorderBrush="#E0E0E0">
+        <materialDesign:Card Grid.Row="1" Grid.Column="0">
             <DockPanel Width="auto" Height="auto">
                 <TabControl >
                     <TabItem Header="Charge">
@@ -187,9 +179,10 @@
                                           Tag="{StaticResource IconDelete}"
                                           ToolTip="Delete"/>
                               </StackPanel>
-                            <ListBox ItemsSource="{Binding ChargeProfiles}"
+                            <ListBox Style="{StaticResource DenseListBox}"
+                                 ItemsSource="{Binding ChargeProfiles}"
                                  SelectedItem="{Binding SelectedChargeProfile, Mode=TwoWay}"
-                                 ItemContainerStyle="{StaticResource ProfileListItemStyle}">
+                                 ItemContainerStyle="{StaticResource DenseListBoxItem}">
                                 <ListBox.ItemTemplate>
                                     <DataTemplate>
                                         <StackPanel>
@@ -218,9 +211,10 @@
                                           Tag="{StaticResource IconDelete}"
                                           ToolTip="Delete"/>
                               </StackPanel>
-                            <ListBox ItemsSource="{Binding DischargeProfiles}"
+                            <ListBox Style="{StaticResource DenseListBox}"
+                                 ItemsSource="{Binding DischargeProfiles}"
                                  SelectedItem="{Binding SelectedDischargeProfile, Mode=TwoWay}"
-                                 ItemContainerStyle="{StaticResource ProfileListItemStyle}">
+                                 ItemContainerStyle="{StaticResource DenseListBoxItem}">
                                 <ListBox.ItemTemplate>
                                     <DataTemplate>
                                         <StackPanel>
@@ -249,9 +243,10 @@
                                           Tag="{StaticResource IconDelete}"
                                           ToolTip="Delete"/>
                               </StackPanel>
-                            <ListBox ItemsSource="{Binding RestProfiles}"
+                            <ListBox Style="{StaticResource DenseListBox}"
+                                 ItemsSource="{Binding RestProfiles}"
                                  SelectedItem="{Binding SelectedRestProfile, Mode=TwoWay}"
-                                 ItemContainerStyle="{StaticResource ProfileListItemStyle}">
+                                 ItemContainerStyle="{StaticResource DenseListBoxItem}">
                                 <ListBox.ItemTemplate>
                                     <DataTemplate>
                                         <StackPanel>
@@ -280,9 +275,10 @@
                                           Tag="{StaticResource IconDelete}"
                                           ToolTip="Delete"/>
                               </StackPanel>
-                            <ListBox ItemsSource="{Binding OcvProfiles}"
+                            <ListBox Style="{StaticResource DenseListBox}"
+                                 ItemsSource="{Binding OcvProfiles}"
                                  SelectedItem="{Binding SelectedOcvProfile, Mode=TwoWay}"
-                                 ItemContainerStyle="{StaticResource ProfileListItemStyle}">
+                                 ItemContainerStyle="{StaticResource DenseListBoxItem}">
                                 <ListBox.ItemTemplate>
                                     <DataTemplate>
                                         <StackPanel>
@@ -311,9 +307,10 @@
                                           Tag="{StaticResource IconDelete}"
                                           ToolTip="Delete"/>
                               </StackPanel>
-                            <ListBox ItemsSource="{Binding EcmPulseProfiles}"
+                            <ListBox Style="{StaticResource DenseListBox}"
+                                 ItemsSource="{Binding EcmPulseProfiles}"
                                  SelectedItem="{Binding SelectedEcmPulseProfile, Mode=TwoWay}"
-                                 ItemContainerStyle="{StaticResource ProfileListItemStyle}">
+                                 ItemContainerStyle="{StaticResource DenseListBoxItem}">
                                 <ListBox.ItemTemplate>
                                     <DataTemplate>
                                         <StackPanel>
@@ -334,22 +331,22 @@
             </DockPanel>
         </materialDesign:Card>
         <!-- RIGHT: Auto-switched editor + Save -->
-        <DockPanel Grid.Row="1" Grid.Column="2" Margin="8">
-              <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Margin="0,0,0,8">
-                  <TextBlock Text="Editor" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,12,0"/>
-                  <Button Style="{StaticResource PrimaryActionButton}"
-                          Content="Save"
-                          Command="{Binding SaveCurrentCommand}"
-                          Margin="0,0,6,0"/>
-                  <Button Style="{StaticResource MaterialDesignFlatButton}"
-                          Content="Delete"
-                          Command="{Binding DeleteCurrentCommand}" />
-              </StackPanel>
+        <materialDesign:Card Grid.Row="1" Grid.Column="2">
+            <DockPanel>
+                  <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Margin="0,0,0,8">
+                      <TextBlock Text="Editor" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                      <Button Style="{StaticResource PrimaryActionButton}"
+                              Content="Save"
+                              Command="{Binding SaveCurrentCommand}"
+                              Margin="0,0,6,0"/>
+                      <Button Style="{StaticResource MaterialDesignFlatButton}"
+                              Content="Delete"
+                              Command="{Binding DeleteCurrentCommand}" />
+                  </StackPanel>
 
-            <Border BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" Padding="8">
                 <ContentControl Content="{Binding CurrentEditor}"/>
-            </Border>
-        </DockPanel>
+            </DockPanel>
+        </materialDesign:Card>
     </Grid>
 </UserControl>
 

--- a/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
@@ -11,6 +11,51 @@
              Grid.IsSharedSizeScope="True">
 
     <UserControl.Resources>
+        <!-- Icon resources and image button style reused from Cell Library design -->
+        <BitmapImage x:Key="IconNew"    UriSource="pack://application:,,,/Image/new.png"/>
+        <BitmapImage x:Key="IconDelete" UriSource="pack://application:,,,/Image/delete.png"/>
+
+        <!-- 이미지 버튼 스타일 -->
+        <Style x:Key="ImageButton" TargetType="Button">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Grid>
+                            <!-- 버튼 이미지 -->
+                            <Image x:Name="Img" Source="{TemplateBinding Tag}"
+                                   Stretch="Uniform"
+                                   RenderOptions.BitmapScalingMode="HighQuality"/>
+                        </Grid>
+
+                        <ControlTemplate.Triggers>
+                            <!-- Hover 효과: 약간 밝게 -->
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Img" Property="Opacity" Value="0.8"/>
+                            </Trigger>
+
+                            <!-- 클릭 효과: Scale 줄이기 -->
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="Img" Property="RenderTransformOrigin" Value="0.5,0.5"/>
+                                <Setter TargetName="Img" Property="RenderTransform">
+                                    <Setter.Value>
+                                        <ScaleTransform ScaleX="0.9" ScaleY="0.9"/>
+                                    </Setter.Value>
+                                </Setter>
+                            </Trigger>
+
+                            <!-- 비활성화 효과: 흐리게 -->
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="Img" Property="Opacity" Value="0.4"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
         <!-- Editor templates: auto-switched by CurrentEditor instance type -->
         <DataTemplate DataType="{x:Type tp:ChargeProfile}">
             <views:ChargeProfileDetailView />
@@ -131,20 +176,17 @@
                 <TabControl >
                     <TabItem Header="Charge">
                         <DockPanel>
-                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6">
-                                <Button Style="{StaticResource MaterialDesignFlatButton}" Command="{Binding AddChargeProfileCommand}" Margin="0,0,6,0">
-                                    <StackPanel Orientation="Horizontal">
-                                        <materialDesign:PackIcon Kind="Plus" />
-                                        <TextBlock Text="New" Margin="4,0,0,0"/>
-                                    </StackPanel>
-                                </Button>
-                                <Button Style="{StaticResource MaterialDesignFlatButton}" Command="{Binding DeleteChargeProfileCommand}">
-                                    <StackPanel Orientation="Horizontal">
-                                        <materialDesign:PackIcon Kind="TrashCan" />
-                                        <TextBlock Text="Delete" Margin="4,0,0,0"/>
-                                    </StackPanel>
-                                </Button>
-                            </StackPanel>
+                              <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6">
+                                  <Button Style="{StaticResource ImageButton}"
+                                          Command="{Binding AddChargeProfileCommand}"
+                                          Tag="{StaticResource IconNew}"
+                                          Margin="0,0,6,0"
+                                          ToolTip="New"/>
+                                  <Button Style="{StaticResource ImageButton}"
+                                          Command="{Binding DeleteChargeProfileCommand}"
+                                          Tag="{StaticResource IconDelete}"
+                                          ToolTip="Delete"/>
+                              </StackPanel>
                             <ListBox ItemsSource="{Binding ChargeProfiles}"
                                  SelectedItem="{Binding SelectedChargeProfile, Mode=TwoWay}"
                                  ItemContainerStyle="{StaticResource ProfileListItemStyle}">
@@ -165,20 +207,17 @@
                     </TabItem>
                     <TabItem Header="Discharge">
                         <DockPanel>
-                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6">
-                                <Button Style="{StaticResource MaterialDesignFlatButton}" Command="{Binding AddDischargeProfileCommand}" Margin="0,0,6,0">
-                                    <StackPanel Orientation="Horizontal">
-                                        <materialDesign:PackIcon Kind="Plus" />
-                                        <TextBlock Text="New" Margin="4,0,0,0"/>
-                                    </StackPanel>
-                                </Button>
-                                <Button Style="{StaticResource MaterialDesignFlatButton}" Command="{Binding DeleteDischargeProfileCommand}">
-                                    <StackPanel Orientation="Horizontal">
-                                        <materialDesign:PackIcon Kind="TrashCan" />
-                                        <TextBlock Text="Delete" Margin="4,0,0,0"/>
-                                    </StackPanel>
-                                </Button>
-                            </StackPanel>
+                              <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6">
+                                  <Button Style="{StaticResource ImageButton}"
+                                          Command="{Binding AddDischargeProfileCommand}"
+                                          Tag="{StaticResource IconNew}"
+                                          Margin="0,0,6,0"
+                                          ToolTip="New"/>
+                                  <Button Style="{StaticResource ImageButton}"
+                                          Command="{Binding DeleteDischargeProfileCommand}"
+                                          Tag="{StaticResource IconDelete}"
+                                          ToolTip="Delete"/>
+                              </StackPanel>
                             <ListBox ItemsSource="{Binding DischargeProfiles}"
                                  SelectedItem="{Binding SelectedDischargeProfile, Mode=TwoWay}"
                                  ItemContainerStyle="{StaticResource ProfileListItemStyle}">
@@ -199,20 +238,17 @@
                     </TabItem>
                     <TabItem Header="Rest">
                         <DockPanel>
-                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6">
-                                <Button Style="{StaticResource MaterialDesignFlatButton}" Command="{Binding AddRestProfileCommand}" Margin="0,0,6,0">
-                                    <StackPanel Orientation="Horizontal">
-                                        <materialDesign:PackIcon Kind="Plus" />
-                                        <TextBlock Text="New" Margin="4,0,0,0"/>
-                                    </StackPanel>
-                                </Button>
-                                <Button Style="{StaticResource MaterialDesignFlatButton}" Command="{Binding DeleteRestProfileCommand}">
-                                    <StackPanel Orientation="Horizontal">
-                                        <materialDesign:PackIcon Kind="TrashCan" />
-                                        <TextBlock Text="Delete" Margin="4,0,0,0"/>
-                                    </StackPanel>
-                                </Button>
-                            </StackPanel>
+                              <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6">
+                                  <Button Style="{StaticResource ImageButton}"
+                                          Command="{Binding AddRestProfileCommand}"
+                                          Tag="{StaticResource IconNew}"
+                                          Margin="0,0,6,0"
+                                          ToolTip="New"/>
+                                  <Button Style="{StaticResource ImageButton}"
+                                          Command="{Binding DeleteRestProfileCommand}"
+                                          Tag="{StaticResource IconDelete}"
+                                          ToolTip="Delete"/>
+                              </StackPanel>
                             <ListBox ItemsSource="{Binding RestProfiles}"
                                  SelectedItem="{Binding SelectedRestProfile, Mode=TwoWay}"
                                  ItemContainerStyle="{StaticResource ProfileListItemStyle}">
@@ -233,20 +269,17 @@
                     </TabItem>
                     <TabItem Header="OCV">
                         <DockPanel>
-                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6">
-                                <Button Style="{StaticResource MaterialDesignFlatButton}" Command="{Binding AddOcvProfileCommand}" Margin="0,0,6,0">
-                                    <StackPanel Orientation="Horizontal">
-                                        <materialDesign:PackIcon Kind="Plus" />
-                                        <TextBlock Text="New" Margin="4,0,0,0"/>
-                                    </StackPanel>
-                                </Button>
-                                <Button Style="{StaticResource MaterialDesignFlatButton}" Command="{Binding DeleteOcvProfileCommand}">
-                                    <StackPanel Orientation="Horizontal">
-                                        <materialDesign:PackIcon Kind="TrashCan" />
-                                        <TextBlock Text="Delete" Margin="4,0,0,0"/>
-                                    </StackPanel>
-                                </Button>
-                            </StackPanel>
+                              <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6">
+                                  <Button Style="{StaticResource ImageButton}"
+                                          Command="{Binding AddOcvProfileCommand}"
+                                          Tag="{StaticResource IconNew}"
+                                          Margin="0,0,6,0"
+                                          ToolTip="New"/>
+                                  <Button Style="{StaticResource ImageButton}"
+                                          Command="{Binding DeleteOcvProfileCommand}"
+                                          Tag="{StaticResource IconDelete}"
+                                          ToolTip="Delete"/>
+                              </StackPanel>
                             <ListBox ItemsSource="{Binding OcvProfiles}"
                                  SelectedItem="{Binding SelectedOcvProfile, Mode=TwoWay}"
                                  ItemContainerStyle="{StaticResource ProfileListItemStyle}">
@@ -267,20 +300,17 @@
                     </TabItem>
                     <TabItem Header="ECM">
                         <DockPanel>
-                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6">
-                                <Button Style="{StaticResource MaterialDesignFlatButton}" Command="{Binding AddEcmProfileCommand}" Margin="0,0,6,0">
-                                    <StackPanel Orientation="Horizontal">
-                                        <materialDesign:PackIcon Kind="Plus" />
-                                        <TextBlock Text="New" Margin="4,0,0,0"/>
-                                    </StackPanel>
-                                </Button>
-                                <Button Style="{StaticResource MaterialDesignFlatButton}" Command="{Binding DeleteEcmProfileCommand}">
-                                    <StackPanel Orientation="Horizontal">
-                                        <materialDesign:PackIcon Kind="TrashCan" />
-                                        <TextBlock Text="Delete" Margin="4,0,0,0"/>
-                                    </StackPanel>
-                                </Button>
-                            </StackPanel>
+                              <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6">
+                                  <Button Style="{StaticResource ImageButton}"
+                                          Command="{Binding AddEcmProfileCommand}"
+                                          Tag="{StaticResource IconNew}"
+                                          Margin="0,0,6,0"
+                                          ToolTip="New"/>
+                                  <Button Style="{StaticResource ImageButton}"
+                                          Command="{Binding DeleteEcmProfileCommand}"
+                                          Tag="{StaticResource IconDelete}"
+                                          ToolTip="Delete"/>
+                              </StackPanel>
                             <ListBox ItemsSource="{Binding EcmPulseProfiles}"
                                  SelectedItem="{Binding SelectedEcmPulseProfile, Mode=TwoWay}"
                                  ItemContainerStyle="{StaticResource ProfileListItemStyle}">
@@ -305,11 +335,16 @@
         </materialDesign:Card>
         <!-- RIGHT: Auto-switched editor + Save -->
         <DockPanel Grid.Row="1" Grid.Column="2" Margin="8">
-            <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Margin="0,0,0,8">
-                <TextBlock Text="Editor" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,12,0"/>
-                <Button Content="Save" Command="{Binding SaveCurrentCommand}" Margin="0,0,6,0"/>
-                <Button Content="Delete" Command="{Binding DeleteCurrentCommand}" />
-            </StackPanel>
+              <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Margin="0,0,0,8">
+                  <TextBlock Text="Editor" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,12,0"/>
+                  <Button Style="{StaticResource PrimaryActionButton}"
+                          Content="Save"
+                          Command="{Binding SaveCurrentCommand}"
+                          Margin="0,0,6,0"/>
+                  <Button Style="{StaticResource MaterialDesignFlatButton}"
+                          Content="Delete"
+                          Command="{Binding DeleteCurrentCommand}" />
+              </StackPanel>
 
             <Border BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" Padding="8">
                 <ContentControl Content="{Binding CurrentEditor}"/>


### PR DESCRIPTION
## Summary
- reuse cell library icon resources in test setup view
- add shared ImageButton style and apply to profile tabs
- style save/delete controls with existing application button styles

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bab05640388323ade64f325802d43a