### PR TITLE
Add icons to schedule step library titles

### DIFF
--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -331,7 +331,46 @@
                         <ItemsControl ItemsSource="{Binding StepLibrary}">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
-                                    <Expander Header="{Binding Name}" Margin="0,0,0,4" IsExpanded="True">
+                                    <Expander Margin="0,0,0,4" IsExpanded="True">
+                                        <Expander.Header>
+                                            <StackPanel Orientation="Horizontal">
+                                                <materialDesign:PackIcon Width="18" Height="18" Margin="0,0,4,0" VerticalAlignment="Center">
+                                                    <materialDesign:PackIcon.Style>
+                                                        <Style TargetType="materialDesign:PackIcon">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding Name}" Value="Charge">
+                                                                    <Setter Property="Kind" Value="BatteryPlus"/>
+                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                </DataTrigger>
+                                                                <DataTrigger Binding="{Binding Name}" Value="Discharge">
+                                                                    <Setter Property="Kind" Value="BatteryMinus"/>
+                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                </DataTrigger>
+                                                                <DataTrigger Binding="{Binding Name}" Value="Rest">
+                                                                    <Setter Property="Kind" Value="BatteryEco"/>
+                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                </DataTrigger>
+                                                                <DataTrigger Binding="{Binding Name}" Value="OCV">
+                                                                    <Setter Property="Kind" Value="StairsDown"/>
+                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                    <Setter Property="LayoutTransform">
+                                                                        <Setter.Value>
+                                                                            <ScaleTransform ScaleX="-1"/>
+                                                                        </Setter.Value>
+                                                                    </Setter>
+                                                                </DataTrigger>
+                                                                <DataTrigger Binding="{Binding Name}" Value="Loop">
+                                                                    <Setter Property="Kind" Value="Repeat"/>
+                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </materialDesign:PackIcon.Style>
+                                                </materialDesign:PackIcon>
+                                                <TextBlock Text="{Binding Name}" VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                        </Expander.Header>
                                         <ItemsControl ItemsSource="{Binding Steps}" ItemTemplate="{StaticResource StepTemplateItem}"
                                                   PreviewMouseLeftButtonDown="ProfileList_PreviewMouseLeftButtonDown"
                                                   PreviewMouseMove="ProfileList_PreviewMouseMove"/>


### PR DESCRIPTION
## Summary
- Show icons beside Charge, Discharge, Rest, OCV, and Loop groups in the Schedule view's Step Library
- OCV header uses mirrored StairsDown icon to match Test Setup tab

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c0de363d1c8323b422b164ffbeaffd