### PR TITLE
Show profile ID in test profile detail views

### DIFF
--- a/CellManager/CellManager/Models/TestProfile/ProfileDisplayIds.cs
+++ b/CellManager/CellManager/Models/TestProfile/ProfileDisplayIds.cs
@@ -1,0 +1,29 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace CellManager.Models.TestProfile
+{
+    public partial class ChargeProfile
+    {
+        [ObservableProperty] private int _displayId;
+    }
+
+    public partial class DischargeProfile
+    {
+        [ObservableProperty] private int _displayId;
+    }
+
+    public partial class RestProfile
+    {
+        [ObservableProperty] private int _displayId;
+    }
+
+    public partial class OCVProfile
+    {
+        [ObservableProperty] private int _displayId;
+    }
+
+    public partial class ECMPulseProfile
+    {
+        [ObservableProperty] private int _displayId;
+    }
+}

--- a/CellManager/CellManager/ViewModels/TestSetupViewModel.cs
+++ b/CellManager/CellManager/ViewModels/TestSetupViewModel.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.ObjectModel;
+using System.Data.SQLite;
+using System.IO;
 using System.Text.Json;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -251,8 +254,37 @@ namespace CellManager.ViewModels
 
         private static T Clone<T>(T source) => JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(source))!;
 
+        private int GetNextProfileId()
+        {
+            var dataDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Data");
+            Directory.CreateDirectory(dataDir);
+            var dbPath = Path.Combine(dataDir, "test_profiles.db");
+            using var conn = new SQLiteConnection($"Data Source={dbPath};Version=3;");
+            conn.Open();
+            return ProfileIdProvider.GetNextId(conn);
+        }
+
         private bool OpenEditor(object profile)
         {
+            switch (profile)
+            {
+                case ChargeProfile cp:
+                    cp.DisplayId = cp.Id > 0 ? cp.Id : GetNextProfileId();
+                    break;
+                case DischargeProfile dp:
+                    dp.DisplayId = dp.Id > 0 ? dp.Id : GetNextProfileId();
+                    break;
+                case RestProfile rp:
+                    rp.DisplayId = rp.Id > 0 ? rp.Id : GetNextProfileId();
+                    break;
+                case OCVProfile op:
+                    op.DisplayId = op.Id > 0 ? op.Id : GetNextProfileId();
+                    break;
+                case ECMPulseProfile ep:
+                    ep.DisplayId = ep.Id > 0 ? ep.Id : GetNextProfileId();
+                    break;
+            }
+
             var window = new ProfileDetailWindow { DataContext = profile };
             return window.ShowDialog() == true;
         }

--- a/CellManager/CellManager/Views/TestSetup/ChargeProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/ChargeProfileDetailView.xaml
@@ -8,6 +8,7 @@
     <Grid Margin="8">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="20"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -48,34 +49,35 @@
         </Grid.Resources>
 
         <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Text="Charge Profile" Margin="4" VerticalAlignment="Center" FontSize="20"/>
+        <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding DisplayId, StringFormat=ID: {0}}" Margin="4"/>
 
-        <TextBlock Grid.Row="2" Text="Name" Margin="4"/>
-        <TextBox Grid.Row="2" Grid.Column="1" Margin="4" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
-        <Border Grid.Row="3" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+        <TextBlock Grid.Row="3" Text="Name" Margin="4"/>
+        <TextBox Grid.Row="3" Grid.Column="1" Margin="4" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
+        <Border Grid.Row="4" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="4" Text="Mode" Margin="4"/>
-        <ComboBox Grid.Row="4" Grid.Column="1" Margin="4" SelectedValue="{Binding ChargeMode, UpdateSourceTrigger=PropertyChanged}" SelectedValuePath="Tag">
+        <TextBlock Grid.Row="5" Text="Mode" Margin="4"/>
+        <ComboBox Grid.Row="5" Grid.Column="1" Margin="4" SelectedValue="{Binding ChargeMode, UpdateSourceTrigger=PropertyChanged}" SelectedValuePath="Tag">
             <ComboBoxItem Content="Charge by capacity" Tag="{x:Static tp:ChargeMode.ChargeByCapacity}"/>
             <ComboBoxItem Content="Charge by time" Tag="{x:Static tp:ChargeMode.ChargeByTime}"/>
             <ComboBoxItem Content="Full charge" Tag="{x:Static tp:ChargeMode.FullCharge}"/>
         </ComboBox>
