### PR TITLE
Adjust profile group layout to fit window

### DIFF
--- a/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
@@ -20,12 +20,12 @@
                 <TextBlock Text="{Binding SelectedCell.SerialNumber, StringFormat='SN: {0}'}" Margin="0,0,0,4"/>
             </WrapPanel>
         </StatusBar>
-        <DockPanel Grid.Row="1" Style="{x:Null}">
-            <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
-                <StackPanel Orientation="Horizontal">
+        <DockPanel Grid.Row="1">
+            <UniformGrid x:Name="ProfilesGrid" Rows="1">
 
                     <!-- Charge Profiles -->
-                    <GroupBox Margin="5,15,16,5" MaxWidth="300">
+                    <GroupBox Margin="5,15,16,5" VerticalAlignment="Stretch"
+                              MaxHeight="{Binding ElementName=ProfilesGrid, Path=ActualHeight}">
                         <DockPanel>
                             <WrapPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6" HorizontalAlignment="Right">
                                 <TextBlock Text="Charge Profiles" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,8,0" FontSize="16"/>
@@ -71,7 +71,8 @@
                     </GroupBox>
 
                     <!-- Discharge Profiles -->
-                    <GroupBox Margin="5,15,16,5">
+                    <GroupBox Margin="5,15,16,5" VerticalAlignment="Stretch"
+                              MaxHeight="{Binding ElementName=ProfilesGrid, Path=ActualHeight}">
                         <DockPanel>
                             <WrapPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6" HorizontalAlignment="Right">
                                 <TextBlock Text="Discharge Profiles" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,8,0" FontSize="16"/>
@@ -117,7 +118,8 @@
                     </GroupBox>
 
                     <!-- Rest Profiles -->
-                    <GroupBox Margin="5,15,16,5">
+                    <GroupBox Margin="5,15,16,5" VerticalAlignment="Stretch"
+                              MaxHeight="{Binding ElementName=ProfilesGrid, Path=ActualHeight}">
                         <DockPanel>
                             <WrapPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6" HorizontalAlignment="Right">
                                 <TextBlock Text="Rest Profiles" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,8,0" FontSize="16"/>
@@ -163,7 +165,8 @@
                     </GroupBox>
 
                     <!-- OCV Profiles -->
-                    <GroupBox Margin="5,15,16,5">
+                    <GroupBox Margin="5,15,16,5" VerticalAlignment="Stretch"
+                              MaxHeight="{Binding ElementName=ProfilesGrid, Path=ActualHeight}">
                         <DockPanel>
                             <WrapPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6" HorizontalAlignment="Right">
                                 <TextBlock Text="OCV Profiles" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,8,0" FontSize="16"/>
@@ -209,7 +212,8 @@
                     </GroupBox>
 
                     <!-- ECM Profiles -->
-                    <GroupBox Margin="5,15,5,5">
+                    <GroupBox Margin="5,15,5,5" VerticalAlignment="Stretch"
+                              MaxHeight="{Binding ElementName=ProfilesGrid, Path=ActualHeight}">
                         <DockPanel>
                             <WrapPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,6" HorizontalAlignment="Right">
                                 <TextBlock Text="ECM Profiles" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,8,0" FontSize="16"/>
@@ -254,8 +258,7 @@
                         </DockPanel>
                     </GroupBox>
 
-                </StackPanel>
-            </ScrollViewer>
+            </UniformGrid>
         </DockPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- Replace scrolling layout with a UniformGrid so all profile group boxes fit within the window
- Bind each profile group box's height to the available space for automatic resizing on window changes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68be578a2ef08323a35b581f78140cb9