### PR TITLE
Show cell details in delete confirmation

### DIFF
--- a/CellManager/CellManager/ViewModels/CellLibraryViewModel.cs
+++ b/CellManager/CellManager/ViewModels/CellLibraryViewModel.cs
@@ -194,7 +194,11 @@ namespace CellManager.ViewModels
         {
             if (cell == null || cell.Id <= 0) return;
 
-            var view = new DeleteConfirmationView { Owner = Application.Current.MainWindow };
+            var view = new DeleteConfirmationView
+            {
+                Owner = Application.Current.MainWindow,
+                DataContext = cell
+            };
             var result = view.ShowDialog();
 
             if (result == true)

--- a/CellManager/CellManager/Views/CellLibary/DeleteConfirmationView.xaml
+++ b/CellManager/CellManager/Views/CellLibary/DeleteConfirmationView.xaml
@@ -12,12 +12,24 @@
     <materialDesign:Card Margin="16">
         <StackPanel Margin="8">
             <TextBlock Text="Are you sure you want to delete the selected cell?"
-                       TextWrapping="Wrap"
-                       Margin="0,0,0,16"/>
+                       TextWrapping="Wrap"/>
+            <TextBlock Text="{Binding DisplayNameAndId}"
+                       FontWeight="Bold"
+                       Margin="0,8,0,16"/>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button Content="Cancel" Width="80" Margin="0,0,8,0" IsCancel="True"/>
-                <Button Content="Delete" Width="80" Style="{StaticResource PrimaryActionButton}"
-                        Click="Delete_Click" IsDefault="True"/>
+                <Button Margin="0,0,8,0" IsCancel="True">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <materialDesign:PackIcon Kind="Cancel" Width="18" Height="18"/>
+                        <TextBlock Text=" Cancel"/>
+                    </StackPanel>
+                </Button>
+                <Button Style="{StaticResource PrimaryActionButton}"
+                        Click="Delete_Click" IsDefault="True">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <materialDesign:PackIcon Kind="Delete" Width="18" Height="18"/>
+                        <TextBlock Text=" Delete"/>
+                    </StackPanel>
+                </Button>
             </StackPanel>
         </StackPanel>
     </materialDesign:Card>


### PR DESCRIPTION
## Summary
- Display ID and name of the cell being deleted in the confirmation dialog
- Add matching icons to Delete and Cancel buttons
- Pass selected cell to the dialog via DataContext

## Testing
- `dotnet test CellManager/CellManager.sln`

------
https://chatgpt.com/codex/tasks/task_e_68be70f2afa4832384986d56f935e37a