-        <Border Grid.Row="5" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+        <Border Grid.Row="6" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="6" Text="Charge Current (A)" Margin="4"/>
-        <TextBox Grid.Row="6" Grid.Column="1" Margin="4" Text="{Binding ChargeCurrent, UpdateSourceTrigger=PropertyChanged}"/>
-        <Border Grid.Row="7" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+        <TextBlock Grid.Row="7" Text="Charge Current (A)" Margin="4"/>
+        <TextBox Grid.Row="7" Grid.Column="1" Margin="4" Text="{Binding ChargeCurrent, UpdateSourceTrigger=PropertyChanged}"/>
+        <Border Grid.Row="8" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="8" Text="Charge Voltage (V)" Margin="4"/>
-        <TextBox Grid.Row="8" Grid.Column="1" Margin="4" Text="{Binding ChargeCutoffVoltage, UpdateSourceTrigger=PropertyChanged}"/>
-        <Border Grid.Row="9" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+        <TextBlock Grid.Row="9" Text="Charge Voltage (V)" Margin="4"/>
+        <TextBox Grid.Row="9" Grid.Column="1" Margin="4" Text="{Binding ChargeCutoffVoltage, UpdateSourceTrigger=PropertyChanged}"/>
+        <Border Grid.Row="10" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="10" Text="Cutoff Current (A)" Margin="4"/>
-        <TextBox Grid.Row="10" Grid.Column="1" Margin="4" Text="{Binding CutoffCurrent, UpdateSourceTrigger=PropertyChanged}"/>
-        <Border Grid.Row="11" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+        <TextBlock Grid.Row="11" Text="Cutoff Current (A)" Margin="4"/>
+        <TextBox Grid.Row="11" Grid.Column="1" Margin="4" Text="{Binding CutoffCurrent, UpdateSourceTrigger=PropertyChanged}"/>
+        <Border Grid.Row="12" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="12" Text="Capacity (mAh)" Margin="4" Style="{StaticResource CapacityVisibilityStyle}"/>
-        <TextBox Grid.Row="12" Grid.Column="1" Margin="4" Text="{Binding ChargeCapacityMah, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource CapacityVisibilityStyle}"/>
-        <Border Grid.Row="13" Grid.ColumnSpan="2" Margin="0,4">
+        <TextBlock Grid.Row="13" Text="Capacity (mAh)" Margin="4" Style="{StaticResource CapacityVisibilityStyle}"/>
+        <TextBox Grid.Row="13" Grid.Column="1" Margin="4" Text="{Binding ChargeCapacityMah, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource CapacityVisibilityStyle}"/>
+        <Border Grid.Row="14" Grid.ColumnSpan="2" Margin="0,4">
             <Border.Style>
                 <Style TargetType="Border" BasedOn="{StaticResource HDivider}">
                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -88,8 +90,8 @@
             </Border.Style>
         </Border>
 
-        <TextBlock Grid.Row="14" Text="Charge Time" Margin="4" Style="{StaticResource TimeVisibilityStyle}"/>
-        <StackPanel Grid.Row="14" Grid.Column="1" Orientation="Horizontal" Margin="4" Style="{StaticResource TimeVisibilityStyle}">
+        <TextBlock Grid.Row="15" Text="Charge Time" Margin="4" Style="{StaticResource TimeVisibilityStyle}"/>
+        <StackPanel Grid.Row="15" Grid.Column="1" Orientation="Horizontal" Margin="4" Style="{StaticResource TimeVisibilityStyle}">
             <TextBox Width="40" Text="{Binding ChargeHours, UpdateSourceTrigger=PropertyChanged}"/>
             <TextBlock Text=":" Margin="2" VerticalAlignment="Center"/>
             <TextBox Width="40" Text="{Binding ChargeMinutes, UpdateSourceTrigger=PropertyChanged}"/>

--- a/CellManager/CellManager/Views/TestSetup/DischargeProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/DischargeProfileDetailView.xaml
@@ -9,6 +9,7 @@
     <Grid Margin="8">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="20"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -28,33 +29,34 @@
         </Grid.ColumnDefinitions>
 
         <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Text="Dishcarge Profile" Margin="4" VerticalAlignment="Center" FontSize="20"/>
+        <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding DisplayId, StringFormat=ID: {0}}" Margin="4"/>
 
