### PR TITLE
feat: show step profile info on hover

### DIFF
--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -10,6 +10,14 @@
     <UserControl.Resources>
         <DataTemplate x:Key="StepTemplateItem">
             <TextBlock Margin="4" VerticalAlignment="Center">
+                <TextBlock.ToolTip>
+                    <StackPanel>
+                        <TextBlock Text="{Binding Id, StringFormat=ID\: {0}}"/>
+                        <TextBlock Text="{Binding Name, StringFormat=Name\: {0}}"/>
+                        <TextBlock Text="{Binding Parameters, StringFormat=Params\: {0}}"/>
+                        <TextBlock Text="{Binding Duration, StringFormat='Duration\: {0:hh\\:mm\\:ss}'}"/>
+                    </StackPanel>
+                </TextBlock.ToolTip>
                 <TextBlock.Style>
                     <Style TargetType="TextBlock">
                         <!-- Default to name so loop templates hide IDs -->


### PR DESCRIPTION
## Summary
- display detailed step profile info in schedule tab on hover

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found, e_sqlite3 load errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c1060358ac8323a653b4d203e7cd8e