### PR TITLE
Prevent duplicate profile IDs across test types

### DIFF
--- a/CellManager/CellManager/Models/ProfileReference.cs
+++ b/CellManager/CellManager/Models/ProfileReference.cs
@@ -7,6 +7,13 @@ namespace CellManager.Models
         public TestProfileType Type { get; set; }
         public int Id { get; set; }
         public string Name { get; set; } = string.Empty;
-        public string DisplayNameAndId => $"ID: {Id} - {Name}";
+
+        /// <summary>
+        /// Generates a unique identifier that accounts for the profile type.
+        /// This prevents ID collisions between different profile tables.
+        /// </summary>
+        public int UniqueId => ((int)Type * 1_000_000) + Id;
+
+        public string DisplayNameAndId => $"ID: {UniqueId} - {Name}";
     }
 }

--- a/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
+++ b/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
@@ -140,7 +140,7 @@ namespace CellManager.ViewModels
             {
                 Name = ScheduleName,
                 Notes = Notes,
-                TestProfileIds = WorkingSchedule.Select(p => p.Id).ToList(),
+                TestProfileIds = WorkingSchedule.Select(p => p.UniqueId).ToList(),
                 Ordering = 0
             };
             _scheduleRepository.Save(schedule);
@@ -190,7 +190,7 @@ namespace CellManager.ViewModels
                 WorkingSchedule.Clear();
                 foreach (var id in value.TestProfileIds)
                 {
-                    var profile = ProfileLibrary.FirstOrDefault(p => p.Id == id);
+                    var profile = ProfileLibrary.FirstOrDefault(p => p.UniqueId == id);
                     if (profile != null)
                         WorkingSchedule.Add(profile);
                 }


### PR DESCRIPTION
## Summary
- derive a global unique identifier for test profiles by combining type and id
- use the combined identifier when saving and loading schedules to avoid collisions

## Testing
- `dotnet test` *(fails: WindowsDesktop targets missing; tests still executed with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68be6022a2c48323a791f3bf0ce2a879