### PR TITLE
Introduce TimeSpanEditor control and use in profile detail views

### DIFF
--- a/CellManager/CellManager/CellManager.csproj
+++ b/CellManager/CellManager/CellManager.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
     <PackageReference Include="SQLite" Version="3.13.0" />
     <PackageReference Include="System.Data.SQLite" Version="2.0.1" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/CellManager/CellManager/Views/Controls/TimeSpanEditor.xaml
+++ b/CellManager/CellManager/Views/Controls/TimeSpanEditor.xaml
@@ -1,0 +1,13 @@
+<UserControl x:Class="CellManager.Views.Controls.TimeSpanEditor"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+             x:Name="root">
+    <StackPanel Orientation="Horizontal">
+        <xctk:IntegerUpDown Width="40" Value="{Binding Hours, ElementName=root, Mode=TwoWay}" Minimum="0"/>
+        <TextBlock Text=":" VerticalAlignment="Center" Margin="2,0"/>
+        <xctk:IntegerUpDown Width="40" Value="{Binding Minutes, ElementName=root, Mode=TwoWay}" Minimum="0" Maximum="59"/>
+        <TextBlock Text=":" VerticalAlignment="Center" Margin="2,0"/>
+        <xctk:IntegerUpDown Width="40" Value="{Binding Seconds, ElementName=root, Mode=TwoWay}" Minimum="0" Maximum="59"/>
+    </StackPanel>
+</UserControl>