-        <TextBlock Grid.Row="2" Text="Name" Margin="4"/>
-        <TextBox Grid.Row="2" Grid.Column="1" Margin="4" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
-        <Border Grid.Row="3" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
-        
-        <TextBlock Grid.Row="4" Text="Mode" Margin="4"/>
-        <ComboBox Grid.Row="4" Grid.Column="1" Margin="4" SelectedValue="{Binding DischargeMode, UpdateSourceTrigger=PropertyChanged}" SelectedValuePath="Tag">
+        <TextBlock Grid.Row="3" Text="Name" Margin="4"/>
+        <TextBox Grid.Row="3" Grid.Column="1" Margin="4" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
+        <Border Grid.Row="4" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+
+        <TextBlock Grid.Row="5" Text="Mode" Margin="4"/>
+        <ComboBox Grid.Row="5" Grid.Column="1" Margin="4" SelectedValue="{Binding DischargeMode, UpdateSourceTrigger=PropertyChanged}" SelectedValuePath="Tag">
             <ComboBoxItem Content="Discharge by capacity" Tag="{x:Static tp:DischargeMode.DischargeByCapacity}"/>
             <ComboBoxItem Content="Discharge by time" Tag="{x:Static tp:DischargeMode.DischargeByTime}"/>
             <ComboBoxItem Content="Full discharge" Tag="{x:Static tp:DischargeMode.FullDischarge}"/>
         </ComboBox>
         
-        <Border Grid.Row="5" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
-      
-        <TextBlock Grid.Row="6" Text="Discharge Current (A)" Margin="4"/>
-        <TextBox Grid.Row="6" Grid.Column="1" Margin="4" Text="{Binding DischargeCurrent, UpdateSourceTrigger=PropertyChanged}"/>
+        <Border Grid.Row="6" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <Border Grid.Row="7" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
-        
-        <TextBlock Grid.Row="8" Text="Cutoff Voltage (V)" Margin="4"/>
-        <TextBox Grid.Row="8" Grid.Column="1" Margin="4" Text="{Binding DischargeCutoffVoltage, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Grid.Row="7" Text="Discharge Current (A)" Margin="4"/>
+        <TextBox Grid.Row="7" Grid.Column="1" Margin="4" Text="{Binding DischargeCurrent, UpdateSourceTrigger=PropertyChanged}"/>
+
+        <Border Grid.Row="8" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+
+        <TextBlock Grid.Row="9" Text="Cutoff Voltage (V)" Margin="4"/>
+        <TextBox Grid.Row="9" Grid.Column="1" Margin="4" Text="{Binding DischargeCutoffVoltage, UpdateSourceTrigger=PropertyChanged}"/>
 
 
 
-        <Border Grid.Row="9" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+        <Border Grid.Row="10" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="10" Text="Capacity (mAh)" Margin="4">
+        <TextBlock Grid.Row="11" Text="Capacity (mAh)" Margin="4">
             <TextBlock.Style>
                 <Style TargetType="TextBlock">
                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -66,7 +68,7 @@
                 </Style>
             </TextBlock.Style>
         </TextBlock>
-        <TextBox Grid.Row="10" Grid.Column="1" Margin="4" Text="{Binding DischargeCapacityMah, UpdateSourceTrigger=PropertyChanged}">
+        <TextBox Grid.Row="11" Grid.Column="1" Margin="4" Text="{Binding DischargeCapacityMah, UpdateSourceTrigger=PropertyChanged}">
             <TextBox.Style>
                 <Style TargetType="TextBox">
                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -78,7 +80,7 @@
                 </Style>
             </TextBox.Style>
         </TextBox>
-        <Border Grid.Row="11" Grid.ColumnSpan="2" Margin="0,4">
+        <Border Grid.Row="12" Grid.ColumnSpan="2" Margin="0,4">
             <Border.Style>
                 <Style TargetType="Border" BasedOn="{StaticResource HDivider}">
                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -91,7 +93,7 @@
             </Border.Style>
         </Border>
 
-        <TextBlock Grid.Row="12" Text="Discharge Time" Margin="4">
+        <TextBlock Grid.Row="13" Text="Discharge Time" Margin="4">
             <TextBlock.Style>
                 <Style TargetType="TextBlock">
                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -103,7 +105,7 @@
                 </Style>
             </TextBlock.Style>
         </TextBlock>
-        <StackPanel Grid.Row="12" Grid.Column="1" Orientation="Horizontal" Margin="4">
+        <StackPanel Grid.Row="13" Grid.Column="1" Orientation="Horizontal" Margin="4">
             <StackPanel.Style>
                 <Style TargetType="StackPanel">
                     <Setter Property="Visibility" Value="Collapsed"/>

