### PR TITLE
Fix schedule save and UI alignment

### DIFF
--- a/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
+++ b/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
@@ -428,9 +428,8 @@ namespace CellManager.ViewModels
 
         private void AddSchedule()
         {
-            var newId = Schedules.Any() ? Schedules.Max(s => s.Id) + 1 : 1;
             var newOrdering = Schedules.Any() ? Schedules.Max(s => s.Ordering) + 1 : 1;
-            var sched = new Schedule { Id = newId, Ordering = newOrdering, Name = $"Schedule {newId}" };
+            var sched = new Schedule { Ordering = newOrdering, Name = $"Schedule {newOrdering}" };
             Schedules.Add(sched);
             SelectedSchedule = sched;
             Sequence.Clear();
@@ -446,6 +445,12 @@ namespace CellManager.ViewModels
             SelectedSchedule.LoopStartIndex = LoopStartIndex;
             SelectedSchedule.LoopEndIndex = LoopEndIndex;
             _scheduleRepo?.Save(SelectedSchedule);
+            if (_scheduleRepo != null)
+            {
+                var savedId = SelectedSchedule.Id;
+                LoadSchedules();
+                SelectedSchedule = Schedules.FirstOrDefault(s => s.Id == savedId);
+            }
         }
 
         private void DeleteSchedule(Schedule? schedule)

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -247,10 +247,11 @@
                 <!-- Sequence list -->
                 <StackPanel Grid.Row="1" Orientation="Vertical">
                     <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{Binding SelectedSchedule.Ordering}" Margin="0,0,8,0" VerticalAlignment="Center"/>
                         <TextBox Width="250" Style="{StaticResource MaterialDesignFilledTextBox}"
-         Text="{Binding ScheduleName}" materialDesign:HintAssist.Hint="Schedule Name"/>
+                                 Text="{Binding ScheduleName}" materialDesign:HintAssist.Hint="Schedule Name"/>
                         <Button Grid.Column="1" Content="Save" Command="{Binding SaveScheduleCommand}"
-        Margin="8,0,0,0" Style="{StaticResource MaterialDesignRaisedButton}"/>
+                                Margin="8,0,0,0" Style="{StaticResource MaterialDesignRaisedButton}"/>
                     </StackPanel>
                     <ListBox x:Name="SequenceList" ItemsSource="{Binding Sequence}" AllowDrop="True" Width="Auto" Height="600"
          PreviewMouseLeftButtonDown="ScheduleList_PreviewMouseLeftButtonDown"
@@ -372,6 +373,7 @@
                                             </StackPanel>
                                         </Expander.Header>
                                         <ItemsControl ItemsSource="{Binding Steps}" ItemTemplate="{StaticResource StepTemplateItem}"
+                                                  Margin="24,0,0,0"
                                                   PreviewMouseLeftButtonDown="ProfileList_PreviewMouseLeftButtonDown"
                                                   PreviewMouseMove="ProfileList_PreviewMouseMove"/>
                                     </Expander>


### PR DESCRIPTION
## Summary
- Show selected script number before the schedule name field
- Align expanded step library items with their headers
- Ensure new schedules are saved to the database and refresh list after saving

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c0e26257788323ae077f16c96a0e80