### PR TITLE
Persist schedule saves and reposition save button

### DIFF
--- a/CellManager/CellManager.Tests/ScheduleViewModelTests.cs
+++ b/CellManager/CellManager.Tests/ScheduleViewModelTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Xunit;
 using CellManager.ViewModels;
@@ -65,6 +66,16 @@ namespace CellManager.Tests
             vm.InsertStep(end, -1);
             Assert.Equal(1, vm.LoopStartIndex);
             Assert.Equal(3, vm.LoopEndIndex);
+        }
+
+        [Fact]
+        public void TotalDuration_SumsStepDurations()
+        {
+            var vm = new ScheduleViewModel();
+            var template = vm.StepLibrary.First().Steps.First();
+            vm.InsertStep(template, -1);
+            vm.InsertStep(template, -1);
+            Assert.Equal(TimeSpan.FromHours(2), vm.TotalDuration);
         }
     }
 }

--- a/CellManager/CellManager.Tests/ScheduleViewModelTests.cs
+++ b/CellManager/CellManager.Tests/ScheduleViewModelTests.cs
@@ -77,5 +77,16 @@ namespace CellManager.Tests
             vm.InsertStep(template, -1);
             Assert.Equal(TimeSpan.FromHours(2), vm.TotalDuration);
         }
+
+        [Fact]
+        public void SelectedSchedule_TracksEstimatedDuration()
+        {
+            var vm = new ScheduleViewModel();
+            vm.AddScheduleCommand.Execute(null);
+            var template = vm.StepLibrary.First().Steps.First();
+            vm.InsertStep(template, -1);
+            vm.InsertStep(template, -1);
+            Assert.Equal(TimeSpan.FromHours(2), vm.SelectedSchedule?.EstimatedDuration);
+        }
     }
 }

--- a/CellManager/CellManager.Tests/ScheduleViewModelTests.cs
+++ b/CellManager/CellManager.Tests/ScheduleViewModelTests.cs
@@ -36,6 +36,7 @@ namespace CellManager.Tests
             vm.AddScheduleCommand.Execute(null);
             Assert.Equal(initialCount + 1, vm.Schedules.Count);
             Assert.Equal(vm.SelectedSchedule, vm.Schedules.Last());
+            Assert.Equal(initialCount + 1, vm.SelectedSchedule?.Ordering);
         }
 
         [Fact]

--- a/CellManager/CellManager/Models/Schedule.cs
+++ b/CellManager/CellManager/Models/Schedule.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using System;
 using System.Collections.Generic;
 using System.Xml.Linq;
 
@@ -30,6 +31,9 @@ namespace CellManager.Models
 
         [ObservableProperty]
         private int _loopEndIndex;
+
+        [ObservableProperty]
+        private TimeSpan _estimatedDuration;
 
         public string DisplayNameAndId => $"ID: {Id} - {Name}";
     }

--- a/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
+++ b/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
@@ -229,6 +229,7 @@ namespace CellManager.ViewModels
             });
 
             AddLoopControls();
+            UpdateScheduleDurations();
         }
 
         private void LoadStepLibrary()
@@ -329,6 +330,7 @@ namespace CellManager.ViewModels
 
             if (SelectedSchedule != null)
                 OnSelectedScheduleChanged(SelectedSchedule);
+            UpdateScheduleDurations();
         }
 
         private void AddLoopControls()
@@ -369,6 +371,8 @@ namespace CellManager.ViewModels
         private void UpdateTotalDuration()
         {
             TotalDuration = new TimeSpan(Sequence.Sum(s => s.Duration.Ticks));
+            if (SelectedSchedule != null)
+                SelectedSchedule.EstimatedDuration = TotalDuration;
             UpdateLoopIndices();
         }
 
@@ -376,6 +380,18 @@ namespace CellManager.ViewModels
         {
             for (int i = 0; i < Sequence.Count; i++)
                 Sequence[i].StepNumber = i + 1;
+        }
+
+        private void UpdateScheduleDurations()
+        {
+            foreach (var sched in Schedules)
+            {
+                var ticks = sched.TestProfileIds
+                    .Select(id => StepLibrary.SelectMany(g => g.Steps)
+                        .FirstOrDefault(s => s.Id == id)?.Duration.Ticks ?? 0)
+                    .Sum();
+                sched.EstimatedDuration = new TimeSpan(ticks);
+            }
         }
 
         private void UpdateLoopIndices()

