### PR TITLE
Add context menu for schedule list management

### DIFF
--- a/CellManager/CellManager.Tests/ScheduleViewModelTests.cs
+++ b/CellManager/CellManager.Tests/ScheduleViewModelTests.cs
@@ -59,7 +59,7 @@ namespace CellManager.Tests
             var vm = new ScheduleViewModel();
             vm.AddScheduleCommand.Execute(null);
             var target = vm.SelectedSchedule;
-            vm.DeleteScheduleCommand.Execute(null);
+            vm.DeleteScheduleCommand.Execute(vm.SelectedSchedule);
             Assert.DoesNotContain(target, vm.Schedules);
         }
 

--- a/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
+++ b/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
@@ -73,7 +73,7 @@ namespace CellManager.ViewModels
         public RelayCommand<StepTemplate> RemoveStepCommand { get; }
         public RelayCommand SaveScheduleCommand { get; }
         public RelayCommand AddScheduleCommand { get; }
-        public RelayCommand DeleteScheduleCommand { get; }
+        public RelayCommand<Schedule> DeleteScheduleCommand { get; }
 
         public ScheduleViewModel() : this(null, null, null, null, null, null) { }
 
@@ -101,7 +101,7 @@ namespace CellManager.ViewModels
             RemoveStepCommand = new RelayCommand<StepTemplate>(s => Sequence.Remove(s));
             SaveScheduleCommand = new RelayCommand(SaveSchedule);
             AddScheduleCommand = new RelayCommand(AddSchedule);
-            DeleteScheduleCommand = new RelayCommand(DeleteSchedule, () => SelectedSchedule != null);
+            DeleteScheduleCommand = new RelayCommand<Schedule>(DeleteSchedule, s => s != null);
 
             if (_scheduleRepo != null)
             {
@@ -448,12 +448,13 @@ namespace CellManager.ViewModels
             _scheduleRepo?.Save(SelectedSchedule);
         }
 
-        private void DeleteSchedule()
+        private void DeleteSchedule(Schedule? schedule)
         {
-            if (SelectedSchedule == null) return;
-            _scheduleRepo?.Delete(SelectedSchedule.Id);
-            var index = Schedules.IndexOf(SelectedSchedule);
-            Schedules.Remove(SelectedSchedule);
+            var target = schedule ?? SelectedSchedule;
+            if (target == null) return;
+            _scheduleRepo?.Delete(target.Id);
+            var index = Schedules.IndexOf(target);
+            Schedules.Remove(target);
             SelectedSchedule = index < Schedules.Count ? Schedules[index] : Schedules.FirstOrDefault();
         }
     }

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -66,11 +66,38 @@
                         <Button Command="{Binding AddScheduleCommand}" Style="{StaticResource MaterialDesignToolButton}">
                             <materialDesign:PackIcon Kind="Plus" Width="16" Height="16"/>
                         </Button>
-                        <Button Command="{Binding DeleteScheduleCommand}" Style="{StaticResource MaterialDesignToolButton}">
+                        <Button Command="{Binding DeleteScheduleCommand}" CommandParameter="{Binding SelectedSchedule}" Style="{StaticResource MaterialDesignToolButton}">
                             <materialDesign:PackIcon Kind="Delete" Width="16" Height="16"/>
                         </Button>
                     </StackPanel>
                     <ListView DockPanel.Dock="Bottom" ItemsSource="{Binding Schedules}" SelectedItem="{Binding SelectedSchedule}" HorizontalAlignment="Stretch">
+                        <ListView.ItemContainerStyle>
+                            <Style TargetType="ListViewItem">
+                                <Setter Property="Tag" Value="{Binding DataContext, RelativeSource={RelativeSource AncestorType=ListView}}"/>
+                                <Setter Property="ContextMenu">
+                                    <Setter.Value>
+                                        <ContextMenu>
+                                            <ContextMenu.ItemContainerStyle>
+                                                <Style TargetType="MenuItem">
+                                                    <Setter Property="FontSize" Value="14"/>
+                                                    <Setter Property="HorizontalContentAlignment" Value="Left"/>
+                                                </Style>
+                                            </ContextMenu.ItemContainerStyle>
+                                            <MenuItem Header="Add" Command="{Binding PlacementTarget.Tag.AddScheduleCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
+                                                <MenuItem.Icon>
+                                                    <materialDesign:PackIcon Kind="Plus" Width="16" Height="16"/>
+                                                </MenuItem.Icon>
+                                            </MenuItem>
+                                            <MenuItem Header="Delete" Command="{Binding PlacementTarget.Tag.DeleteScheduleCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}" CommandParameter="{Binding}">
+                                                <MenuItem.Icon>
+                                                    <materialDesign:PackIcon Kind="Delete" Width="16" Height="16"/>
+                                                </MenuItem.Icon>
+                                            </MenuItem>
+                                        </ContextMenu>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </ListView.ItemContainerStyle>
                         <ListView.View>
                             <GridView>
                                 <GridViewColumn Header="Script #" DisplayMemberBinding="{Binding Ordering}" Width="80"/>


### PR DESCRIPTION
## Summary
- enable adding and deleting schedules from schedule list via right-click context menu
- parameterize DeleteSchedule command to operate on provided schedule
- adjust unit tests for new command signature

## Testing
- `dotnet test CellManager/CellManager.sln`

------
https://chatgpt.com/codex/tasks/task_e_68c0d4f85e00832391097c00e9b90cca