### PR TITLE
Design RUN tab layout with schedule selection and controls

### DIFF
--- a/CellManager/CellManager/MainWindow.xaml
+++ b/CellManager/CellManager/MainWindow.xaml
@@ -25,9 +25,7 @@
             <views:ScheduleView/>
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:RunViewModel}">
-            <Grid Background="#FFFFFF">
-                <TextBlock Text="Run Content" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="20"/>
-            </Grid>
+            <views:RunView/>
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:DisplayViewModel}">
             <Grid Background="#FFFFFF">

--- a/CellManager/CellManager/ViewModels/RunViewModel.cs
+++ b/CellManager/CellManager/ViewModels/RunViewModel.cs
@@ -1,4 +1,8 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CellManager.Models;
 
 namespace CellManager.ViewModels
 {
@@ -9,5 +13,47 @@ namespace CellManager.ViewModels
 
         [ObservableProperty]
         private bool _isViewEnabled = true;
+
+        public ObservableCollection<Schedule> AvailableSchedules { get; } = new();
+
+        [ObservableProperty]
+        private Schedule? _selectedSchedule;
+
+        [ObservableProperty]
+        private double _boardVoltage;
+
+        [ObservableProperty]
+        private double _boardCurrent;
+
+        [ObservableProperty]
+        private double _boardTemperature;
+
+        [ObservableProperty]
+        private bool _isBoardConnected;
+
+        [ObservableProperty]
+        private double _progress;
+
+        [ObservableProperty]
+        private int _currentStep;
+
+        [ObservableProperty]
+        private TimeSpan _elapsedTime;
+
+        [ObservableProperty]
+        private TimeSpan _remainingTime;
+
+        public ObservableCollection<string> RunLogs { get; } = new();
+
+        public RelayCommand StartCommand { get; }
+        public RelayCommand PauseCommand { get; }
+        public RelayCommand StopCommand { get; }
+
+        public RunViewModel()
+        {
+            StartCommand = new RelayCommand(() => { });
+            PauseCommand = new RelayCommand(() => { });
+            StopCommand = new RelayCommand(() => { });
+        }
     }
 }

--- a/CellManager/CellManager/Views/Controls/TimelinePreviewControl.xaml
+++ b/CellManager/CellManager/Views/Controls/TimelinePreviewControl.xaml
@@ -1,0 +1,12 @@
+<UserControl x:Class="CellManager.Views.Controls.TimelinePreviewControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="200" d:DesignWidth="400">
+    <Border BorderBrush="#E0E0E0" BorderThickness="1" Background="#FAFAFA" CornerRadius="4">
+        <TextBlock Text="Timeline Preview" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Border>
+</UserControl>
+

--- a/CellManager/CellManager/Views/Controls/TimelinePreviewControl.xaml.cs
+++ b/CellManager/CellManager/Views/Controls/TimelinePreviewControl.xaml.cs
@@ -1,0 +1,16 @@
+using System.Windows.Controls;
+using CellManager.Models;
+
+namespace CellManager.Views.Controls
+{
+    public partial class TimelinePreviewControl : UserControl
+    {
+        public TimelinePreviewControl()
+        {
+            InitializeComponent();
+        }
+
+        public Schedule? Schedule { get; set; }
+    }
+}
+

--- a/CellManager/CellManager/Views/RunView.xaml
+++ b/CellManager/CellManager/Views/RunView.xaml
@@ -1,0 +1,83 @@
+<UserControl x:Class="CellManager.Views.RunView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:local="clr-namespace:CellManager.Views.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="800" d:DesignWidth="1200">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="350"/>
+        </Grid.ColumnDefinitions>
+
+        <!-- Header and schedule selection -->
+        <Grid Grid.Row="0" Grid.ColumnSpan="2" Margin="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="240"/>
+            </Grid.ColumnDefinitions>
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                <materialDesign:PackIcon Kind="Play" Width="24" Height="24" Margin="0,0,8,0"/>
+                <TextBlock Text="RUN" FontSize="20" FontWeight="Bold"/>
+            </StackPanel>
+            <ComboBox Grid.Column="1"
+                      ItemsSource="{Binding AvailableSchedules}"
+                      SelectedItem="{Binding SelectedSchedule}"
+                      DisplayMemberPath="DisplayNameAndId"
+                      Margin="8,0,0,0"/>
+        </Grid>
+
+        <!-- Timeline preview and board status -->
+        <Grid Grid.Row="1" Grid.ColumnSpan="2" Margin="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="300"/>
+            </Grid.ColumnDefinitions>
+
+            <GroupBox Grid.Column="0" Header="Timeline Preview" Margin="0,0,8,0">
+                <local:TimelinePreviewControl Schedule="{Binding SelectedSchedule}"/>
+            </GroupBox>
+
+            <GroupBox Grid.Column="1" Header="Board Status">
+                <StackPanel>
+                    <TextBlock Text="{Binding BoardVoltage, StringFormat='Voltage: {0:F2} V'}" Margin="0,0,0,4"/>
+                    <TextBlock Text="{Binding BoardCurrent, StringFormat='Current: {0:F2} A'}" Margin="0,0,0,4"/>
+                    <TextBlock Text="{Binding BoardTemperature, StringFormat='Temperature: {0:F1} °C'}" Margin="0,0,0,4"/>
+                    <TextBlock Text="{Binding IsBoardConnected, StringFormat='Connected: {0}'}"/>
+                </StackPanel>
+            </GroupBox>
+        </Grid>
+
+        <!-- Controls -->
+        <GroupBox Grid.Row="2" Grid.ColumnSpan="2" Header="Controls" Margin="8">
+            <StackPanel>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,4">
+                    <Button Content="Start" Command="{Binding StartCommand}" Style="{StaticResource PrimaryActionButton}" Margin="0,0,8,0"/>
+                    <Button Content="Pause" Command="{Binding PauseCommand}" Margin="0,0,8,0"/>
+                    <Button Content="Stop" Command="{Binding StopCommand}" Style="{StaticResource ErrorActionButton}"/>
+                    <ProgressBar Width="200" Height="18" Margin="16,0,0,0" Value="{Binding Progress}" Maximum="100"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,4,0,0">
+                    <TextBlock Text="{Binding CurrentStep, StringFormat='Step: {0}'}" Margin="0,0,16,0"/>
+                    <TextBlock Text="{Binding ElapsedTime, StringFormat='Elapsed: {0:hh\\:mm\\:ss}'}" Margin="0,0,16,0"/>
+                    <TextBlock Text="{Binding RemainingTime, StringFormat='Remaining: {0:hh\\:mm\\:ss}'}"/>
+                </StackPanel>
+            </StackPanel>
+        </GroupBox>
+
+        <!-- Run logs -->
+        <GroupBox Grid.Row="3" Grid.ColumnSpan="2" Header="Run Logs" Margin="8">
+            <ListBox ItemsSource="{Binding RunLogs}" Height="120"
+                     ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+        </GroupBox>
+    </Grid>
+</UserControl>

--- a/CellManager/CellManager/Views/RunView.xaml.cs
+++ b/CellManager/CellManager/Views/RunView.xaml.cs
@@ -1,0 +1,13 @@
+using System.Windows.Controls;
+
+namespace CellManager.Views
+{
+    public partial class RunView : UserControl
+    {
+        public RunView()
+        {
+            InitializeComponent();
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Extend `RunViewModel` with schedule lists, board status properties, run logs and commands
- Introduce `RunView` with header, timeline preview, board status, control buttons and log panel
- Update main window to host the new run view and add stub timeline preview control

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c114daa3dc8323b10c55bd4c1e656d