--- a/CellManager/CellManager/Views/TestSetup/EcmProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/EcmProfileDetailView.xaml
@@ -7,6 +7,7 @@
     <Grid Margin="8">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="20"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -24,24 +25,25 @@
         </Grid.ColumnDefinitions>
 
         <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Text="ECM Pulse Profile" Margin="4" VerticalAlignment="Center" FontSize="20"/>
+        <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding DisplayId, StringFormat=ID: {0}}" Margin="4"/>
 
-        <TextBlock Grid.Row="2" Text="Name" Margin="4"/>
-        <TextBox Grid.Row="2" Grid.Column="1" Margin="4" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
-        <Border Grid.Row="3" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+        <TextBlock Grid.Row="3" Text="Name" Margin="4"/>
+        <TextBox Grid.Row="3" Grid.Column="1" Margin="4" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
+        <Border Grid.Row="4" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="4" Text="Pulse Current (A)" Margin="4"/>
-        <TextBox Grid.Row="4" Grid.Column="1" Margin="4" Text="{Binding PulseCurrent, UpdateSourceTrigger=PropertyChanged}"/>
-        <Border Grid.Row="5" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+        <TextBlock Grid.Row="5" Text="Pulse Current (A)" Margin="4"/>
+        <TextBox Grid.Row="5" Grid.Column="1" Margin="4" Text="{Binding PulseCurrent, UpdateSourceTrigger=PropertyChanged}"/>
+        <Border Grid.Row="6" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="6" Text="Pulse Duration (ms)" Margin="4"/>
-        <TextBox Grid.Row="6" Grid.Column="1" Margin="4" Text="{Binding PulseDuration, UpdateSourceTrigger=PropertyChanged}"/>
-        <Border Grid.Row="7" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+        <TextBlock Grid.Row="7" Text="Pulse Duration (ms)" Margin="4"/>
+        <TextBox Grid.Row="7" Grid.Column="1" Margin="4" Text="{Binding PulseDuration, UpdateSourceTrigger=PropertyChanged}"/>
+        <Border Grid.Row="8" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="8" Text="Reset Time After Pulse (ms)" Margin="4"/>
-        <TextBox Grid.Row="8" Grid.Column="1" Margin="4" Text="{Binding ResetTimeAfterPulse, UpdateSourceTrigger=PropertyChanged}"/>
-        <Border Grid.Row="9" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+        <TextBlock Grid.Row="9" Text="Reset Time After Pulse (ms)" Margin="4"/>
+        <TextBox Grid.Row="9" Grid.Column="1" Margin="4" Text="{Binding ResetTimeAfterPulse, UpdateSourceTrigger=PropertyChanged}"/>
+        <Border Grid.Row="10" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="10" Text="Sampling Rate (ms)" Margin="4"/>
-        <TextBox Grid.Row="10" Grid.Column="1" Margin="4" Text="{Binding SamplingRateMs, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Grid.Row="11" Text="Sampling Rate (ms)" Margin="4"/>
+        <TextBox Grid.Row="11" Grid.Column="1" Margin="4" Text="{Binding SamplingRateMs, UpdateSourceTrigger=PropertyChanged}"/>
     </Grid>
 </UserControl>

--- a/CellManager/CellManager/Views/TestSetup/OcvProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/OcvProfileDetailView.xaml
@@ -7,6 +7,7 @@
     <Grid Margin="8">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="20"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -26,28 +27,29 @@
         </Grid.ColumnDefinitions>
 
         <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Text="OCV Profile" Margin="4" VerticalAlignment="Center" FontSize="20"/>
+        <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding DisplayId, StringFormat=ID: {0}}" Margin="4"/>
 
