### PR TITLE
Style cell deletion popup to match cell library

### DIFF
--- a/CellManager/CellManager/ViewModels/CellLibraryViewModel.cs
+++ b/CellManager/CellManager/ViewModels/CellLibraryViewModel.cs
@@ -194,13 +194,10 @@ namespace CellManager.ViewModels
         {
             if (cell == null || cell.Id <= 0) return;
 
-            var result = MessageBox.Show(
-                "Are you sure you want to delete the selected cell?",
-                "Confirm Delete",
-                MessageBoxButton.YesNo,
-                MessageBoxImage.Question);
+            var view = new DeleteConfirmationView { Owner = Application.Current.MainWindow };
+            var result = view.ShowDialog();
 
-            if (result == MessageBoxResult.Yes)
+            if (result == true)
             {
                 _cellRepository.DeleteCell(cell);
                 ExecuteLoadData();

--- a/CellManager/CellManager/Views/CellLibary/DeleteConfirmationView.xaml
+++ b/CellManager/CellManager/Views/CellLibary/DeleteConfirmationView.xaml
@@ -1,0 +1,24 @@
+<Window x:Class="CellManager.Views.CellLibary.DeleteConfirmationView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        Title="Confirm Delete"
+        Width="400" Height="180"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        WindowStyle="None"
+        Background="Transparent"
+        AllowsTransparency="True">
+    <materialDesign:Card Margin="16">
+        <StackPanel Margin="8">
+            <TextBlock Text="Are you sure you want to delete the selected cell?"
+                       TextWrapping="Wrap"
+                       Margin="0,0,0,16"/>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="Cancel" Width="80" Margin="0,0,8,0" IsCancel="True"/>
+                <Button Content="Delete" Width="80" Style="{StaticResource PrimaryActionButton}"
+                        Click="Delete_Click" IsDefault="True"/>
+            </StackPanel>
+        </StackPanel>
+    </materialDesign:Card>
+</Window>

--- a/CellManager/CellManager/Views/CellLibary/DeleteConfirmationView.xaml.cs
+++ b/CellManager/CellManager/Views/CellLibary/DeleteConfirmationView.xaml.cs
@@ -1,0 +1,17 @@
+using System.Windows;
+
+namespace CellManager.Views.CellLibary
+{
+    public partial class DeleteConfirmationView : Window
+    {
+        public DeleteConfirmationView()
+        {
+            InitializeComponent();
+        }
+
+        private void Delete_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace default MessageBox with DeleteConfirmationView styled like the cell library
- add DeleteConfirmationView dialog using existing MaterialDesign resources

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68be33c074b883238ad52a5b5d614a56