--- a/CellManager/CellManager/Views/Controls/TimeSpanEditor.xaml.cs
+++ b/CellManager/CellManager/Views/Controls/TimeSpanEditor.xaml.cs
@@ -1,0 +1,52 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace CellManager.Views.Controls
+{
+    public partial class TimeSpanEditor : UserControl
+    {
+        public TimeSpanEditor()
+        {
+            InitializeComponent();
+        }
+
+        public int Hours
+        {
+            get => (int)GetValue(HoursProperty);
+            set => SetValue(HoursProperty, value);
+        }
+
+        public static readonly DependencyProperty HoursProperty =
+            DependencyProperty.Register(
+                nameof(Hours),
+                typeof(int),
+                typeof(TimeSpanEditor),
+                new FrameworkPropertyMetadata(0, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+
+        public int Minutes
+        {
+            get => (int)GetValue(MinutesProperty);
+            set => SetValue(MinutesProperty, value);
+        }
+
+        public static readonly DependencyProperty MinutesProperty =
+            DependencyProperty.Register(
+                nameof(Minutes),
+                typeof(int),
+                typeof(TimeSpanEditor),
+                new FrameworkPropertyMetadata(0, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+
+        public int Seconds
+        {
+            get => (int)GetValue(SecondsProperty);
+            set => SetValue(SecondsProperty, value);
+        }
+
+        public static readonly DependencyProperty SecondsProperty =
+            DependencyProperty.Register(
+                nameof(Seconds),
+                typeof(int),
+                typeof(TimeSpanEditor),
+                new FrameworkPropertyMetadata(0, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+    }
+}

--- a/CellManager/CellManager/Views/TestSetup/ChargeProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/ChargeProfileDetailView.xaml
@@ -4,6 +4,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:tp="clr-namespace:CellManager.Models.TestProfile"
+             xmlns:controls="clr-namespace:CellManager.Views.Controls"
              mc:Ignorable="d" d:DesignHeight="200" d:DesignWidth="400">
     <Grid Margin="8">
         <Grid.RowDefinitions>
@@ -91,13 +92,10 @@
         </Border>
 
         <TextBlock Grid.Row="15" Text="Charge Time" Margin="4" Style="{StaticResource TimeVisibilityStyle}"/>
-        <StackPanel Grid.Row="15" Grid.Column="1" Orientation="Horizontal" Margin="4" Style="{StaticResource TimeVisibilityStyle}">
-            <TextBox Width="40" Text="{Binding ChargeHours, UpdateSourceTrigger=PropertyChanged}"/>
-            <TextBlock Text=":" Margin="2" VerticalAlignment="Center"/>
-            <TextBox Width="40" Text="{Binding ChargeMinutes, UpdateSourceTrigger=PropertyChanged}"/>
-            <TextBlock Text=":" Margin="2" VerticalAlignment="Center"/>
-            <TextBox Width="40" Text="{Binding ChargeSeconds, UpdateSourceTrigger=PropertyChanged}"/>
-        </StackPanel>
+        <controls:TimeSpanEditor Grid.Row="15" Grid.Column="1" Margin="4" Style="{StaticResource TimeVisibilityStyle}"
+                                 Hours="{Binding ChargeHours, UpdateSourceTrigger=PropertyChanged}"
+                                 Minutes="{Binding ChargeMinutes, UpdateSourceTrigger=PropertyChanged}"
+                                 Seconds="{Binding ChargeSeconds, UpdateSourceTrigger=PropertyChanged}"/>
     </Grid>
 </UserControl>
 

--- a/CellManager/CellManager/Views/TestSetup/DischargeProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/DischargeProfileDetailView.xaml
@@ -4,6 +4,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:tp="clr-namespace:CellManager.Models.TestProfile"
+             xmlns:controls="clr-namespace:CellManager.Views.Controls"
              mc:Ignorable="d" d:DesignHeight="200" d:DesignWidth="400">
 
     <Grid Margin="8">
@@ -105,9 +106,12 @@
                 </Style>
             </TextBlock.Style>
         </TextBlock>
-        <StackPanel Grid.Row="13" Grid.Column="1" Orientation="Horizontal" Margin="4">
-            <StackPanel.Style>
-                <Style TargetType="StackPanel">
+        <controls:TimeSpanEditor Grid.Row="13" Grid.Column="1" Margin="4"
+                                 Hours="{Binding DischargeHours, UpdateSourceTrigger=PropertyChanged}"
+                                 Minutes="{Binding DischargeMinutes, UpdateSourceTrigger=PropertyChanged}"
+                                 Seconds="{Binding DischargeSeconds, UpdateSourceTrigger=PropertyChanged}">
+            <controls:TimeSpanEditor.Style>
+                <Style TargetType="controls:TimeSpanEditor">
                     <Setter Property="Visibility" Value="Collapsed"/>
                     <Style.Triggers>
                         <DataTrigger Binding="{Binding DischargeMode}" Value="{x:Static tp:DischargeMode.DischargeByTime}">
@@ -115,12 +119,7 @@
                         </DataTrigger>
                     </Style.Triggers>
                 </Style>
-            </StackPanel.Style>
-            <TextBox Width="40" Text="{Binding DischargeHours, UpdateSourceTrigger=PropertyChanged}"/>
-            <TextBlock Text=":" VerticalAlignment="Center" Margin="2,0"/>
-            <TextBox Width="40" Text="{Binding DischargeMinutes, UpdateSourceTrigger=PropertyChanged}"/>
-            <TextBlock Text=":" VerticalAlignment="Center" Margin="2,0"/>
-            <TextBox Width="40" Text="{Binding DischargeSeconds, UpdateSourceTrigger=PropertyChanged}"/>
-        </StackPanel>
+            </controls:TimeSpanEditor.Style>
+        </controls:TimeSpanEditor>
     </Grid>
 </UserControl>

--- a/CellManager/CellManager/Views/TestSetup/RestProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/RestProfileDetailView.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:CellManager.Views.Controls"
              mc:Ignorable="d" d:DesignHeight="200" d:DesignWidth="400">
     <Grid Margin="8">
         <Grid.RowDefinitions>
@@ -26,12 +27,9 @@
         <Border Grid.Row="4" Grid.ColumnSpan="2" Style="{StaticResource HDivider}" Margin="0,4"/>
 
         <TextBlock Grid.Row="5" Text="Rest Time" Margin="4"/>
-        <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal" Margin="4">
-            <TextBox Width="40" Text="{Binding RestHours, UpdateSourceTrigger=PropertyChanged}"/>
-            <TextBlock Text=":" Margin="2" VerticalAlignment="Center"/>
-            <TextBox Width="40" Text="{Binding RestMinutes, UpdateSourceTrigger=PropertyChanged}"/>
-            <TextBlock Text=":" Margin="2" VerticalAlignment="Center"/>
-            <TextBox Width="40" Text="{Binding RestSeconds, UpdateSourceTrigger=PropertyChanged}"/>
-        </StackPanel>
+        <controls:TimeSpanEditor Grid.Row="5" Grid.Column="1" Margin="4"
+                                 Hours="{Binding RestHours, UpdateSourceTrigger=PropertyChanged}"
+                                 Minutes="{Binding RestMinutes, UpdateSourceTrigger=PropertyChanged}"
+                                 Seconds="{Binding RestSeconds, UpdateSourceTrigger=PropertyChanged}"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- add reusable `TimeSpanEditor` user control using Xceed's IntegerUpDown inputs
- swap textbox time inputs with new control in charge, discharge, and rest profile detail views
- add Extended.Wpf.Toolkit package reference

## Testing
- `dotnet test CellManager/CellManager.sln`

------
https://chatgpt.com/codex/tasks/task_e_68bf7cbb046c8323a224ffb27e3014f5