### PR TITLE
Adjust schedule list columns on resize

### DIFF
--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -84,11 +84,12 @@
                             </StackPanel>
                         </Button>
                     </Grid>
-                    <ListView DockPanel.Dock="Bottom"
+                    <ListView x:Name="ScheduleList" DockPanel.Dock="Bottom"
                               ItemsSource="{Binding Schedules}"
                               SelectedItem="{Binding SelectedSchedule}"
                               HorizontalAlignment="Stretch"
-                              Tag="{Binding}">
+                              Tag="{Binding}"
+                              SizeChanged="ScheduleList_SizeChanged">
                         <ListView.ContextMenu>
                             <ContextMenu>
                                 <ContextMenu.ItemContainerStyle>

--- a/CellManager/CellManager/Views/ScheduleView.xaml.cs
+++ b/CellManager/CellManager/Views/ScheduleView.xaml.cs
@@ -92,6 +92,21 @@ namespace CellManager.Views
             RemoveDragAdorner();
         }
 
+        private void ScheduleList_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            if (sender is not ListView listView) return;
+            if (listView.View is not GridView gridView) return;
+
+            double workingWidth = listView.ActualWidth - SystemParameters.VerticalScrollBarWidth;
+
+            if (gridView.Columns.Count >= 3)
+            {
+                gridView.Columns[0].Width = workingWidth * 0.2;
+                gridView.Columns[1].Width = workingWidth * 0.6;
+                gridView.Columns[2].Width = workingWidth * 0.2;
+            }
+        }
+
         private static int GetInsertIndex(ItemsControl list, Point position)
         {
             var orientation = GetOrientation(list);

--- a/CellManager/CellManager/Views/ScheduleView.xaml.cs
+++ b/CellManager/CellManager/Views/ScheduleView.xaml.cs
@@ -97,7 +97,13 @@ namespace CellManager.Views
             if (sender is not ListView listView) return;
             if (listView.View is not GridView gridView) return;
 
-            double workingWidth = listView.ActualWidth - SystemParameters.VerticalScrollBarWidth;
+            double workingWidth = listView.ActualWidth;
+
+            var scrollViewer = FindVisualChild<ScrollViewer>(listView);
+            if (scrollViewer?.ComputedVerticalScrollBarVisibility == Visibility.Visible)
+            {
+                workingWidth -= SystemParameters.VerticalScrollBarWidth;
+            }
 
             if (gridView.Columns.Count >= 3)
             {
@@ -105,6 +111,18 @@ namespace CellManager.Views
                 gridView.Columns[1].Width = workingWidth * 0.6;
                 gridView.Columns[2].Width = workingWidth * 0.2;
             }
+        }
+
+        private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+        {
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                if (child is T tChild) return tChild;
+                var result = FindVisualChild<T>(child);
+                if (result != null) return result;
+            }
+            return null;
         }
 
         private static int GetInsertIndex(ItemsControl list, Point position)


### PR DESCRIPTION
## Summary
- resize schedule list columns dynamically when window size changes

## Testing
- `dotnet test CellManager/CellManager.sln`

------
https://chatgpt.com/codex/tasks/task_e_68c10ec51e508323a6171c312f8b66ae