### PR TITLE
Allow duplicate profiles in schedule builder

### DIFF
--- a/CellManager/CellManager.Tests/CellManager.Tests.csproj
+++ b/CellManager/CellManager.Tests/CellManager.Tests.csproj
@@ -28,6 +28,18 @@
     <Compile Include="../CellManager/Models/Cell.cs" Link="Models/Cell.cs" />
     <Compile Include="../CellManager/Services/ICellRepository.cs" Link="Services/ICellRepository.cs" />
     <Compile Include="../CellManager/Services/SQLiteCellRepository.cs" Link="Services/SQLiteCellRepository.cs" />
+    <Compile Include="../CellManager/Models/ProfileReference.cs" Link="Models/ProfileReference.cs" />
+    <Compile Include="../CellManager/Models/Schedule.cs" Link="Models/Schedule.cs" />
+    <Compile Include="../CellManager/Models/TestProfile/*.cs" Link="Models/TestProfile/%(Filename)%(Extension)" />
+    <Compile Include="../CellManager/Services/IChargeProfileRepository.cs" Link="Services/IChargeProfileRepository.cs" />
+    <Compile Include="../CellManager/Services/IDischargeProfileRepository.cs" Link="Services/IDischargeProfileRepository.cs" />
+    <Compile Include="../CellManager/Services/IEcmPulseProfileRepository.cs" Link="Services/IEcmPulseProfileRepository.cs" />
+    <Compile Include="../CellManager/Services/IOcvProfileRepository.cs" Link="Services/IOcvProfileRepository.cs" />
+    <Compile Include="../CellManager/Services/IRestProfileRepository.cs" Link="Services/IRestProfileRepository.cs" />
+    <Compile Include="../CellManager/Services/IScheduleRepository.cs" Link="Services/IScheduleRepository.cs" />
+    <Compile Include="../CellManager/Models/ScheduleTimeCalculator.cs" Link="Models/ScheduleTimeCalculator.cs" />
+    <Compile Include="../CellManager/Messages/CellSelectedMessage.cs" Link="Messages/CellSelectedMessage.cs" />
+    <Compile Include="../CellManager/ViewModels/ScheduleViewModel.cs" Link="ViewModels/ScheduleViewModel.cs" />
   </ItemGroup>
 
 </Project>

--- a/CellManager/CellManager.Tests/ScheduleViewModelTests.cs
+++ b/CellManager/CellManager.Tests/ScheduleViewModelTests.cs
@@ -1,0 +1,92 @@
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using Xunit;
+using CellManager.ViewModels;
+using CellManager.Models;
+using CellManager.Models.TestProfile;
+using CellManager.Services;
+
+namespace CellManager.Tests
+{
+    public class ScheduleViewModelTests
+    {
+        private class DummyScheduleRepository : IScheduleRepository
+        {
+            public List<Schedule> GetAll() => new();
+            public Schedule? GetById(int id) => null;
+            public void Save(Schedule schedule) { }
+            public void Delete(int id) { }
+        }
+
+        private class DummyChargeProfileRepository : IChargeProfileRepository
+        {
+            public ObservableCollection<ChargeProfile> Load(int cellId) => new();
+            public void Save(ChargeProfile profile, int cellId) { }
+            public void Delete(ChargeProfile profile) { }
+        }
+
+        private class DummyDischargeProfileRepository : IDischargeProfileRepository
+        {
+            public ObservableCollection<DischargeProfile> Load(int cellId) => new();
+            public void Save(DischargeProfile profile, int cellId) { }
+            public void Delete(DischargeProfile profile) { }
+        }
+
+        private class DummyEcmPulseProfileRepository : IEcmPulseProfileRepository
+        {
+            public ObservableCollection<ECMPulseProfile> Load(int cellId) => new();
+            public void Save(ECMPulseProfile profile, int cellId) { }
+            public void Delete(ECMPulseProfile profile) { }
+        }
+
+        private class DummyOcvProfileRepository : IOcvProfileRepository
+        {
+            public ObservableCollection<OCVProfile> Load(int cellId) => new();
+            public void Save(OCVProfile profile, int cellId) { }
+            public void Delete(OCVProfile profile) { }
+        }
+
+        private class DummyRestProfileRepository : IRestProfileRepository
+        {
+            public ObservableCollection<RestProfile> Load(int cellId) => new();
+            public void Save(RestProfile profile, int cellId) { }
+            public void Delete(RestProfile profile) { }
+        }
+
+        private static ScheduleViewModel CreateViewModel()
+        {
+            return new ScheduleViewModel(
+                new DummyChargeProfileRepository(),
+                new DummyDischargeProfileRepository(),
+                new DummyEcmPulseProfileRepository(),
+                new DummyOcvProfileRepository(),
+                new DummyRestProfileRepository(),
+                new DummyScheduleRepository());
+        }
+
+        [Fact]
+        public void InsertProfile_AllowsDuplicateProfiles()
+        {
+            var vm = CreateViewModel();
+            var profile = new ProfileReference { CellId = 1, Type = TestProfileType.Charge, Id = 1, Name = "P1" };
+            vm.InsertProfile(profile, -1);
+            vm.InsertProfile(profile, -1);
+            Assert.Equal(2, vm.WorkingSchedule.Count);
+        }
+
+        [Fact]
+        public void MoveProfile_ReordersExistingProfile()
+        {
+            var vm = CreateViewModel();
+            var p1 = new ProfileReference { CellId = 1, Type = TestProfileType.Charge, Id = 1, Name = "P1" };
+            var p2 = new ProfileReference { CellId = 1, Type = TestProfileType.Charge, Id = 2, Name = "P2" };
+            vm.InsertProfile(p1, -1);
+            vm.InsertProfile(p2, -1);
+            var first = vm.WorkingSchedule[0];
+            vm.MoveProfile(first, 2);
+            Assert.Equal(p2, vm.WorkingSchedule[0].Reference);
+            Assert.Equal(p1, vm.WorkingSchedule[1].Reference);
+        }
+    }
+}
+

