### PR TITLE
Add timeline preview chart control

### DIFF
--- a/CellManager/CellManager/CellManager.csproj
+++ b/CellManager/CellManager/CellManager.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="SQLite" Version="3.13.0" />
     <PackageReference Include="System.Data.SQLite" Version="2.0.1" />
     <PackageReference Include="Extended.Wpf.Toolkit" Version="4.5.0" />
+    <PackageReference Include="OxyPlot.Wpf" Version="2.1.2" />
   </ItemGroup>
 
 </Project>

--- a/CellManager/CellManager/Views/Controls/TimelinePreviewControl.xaml
+++ b/CellManager/CellManager/Views/Controls/TimelinePreviewControl.xaml
@@ -1,0 +1,9 @@
+<UserControl x:Class="CellManager.Views.Controls.TimelinePreviewControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:oxy="http://oxyplot.org/wpf"
+             DataContext="{Binding RelativeSource={RelativeSource Self}}">
+    <Grid>
+        <oxy:PlotView x:Name="PlotView" Model="{Binding PlotModel}" />
+    </Grid>
+</UserControl>

--- a/CellManager/CellManager/Views/Controls/TimelinePreviewControl.xaml.cs
+++ b/CellManager/CellManager/Views/Controls/TimelinePreviewControl.xaml.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Controls;
+using CellManager.Models;
+using CellManager.ViewModels;
+using OxyPlot;
+using OxyPlot.Axes;
+using OxyPlot.Series;
+
+namespace CellManager.Views.Controls
+{
+    public partial class TimelinePreviewControl : UserControl
+    {
+        public static readonly DependencyProperty SelectedScheduleProperty =
+            DependencyProperty.Register(nameof(SelectedSchedule), typeof(Schedule), typeof(TimelinePreviewControl),
+                new PropertyMetadata(null, OnDataChanged));
+
+        public static readonly DependencyProperty StepsProperty =
+            DependencyProperty.Register(nameof(Steps), typeof(ObservableCollection<StepTemplate>), typeof(TimelinePreviewControl),
+                new PropertyMetadata(null, OnStepsChanged));
+
+        public Schedule? SelectedSchedule
+        {
+            get => (Schedule?)GetValue(SelectedScheduleProperty);
+            set => SetValue(SelectedScheduleProperty, value);
+        }
+
+        public ObservableCollection<StepTemplate>? Steps
+        {
+            get => (ObservableCollection<StepTemplate>?)GetValue(StepsProperty);
+            set => SetValue(StepsProperty, value);
+        }
+
+        public PlotModel PlotModel { get; } = new PlotModel { Title = "Schedule" };
+
+        public TimelinePreviewControl()
+        {
+            InitializeComponent();
+            ConfigurePlot();
+        }
+
+        private static void OnDataChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var control = (TimelinePreviewControl)d;
+            control.UpdatePlot();
+        }
+
+        private static void OnStepsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var control = (TimelinePreviewControl)d;
+            if (e.OldValue is ObservableCollection<StepTemplate> old)
+                old.CollectionChanged -= control.OnCollectionChanged;
+            if (e.NewValue is ObservableCollection<StepTemplate> @new)
+                @new.CollectionChanged += control.OnCollectionChanged;
+            control.UpdatePlot();
+        }
+
+        private void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e) => UpdatePlot();
+
+        private void ConfigurePlot()
+        {
+            PlotModel.Axes.Clear();
+            PlotModel.Axes.Add(new LinearAxis
+            {
+                Position = AxisPosition.Bottom,
+                Title = "Time (s)",
+                IsPanEnabled = true,
+                IsZoomEnabled = true
+            });
+            PlotModel.Axes.Add(new LinearAxis
+            {
+                Position = AxisPosition.Left,
+                Title = "Value",
+                IsPanEnabled = true,
+                IsZoomEnabled = true
+            });
+        }
+
+        private void UpdatePlot()
+        {
+            PlotModel.Series.Clear();
+            if (Steps == null || Steps.Count == 0)
+            {
+                PlotModel.InvalidatePlot(true);
+                return;
+            }
+
+            var voltageSeries = new LineSeries { Title = "Voltage", TrackerFormatString = "{0}\nTime: {1:0.##} s\nVoltage: {2:0.##} V" };
+            var currentSeries = new LineSeries { Title = "Current", TrackerFormatString = "{0}\nTime: {1:0.##} s\nCurrent: {2:0.##} A" };
+
+            double time = 0;
+            foreach (var step in Steps)
+            {
+                var duration = step.Duration.TotalSeconds;
+                var (voltage, current) = ParseParameters(step.Parameters);
+
+                if (voltage.HasValue)
+                {
+                    voltageSeries.Points.Add(new DataPoint(time, voltage.Value));
+                    voltageSeries.Points.Add(new DataPoint(time + duration, voltage.Value));
+                }
+
+                if (current.HasValue)
+                {
+                    currentSeries.Points.Add(new DataPoint(time, current.Value));
+                    currentSeries.Points.Add(new DataPoint(time + duration, current.Value));
+                }
+
+                time += duration;
+            }
+
+            if (voltageSeries.Points.Count > 0)
+                PlotModel.Series.Add(voltageSeries);
+            if (currentSeries.Points.Count > 0)
+                PlotModel.Series.Add(currentSeries);
+
+            PlotModel.InvalidatePlot(true);
+        }
+
+        private static (double? voltage, double? current) ParseParameters(string? parameters)
+        {
+            double? voltage = null;
+            double? current = null;
+            if (!string.IsNullOrEmpty(parameters))
+            {
+                var voltMatch = Regex.Match(parameters, @"([\d\.]+)\s*[Vv]");
+                if (voltMatch.Success && double.TryParse(voltMatch.Groups[1].Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var v))
+                    voltage = v;
+                var currMatch = Regex.Match(parameters, @"([\d\.]+)\s*[Aa]");
+                if (currMatch.Success && double.TryParse(currMatch.Groups[1].Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var c))
+                    current = c;
+            }
+            return (voltage, current);
+        }
+    }
+}

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -6,6 +6,7 @@
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:vm="clr-namespace:CellManager.ViewModels"
              xmlns:converters="clr-namespace:CellManager.Converters"
