### PR TITLE
Make TimelinePreviewControl Schedule property bindable

### DIFF
--- a/CellManager/CellManager/Views/Controls/TimelinePreviewControl.xaml.cs
+++ b/CellManager/CellManager/Views/Controls/TimelinePreviewControl.xaml.cs
@@ -1,3 +1,4 @@
+using System.Windows;
 using System.Windows.Controls;
 using CellManager.Models;
 
@@ -10,7 +11,21 @@ namespace CellManager.Views.Controls
             InitializeComponent();
         }
 
-        public Schedule? Schedule { get; set; }
+        /// <summary>
+        /// Gets or sets the <see cref="Schedule"/> displayed by this control.
+        /// </summary>
+        public Schedule? Schedule
+        {
+            get => (Schedule?)GetValue(ScheduleProperty);
+            set => SetValue(ScheduleProperty, value);
+        }
+
+        public static readonly DependencyProperty ScheduleProperty =
+            DependencyProperty.Register(
+                nameof(Schedule),
+                typeof(Schedule),
+                typeof(TimelinePreviewControl),
+                new PropertyMetadata(default(Schedule)));
     }
 }
 


### PR DESCRIPTION
## Summary
- register TimelinePreviewControl.Schedule as a DependencyProperty to support binding

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c12cf247c88323bce6bed5eda0187f