### PR TITLE
Flatten test setup profile list styling

### DIFF
--- a/CellManager/CellManager/App.xaml
+++ b/CellManager/CellManager/App.xaml
@@ -339,6 +339,23 @@
                     </Setter.Value>
                 </Setter>
             </Style>
+
+            <!-- Flat ListBox for profile lists inside GroupBoxes -->
+            <Style x:Key="ProfileListBox" TargetType="ListBox" BasedOn="{StaticResource DenseListBox}">
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="BorderBrush" Value="Transparent"/>
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="Margin" Value="0"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ListBox">
+                            <ScrollViewer Focusable="False" Padding="{TemplateBinding Padding}">
+                                <ItemsPresenter/>
+                            </ScrollViewer>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
             <Style x:Key="PrimaryActionButton"
        TargetType="Button"
        BasedOn="{StaticResource MaterialDesignRaisedButton}">

--- a/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
@@ -37,7 +37,7 @@
                                 </StackPanel>
                                 </Button>
                             </WrapPanel>
-                            <ListBox Style="{StaticResource DenseListBox}"
+                            <ListBox Style="{StaticResource ProfileListBox}"
                                      ItemsSource="{Binding ChargeProfiles}"
                                      SelectedItem="{Binding SelectedChargeProfile, Mode=TwoWay}">
                                 <ListBox.ItemTemplate>
@@ -84,7 +84,7 @@
                                 </StackPanel>
                                 </Button>
                             </WrapPanel>
-                            <ListBox Style="{StaticResource DenseListBox}"
+                            <ListBox Style="{StaticResource ProfileListBox}"
                                      ItemsSource="{Binding DischargeProfiles}"
                                      SelectedItem="{Binding SelectedDischargeProfile, Mode=TwoWay}">
                                 <ListBox.ItemTemplate>
@@ -131,7 +131,7 @@
                                 </StackPanel>
                                 </Button>
                             </WrapPanel>
-                            <ListBox Style="{StaticResource DenseListBox}"
+                            <ListBox Style="{StaticResource ProfileListBox}"
                                      ItemsSource="{Binding RestProfiles}"
                                      SelectedItem="{Binding SelectedRestProfile, Mode=TwoWay}">
                                 <ListBox.ItemTemplate>
@@ -182,7 +182,7 @@
                                 </StackPanel>
                                 </Button>
                             </WrapPanel>
-                            <ListBox Style="{StaticResource DenseListBox}"
+                            <ListBox Style="{StaticResource ProfileListBox}"
                                      ItemsSource="{Binding OcvProfiles}"
                                      SelectedItem="{Binding SelectedOcvProfile, Mode=TwoWay}">
                                 <ListBox.ItemTemplate>
@@ -229,7 +229,7 @@
                                 </StackPanel>
                                 </Button>
                             </WrapPanel>
-                            <ListBox Style="{StaticResource DenseListBox}"
+                            <ListBox Style="{StaticResource ProfileListBox}"
                                      ItemsSource="{Binding EcmPulseProfiles}"
                                      SelectedItem="{Binding SelectedEcmPulseProfile, Mode=TwoWay}">
                                 <ListBox.ItemTemplate>


### PR DESCRIPTION
## Summary
- add ProfileListBox style to remove card borders and corner radius from inner lists
- apply new style to all profile lists in TestSetupView

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bff77ffc788323ab84f7d7bfa82b92