+             xmlns:controls="clr-namespace:CellManager.Views.Controls"
              mc:Ignorable="d"
              d:DesignHeight="800" d:DesignWidth="1200">
     <UserControl.Resources>
@@ -227,50 +228,7 @@
                             <TextBlock Text="{Binding TotalDuration, StringFormat='Total: {0:hh\\:mm\\:ss}'}"
                                Margin="16,0,0,0" VerticalAlignment="Center"/>
                         </StackPanel>
-                        <ItemsControl x:Name="TimelinePreview" ItemsSource="{Binding Sequence}"
-                                  HorizontalAlignment="Stretch" ClipToBounds="True" Style="{x:Null}" AlternationCount="1000">
-                            <ItemsControl.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                    <StackPanel Orientation="Horizontal" Height="40"/>
-                                </ItemsPanelTemplate>
-                            </ItemsControl.ItemsPanel>
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                        <Border Margin="1" Padding="2" Width="50" Height="32"
-                                                Background="{DynamicResource PrimaryHueLightBrush}"
-                                                BorderBrush="Black" BorderThickness="1" CornerRadius="0">
-                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                                <materialDesign:PackIcon Kind="{Binding IconKind}" Width="14" Height="14" Margin="0,0,2,0"/>
-                                                <TextBlock FontSize="10" Foreground="Black">
-                                                    <TextBlock.Style>
-                                                        <Style TargetType="TextBlock">
-                                                            <Setter Property="Text" Value="{Binding Id}"/>
-                                                            <Style.Triggers>
-                                                                <DataTrigger Binding="{Binding Kind}" Value="{x:Static vm:StepKind.LoopStart}">
-                                                                    <Setter Property="Text" Value="Start"/>
-                                                                </DataTrigger>
-                                                                <DataTrigger Binding="{Binding Kind}" Value="{x:Static vm:StepKind.LoopEnd}">
-                                                                    <Setter Property="Text" Value="End"/>
-                                                                </DataTrigger>
-                                                            </Style.Triggers>
-                                                        </Style>
-                                                    </TextBlock.Style>
-                                                </TextBlock>
-                                            </StackPanel>
-                                        </Border>
-                                        <materialDesign:PackIcon Kind="ChevronRight" Width="14" Height="14" Margin="4,0" VerticalAlignment="Center">
-                                            <materialDesign:PackIcon.Visibility>
-                                                <MultiBinding Converter="{StaticResource IsNotLastItemConverter}">
-                                                    <Binding RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=ContentPresenter}" Path="(ItemsControl.AlternationIndex)"/>
-                                                    <Binding RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=ItemsControl}" Path="Items.Count"/>
-                                                </MultiBinding>
-                                            </materialDesign:PackIcon.Visibility>
-                                        </materialDesign:PackIcon>
-                                    </StackPanel>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
+                        <controls:TimelinePreviewControl SelectedSchedule="{Binding SelectedSchedule}" Steps="{Binding Sequence}" Height="120"/>
                     </StackPanel>
 
                     <!-- Sequence list -->


### PR DESCRIPTION
## Summary
- replace timeline preview placeholder with OxyPlot chart bound to schedule steps
- add TimelinePreviewControl with zoomable voltage/current segments and tooltips
- wire up new control in ScheduleView and include OxyPlot dependency

## Testing
- `dotnet restore`
- `dotnet test` (fails to load sqlite shared library but tests passed)


------
https://chatgpt.com/codex/tasks/task_e_68c12b881fd083239f0382899b251e16