--- a/CellManager/CellManager.Tests/SystemWindowsStubs.cs
+++ b/CellManager/CellManager.Tests/SystemWindowsStubs.cs
@@ -1,0 +1,11 @@
+namespace System.Windows
+{
+    public enum MessageBoxButton { OK }
+    public enum MessageBoxImage { Error }
+    public enum MessageBoxResult { OK }
+    public static class MessageBox
+    {
+        public static MessageBoxResult Show(string text, string caption, MessageBoxButton button, MessageBoxImage icon)
+            => MessageBoxResult.OK;
+    }
+}

--- a/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
+++ b/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
@@ -154,14 +154,6 @@ namespace CellManager.ViewModels
 
         public void InsertProfile(ProfileReference profile, int index)
         {
-            var existing = WorkingSchedule.FirstOrDefault(p => p.Reference.UniqueId == profile.UniqueId);
-            if (existing != null)
-            {
-                var oldIndex = WorkingSchedule.IndexOf(existing);
-                if (oldIndex < index) index--;
-                WorkingSchedule.RemoveAt(oldIndex);
-            }
-
             var item = new ScheduledProfile { Reference = profile };
             if (index < 0 || index > WorkingSchedule.Count)
                 WorkingSchedule.Add(item);
@@ -171,6 +163,17 @@ namespace CellManager.ViewModels
             RecalculateScheduleTimes();
             SaveScheduleCommand.NotifyCanExecuteChanged();
             ClearScheduleCommand.NotifyCanExecuteChanged();
+        }
+
+        public void MoveProfile(ScheduledProfile profile, int index)
+        {
+            var oldIndex = WorkingSchedule.IndexOf(profile);
+            if (oldIndex < 0) return;
+            if (oldIndex < index) index--;
+            if (index < 0) index = 0;
+            if (index >= WorkingSchedule.Count) index = WorkingSchedule.Count - 1;
+            WorkingSchedule.Move(oldIndex, index);
+            RecalculateScheduleTimes();
         }
 
         private void SaveSchedule()

--- a/CellManager/CellManager/Views/ScheduleBuilderView.xaml.cs
+++ b/CellManager/CellManager/Views/ScheduleBuilderView.xaml.cs
@@ -50,7 +50,9 @@ namespace CellManager.Views
             {
                 if (item.DataContext is ScheduledProfile sp)
                 {
-                    var data = new DataObject(typeof(ProfileReference), sp.Reference);
+                    var data = new DataObject();
+                    data.SetData(typeof(ProfileReference), sp.Reference);
+                    data.SetData(typeof(ScheduledProfile), sp);
                     DragDrop.DoDragDrop(list, data, DragDropEffects.Move);
                 }
             }
@@ -72,10 +74,20 @@ namespace CellManager.Views
         {
             if (DataContext is not ScheduleViewModel vm) return;
             if (!e.Data.GetDataPresent(typeof(ProfileReference))) return;
-            var profile = (ProfileReference)e.Data.GetData(typeof(ProfileReference));
             var list = (ItemsControl)sender;
             var index = GetInsertIndex(list, e.GetPosition(list));
-            vm.InsertProfile(profile, index);
+
+            if (e.Data.GetDataPresent(typeof(ScheduledProfile)))
+            {
+                var sp = (ScheduledProfile)e.Data.GetData(typeof(ScheduledProfile));
+                vm.MoveProfile(sp, index);
+            }
+            else
+            {
+                var profile = (ProfileReference)e.Data.GetData(typeof(ProfileReference));
+                vm.InsertProfile(profile, index);
+            }
+
             RemoveInsertionAdorner();
         }
 


### PR DESCRIPTION
## Summary
- allow scheduling the same profile multiple times
- support reordering of scheduled profiles via drag-and-drop
- add tests for inserting and moving scheduled profiles

## Testing
- `dotnet test CellManager.Tests/CellManager.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bf853d7dbc8323b4ac75c461665090