--- a/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
+++ b/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
@@ -136,8 +136,8 @@ namespace CellManager.ViewModels
 
         private void BuildMockSchedules()
         {
-            Schedules.Add(new Schedule { Id = 1, Name = "Schedule A", TestProfileIds = { 1, 2 } });
-            Schedules.Add(new Schedule { Id = 2, Name = "Schedule B", TestProfileIds = { 3 } });
+            Schedules.Add(new Schedule { Id = 1, Ordering = 1, Name = "Schedule A", TestProfileIds = { 1, 2 } });
+            Schedules.Add(new Schedule { Id = 2, Ordering = 2, Name = "Schedule B", TestProfileIds = { 3 } });
         }
 
         private void BuildMockLibrary()
@@ -229,7 +229,6 @@ namespace CellManager.ViewModels
             });
 
             AddLoopControls();
-            BuildMockSchedules();
         }
 
         private void LoadStepLibrary()
@@ -409,7 +408,8 @@ namespace CellManager.ViewModels
         private void AddSchedule()
         {
             var newId = Schedules.Any() ? Schedules.Max(s => s.Id) + 1 : 1;
-            var sched = new Schedule { Id = newId, Name = $"Schedule {newId}" };
+            var newOrdering = Schedules.Any() ? Schedules.Max(s => s.Ordering) + 1 : 1;
+            var sched = new Schedule { Id = newId, Ordering = newOrdering, Name = $"Schedule {newId}" };
             Schedules.Add(sched);
             SelectedSchedule = sched;
             Sequence.Clear();

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -80,6 +80,13 @@
                             <GridViewColumn Header="Script #" DisplayMemberBinding="{Binding Ordering}" Width="80"/>
                             <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Name}" Width="150"/>
                             <GridViewColumn Header="Profiles" DisplayMemberBinding="{Binding TestProfileIds.Count}" Width="60"/>
+                            <GridViewColumn Header="Duration" Width="90">
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding EstimatedDuration, StringFormat='{}{0:hh\\:mm\\:ss}'}"/>
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
                         </GridView>
                     </ListView.View>
                 </ListView>

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -34,6 +34,7 @@
                         </Style>
                     </TextBlock.Style>
                 </TextBlock>
+                <TextBlock Text="{Binding Duration, StringFormat='{}{0:hh\\:mm\\:ss}'}" Margin="8,0,0,0" VerticalAlignment="Center"/>
             </StackPanel>
         </DataTemplate>
     </UserControl.Resources>
@@ -92,9 +93,10 @@
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
 
-                <!-- Schedule name and save button -->
+                <!-- Schedule name, save button and total duration -->
                 <Grid Grid.Row="0" Margin="0,0,0,8">
                     <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
@@ -102,6 +104,8 @@
                              Text="{Binding ScheduleName}" materialDesign:HintAssist.Hint="Schedule Name"/>
                     <Button Grid.Column="1" Content="Save Schedule" Command="{Binding SaveScheduleCommand}"
                             Margin="8,0,0,0" Style="{StaticResource MaterialDesignRaisedButton}"/>
+                    <TextBlock Grid.Column="2" Text="{Binding TotalDuration, StringFormat='Total: {0:hh\\:mm\\:ss}'}"
+                               Margin="16,0,0,0" VerticalAlignment="Center"/>
                 </Grid>
 
                 <!-- Timeline preview -->
@@ -159,6 +163,7 @@
                                         <ColumnDefinition Width="Auto"/>
                                         <ColumnDefinition Width="*"/>
                                         <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="Auto"/>
                                     </Grid.ColumnDefinitions>
                                     <TextBlock Text="{Binding StepNumber}" FontWeight="Bold" Margin="0,0,8,0"/>
                                     <materialDesign:PackIcon Grid.Column="1" Kind="{Binding IconKind}" Width="24" Height="24" Margin="0,0,8,0"/>
@@ -201,7 +206,8 @@
                                             </TextBlock.Style>
                                         </TextBlock>
                                     </StackPanel>
-                                    <Button Grid.Column="3" Style="{StaticResource MaterialDesignToolButton}"
+                                    <TextBlock Grid.Column="3" Text="{Binding Duration, StringFormat='{}{0:hh\\:mm\\:ss}'}" Margin="8,0" VerticalAlignment="Center"/>
+                                    <Button Grid.Column="4" Style="{StaticResource MaterialDesignToolButton}"
                                             Command="{Binding DataContext.RemoveStepCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
                                             CommandParameter="{Binding}">
                                         <materialDesign:PackIcon Kind="Close" Width="16" Height="16"/>

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -76,6 +76,7 @@
                 <ListView ItemsSource="{Binding Schedules}" SelectedItem="{Binding SelectedSchedule}" HorizontalAlignment="Stretch">
                     <ListView.View>
                         <GridView>