-        <TextBlock Grid.Row="2" Text="Name" Margin="4"/>
-        <TextBox Grid.Row="2" Grid.Column="1" Margin="4" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
-        <Border Grid.Row="3" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+        <TextBlock Grid.Row="3" Text="Name" Margin="4"/>
+        <TextBox Grid.Row="3" Grid.Column="1" Margin="4" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
+        <Border Grid.Row="4" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="4" Text="Qmax" Margin="4"/>
-        <TextBox Grid.Row="4" Grid.Column="1" Margin="4" Text="{Binding Qmax, UpdateSourceTrigger=PropertyChanged}"/>
-        <Border Grid.Row="5" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+        <TextBlock Grid.Row="5" Text="Qmax" Margin="4"/>
+        <TextBox Grid.Row="5" Grid.Column="1" Margin="4" Text="{Binding Qmax, UpdateSourceTrigger=PropertyChanged}"/>
+        <Border Grid.Row="6" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="6" Text="SOC Step (%)" Margin="4"/>
-        <TextBox Grid.Row="6" Grid.Column="1" Margin="4" Text="{Binding SocStepPercent, UpdateSourceTrigger=PropertyChanged}"/>
-        <Border Grid.Row="7" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+        <TextBlock Grid.Row="7" Text="SOC Step (%)" Margin="4"/>
+        <TextBox Grid.Row="7" Grid.Column="1" Margin="4" Text="{Binding SocStepPercent, UpdateSourceTrigger=PropertyChanged}"/>
+        <Border Grid.Row="8" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="8" Text="Discharge Current (A)" Margin="4"/>
-        <TextBox Grid.Row="8" Grid.Column="1" Margin="4" Text="{Binding DischargeCurrent_OCV, UpdateSourceTrigger=PropertyChanged}"/>
-        <Border Grid.Row="9" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+        <TextBlock Grid.Row="9" Text="Discharge Current (A)" Margin="4"/>
+        <TextBox Grid.Row="9" Grid.Column="1" Margin="4" Text="{Binding DischargeCurrent_OCV, UpdateSourceTrigger=PropertyChanged}"/>
+        <Border Grid.Row="10" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="10" Text="Rest Time (s)" Margin="4"/>
-        <TextBox Grid.Row="10" Grid.Column="1" Margin="4" Text="{Binding RestTime_OCV, UpdateSourceTrigger=PropertyChanged}"/>
-        <Border Grid.Row="11" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+        <TextBlock Grid.Row="11" Text="Rest Time (s)" Margin="4"/>
+        <TextBox Grid.Row="11" Grid.Column="1" Margin="4" Text="{Binding RestTime_OCV, UpdateSourceTrigger=PropertyChanged}"/>
+        <Border Grid.Row="12" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="12" Text="Cutoff Voltage (V)" Margin="4"/>
-        <TextBox Grid.Row="12" Grid.Column="1" Margin="4" Text="{Binding DischargeCutoffVoltage_OCV, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Grid.Row="13" Text="Cutoff Voltage (V)" Margin="4"/>
+        <TextBox Grid.Row="13" Grid.Column="1" Margin="4" Text="{Binding DischargeCutoffVoltage_OCV, UpdateSourceTrigger=PropertyChanged}"/>
     </Grid>
 </UserControl>

--- a/CellManager/CellManager/Views/TestSetup/RestProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/RestProfileDetailView.xaml
@@ -7,6 +7,7 @@
     <Grid Margin="8">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="20"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -18,12 +19,13 @@
         </Grid.ColumnDefinitions>
 
         <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Text="Rest Profile" Margin="4" VerticalAlignment="Center" FontSize="20"/>
+        <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding DisplayId, StringFormat=ID: {0}}" Margin="4"/>
 
-        <TextBlock Grid.Row="2" Text="Name" Margin="4"/>
-        <TextBox Grid.Row="2" Grid.Column="1" Margin="4" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
-        <Border Grid.Row="3" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
+        <TextBlock Grid.Row="3" Text="Name" Margin="4"/>
+        <TextBox Grid.Row="3" Grid.Column="1" Margin="4" Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"/>
+        <Border Grid.Row="4" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
-        <TextBlock Grid.Row="4" Text="Rest Time (s)" Margin="4"/>
-        <TextBox Grid.Row="4" Grid.Column="1" Margin="4" Text="{Binding RestTime, UpdateSourceTrigger=PropertyChanged}"/>
+        <TextBlock Grid.Row="5" Text="Rest Time (s)" Margin="4"/>
+        <TextBox Grid.Row="5" Grid.Column="1" Margin="4" Text="{Binding RestTime, UpdateSourceTrigger=PropertyChanged}"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- display profile IDs when creating or editing in test setup
- compute next profile ID using `ProfileIdProvider`
- add `DisplayId` to profile models

## Testing
- `dotnet test CellManager/CellManager.sln` *(fails: missing Microsoft.NET.Sdk.WindowsDesktop but tests still executed)*

------
https://chatgpt.com/codex/tasks/task_e_68be6e3fabd0832384824643f6fc9894