### PR TITLE
Improve timeline preview design

### DIFF
--- a/CellManager/CellManager/Converters/IsNotLastItemConverter.cs
+++ b/CellManager/CellManager/Converters/IsNotLastItemConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace CellManager.Converters
+{
+    public class IsNotLastItemConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (values.Length < 2) return Visibility.Visible;
+            if (values[0] is int index && values[1] is int count)
+            {
+                return index < count - 1 ? Visibility.Visible : Visibility.Collapsed;
+            }
+            return Visibility.Visible;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object? parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -5,9 +5,11 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:vm="clr-namespace:CellManager.ViewModels"
+             xmlns:converters="clr-namespace:CellManager.Converters"
              mc:Ignorable="d"
              d:DesignHeight="800" d:DesignWidth="1200">
     <UserControl.Resources>
+        <converters:IsNotLastItemConverter x:Key="IsNotLastItemConverter"/>
         <DataTemplate x:Key="StepTemplateItem">
             <TextBlock Margin="4" VerticalAlignment="Center">
                 <TextBlock.ToolTip>
@@ -226,7 +228,7 @@
                                Margin="16,0,0,0" VerticalAlignment="Center"/>
                         </StackPanel>
                         <ItemsControl x:Name="TimelinePreview" ItemsSource="{Binding Sequence}"
-                                  HorizontalAlignment="Stretch" ClipToBounds="True" Style="{x:Null}">
+                                  HorizontalAlignment="Stretch" ClipToBounds="True" Style="{x:Null}" AlternationCount="1000">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <StackPanel Orientation="Horizontal" Height="40"/>
@@ -234,27 +236,38 @@
                             </ItemsControl.ItemsPanel>
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
-                                    <materialDesign:Card Margin="1" Padding="2" Width="50" Height="32"
-                                                     Background="{DynamicResource PrimaryHueLightBrush}">
-                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                            <materialDesign:PackIcon Kind="{Binding IconKind}" Width="14" Height="14" Margin="0,0,2,0"/>
-                                            <TextBlock FontSize="10" Foreground="Black">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
-                                                        <Setter Property="Text" Value="{Binding Id}"/>
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding Kind}" Value="{x:Static vm:StepKind.LoopStart}">
-                                                                <Setter Property="Text" Value="Start"/>
-                                                            </DataTrigger>
-                                                            <DataTrigger Binding="{Binding Kind}" Value="{x:Static vm:StepKind.LoopEnd}">
-                                                                <Setter Property="Text" Value="End"/>
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
-                                        </StackPanel>
-                                    </materialDesign:Card>
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                        <Border Margin="1" Padding="2" Width="50" Height="32"
+                                                Background="{DynamicResource PrimaryHueLightBrush}"
+                                                BorderBrush="Black" BorderThickness="1" CornerRadius="0">
+                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                <materialDesign:PackIcon Kind="{Binding IconKind}" Width="14" Height="14" Margin="0,0,2,0"/>
+                                                <TextBlock FontSize="10" Foreground="Black">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="Text" Value="{Binding Id}"/>
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding Kind}" Value="{x:Static vm:StepKind.LoopStart}">
+                                                                    <Setter Property="Text" Value="Start"/>
+                                                                </DataTrigger>
+                                                                <DataTrigger Binding="{Binding Kind}" Value="{x:Static vm:StepKind.LoopEnd}">
+                                                                    <Setter Property="Text" Value="End"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </StackPanel>
+                                        </Border>
+                                        <materialDesign:PackIcon Kind="ChevronRight" Width="14" Height="14" Margin="4,0" VerticalAlignment="Center">
+                                            <materialDesign:PackIcon.Visibility>
+                                                <MultiBinding Converter="{StaticResource IsNotLastItemConverter}">
+                                                    <Binding RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=ContentPresenter}" Path="(ItemsControl.AlternationIndex)"/>
+                                                    <Binding RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=ItemsControl}" Path="Items.Count"/>
+                                                </MultiBinding>
+                                            </materialDesign:PackIcon.Visibility>
+                                        </materialDesign:PackIcon>
+                                    </StackPanel>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>


### PR DESCRIPTION
## Summary
- Show steps in timeline preview with square borders instead of rounded cards
- Add arrow connectors between steps for clearer flow
- Hide final connector using a converter

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c11364002483239e7a05e3a770caa8