+                            <GridViewColumn Header="Script #" DisplayMemberBinding="{Binding Ordering}" Width="80"/>
                             <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Name}" Width="150"/>
                             <GridViewColumn Header="Profiles" DisplayMemberBinding="{Binding TestProfileIds.Count}" Width="60"/>
                         </GridView>
@@ -212,38 +213,22 @@
                 </ListBox>
             </Grid>
 
-            <!-- Step library and options -->
-            <Grid Grid.Column="2" Margin="8">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="*"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-
-                <GroupBox Grid.Row="0" Header="Step Library" Margin="0,0,0,8">
-                    <ScrollViewer VerticalScrollBarVisibility="Auto">
-                        <ItemsControl ItemsSource="{Binding StepLibrary}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <Expander Header="{Binding Name}" Margin="0,0,0,4" IsExpanded="True">
-                                        <ItemsControl ItemsSource="{Binding Steps}" ItemTemplate="{StaticResource StepTemplateItem}"
-                                                      PreviewMouseLeftButtonDown="ProfileList_PreviewMouseLeftButtonDown"
-                                                      PreviewMouseMove="ProfileList_PreviewMouseMove"/>
-                                    </Expander>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </ScrollViewer>
-                </GroupBox>
-
-                <GroupBox Grid.Row="1" Header="Schedule Options">
-                    <StackPanel Margin="8">
-                        <TextBox Margin="0,0,0,8" Style="{StaticResource MaterialDesignFilledTextBox}"
-                                 Text="{Binding RepeatCount}" materialDesign:HintAssist.Hint="Repeat Count"/>
-                        <TextBlock Text="{Binding LoopStartIndex, StringFormat=Loop Start: {0}}" Margin="0,0,0,4"/>
-                        <TextBlock Text="{Binding LoopEndIndex, StringFormat=Loop End: {0}}"/>
-                    </StackPanel>
-                </GroupBox>
-            </Grid>
+            <!-- Step library -->
+            <GroupBox Grid.Column="2" Margin="8" Header="Step Library">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <ItemsControl ItemsSource="{Binding StepLibrary}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Expander Header="{Binding Name}" Margin="0,0,0,4" IsExpanded="True">
+                                    <ItemsControl ItemsSource="{Binding Steps}" ItemTemplate="{StaticResource StepTemplateItem}"
+                                                  PreviewMouseLeftButtonDown="ProfileList_PreviewMouseLeftButtonDown"
+                                                  PreviewMouseMove="ProfileList_PreviewMouseMove"/>
+                                </Expander>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+            </GroupBox>
         </Grid>
 
     </Grid>

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -42,7 +42,6 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <!-- Cell info status bar -->
@@ -92,9 +91,17 @@
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
 
-                <!-- Schedule name -->
-                <TextBox Grid.Row="0" Width="250" Margin="0,0,0,8" Style="{StaticResource MaterialDesignFilledTextBox}"
-                         Text="{Binding ScheduleName}" materialDesign:HintAssist.Hint="Schedule Name"/>
+                <!-- Schedule name and save button -->
+                <Grid Grid.Row="0" Margin="0,0,0,8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBox Width="250" Style="{StaticResource MaterialDesignFilledTextBox}"
+                             Text="{Binding ScheduleName}" materialDesign:HintAssist.Hint="Schedule Name"/>
+                    <Button Grid.Column="1" Content="Save Schedule" Command="{Binding SaveScheduleCommand}"
+                            Margin="8,0,0,0" Style="{StaticResource MaterialDesignRaisedButton}"/>
+                </Grid>
 
                 <!-- Timeline preview -->
                 <ItemsControl x:Name="TimelinePreview" Grid.Row="1" ItemsSource="{Binding Sequence}" Margin="0,0,0,8"
@@ -239,9 +246,5 @@
             </Grid>
         </Grid>
 
-        <!-- Bottom buttons -->
-        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="8">
-            <Button Content="Save Schedule" Command="{Binding SaveScheduleCommand}" Margin="4" Style="{StaticResource MaterialDesignRaisedButton}"/>
-        </StackPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- persist schedule data by injecting `IScheduleRepository` and saving via `SaveSchedule`
- load schedules from the repository instead of mock data
- move "Save Schedule" button beside the schedule name field

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bfec82b378832384efb4afdbe94ee8