### PR TITLE
Make TimelinePreviewControl Schedule property bindable and define ErrorActionButton style

### DIFF
--- a/CellManager/CellManager/App.xaml
+++ b/CellManager/CellManager/App.xaml
@@ -23,6 +23,13 @@
             <SolidColorBrush x:Key="PrimaryDisabledFg"  Color="#FFFFFF"/>
             <!-- Disabled fg(흰색 유지) -->
 
+            <!-- Error button colors -->
+            <SolidColorBrush x:Key="ErrorMain"        Color="#F44336"/>
+            <SolidColorBrush x:Key="ErrorHover"       Color="#E53935"/>
+            <SolidColorBrush x:Key="ErrorPressed"     Color="#C62828"/>
+            <SolidColorBrush x:Key="ErrorDisabledBg"  Color="#FFCDD2"/>
+            <SolidColorBrush x:Key="ErrorDisabledFg"  Color="#FFFFFF"/>
+
             <!-- 가로선 -->
             <Style x:Key="HDivider" TargetType="Border">
                 <Setter Property="Height" Value="1"/>
@@ -407,6 +414,53 @@
                                 <Trigger Property="IsEnabled" Value="False">
                                     <Setter TargetName="bg" Property="Background" Value="{StaticResource PrimaryDisabledBg}"/>
                                     <Setter Property="Foreground" Value="{StaticResource PrimaryDisabledFg}"/>
+                                    <Setter Property="Opacity" Value="0.95"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+            <Style x:Key="ErrorActionButton"
+       TargetType="Button"
+       BasedOn="{StaticResource MaterialDesignRaisedButton}">
+                <Setter Property="Height" Value="36"/>
+                <Setter Property="Padding" Value="16,0"/>
+                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="Background" Value="{StaticResource ErrorMain}"/>
+                <Setter Property="materialDesign:ButtonAssist.CornerRadius" Value="6"/>
+                <Setter Property="HorizontalAlignment" Value="Right"/>
+                <Setter Property="SnapsToDevicePixels" Value="True"/>
+                <Setter Property="FontSize" Value="14"/>
+                <Setter Property="FontWeight" Value="SemiBold"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="bg"
+                Background="{TemplateBinding Background}"
+                CornerRadius="{TemplateBinding materialDesign:ButtonAssist.CornerRadius}">
+                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
+                            Margin="{TemplateBinding Padding}"/>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <!-- Hover / Pressed -->
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="bg" Property="Background" Value="{StaticResource ErrorHover}"/>
+                                </Trigger>
+                                <Trigger Property="IsPressed" Value="True">
+                                    <Setter TargetName="bg" Property="Background" Value="{StaticResource ErrorPressed}"/>
+                                </Trigger>
+
+                                <!-- Keyboard Focus (외곽선 살짝) -->
+                                <Trigger Property="IsKeyboardFocused" Value="True">
+                                    <Setter TargetName="bg" Property="BorderBrush" Value="#90CAF9"/>
+                                    <Setter TargetName="bg" Property="BorderThickness" Value="2"/>
+                                </Trigger>
+
+                                <!-- Disabled -->
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter TargetName="bg" Property="Background" Value="{StaticResource ErrorDisabledBg}"/>
+                                    <Setter Property="Foreground" Value="{StaticResource ErrorDisabledFg}"/>
                                     <Setter Property="Opacity" Value="0.95"/>
                                 </Trigger>
                             </ControlTemplate.Triggers>

--- a/CellManager/CellManager/Views/Controls/TimelinePreviewControl.xaml.cs
+++ b/CellManager/CellManager/Views/Controls/TimelinePreviewControl.xaml.cs
@@ -1,3 +1,4 @@
+using System.Windows;
 using System.Windows.Controls;
 using CellManager.Models;
 
@@ -10,7 +11,21 @@ namespace CellManager.Views.Controls
             InitializeComponent();
         }
 
-        public Schedule? Schedule { get; set; }
+        /// <summary>
+        /// Gets or sets the <see cref="Schedule"/> displayed by this control.
+        /// </summary>
+        public Schedule? Schedule
+        {
+            get => (Schedule?)GetValue(ScheduleProperty);
+            set => SetValue(ScheduleProperty, value);
+        }
+
+        public static readonly DependencyProperty ScheduleProperty =
+            DependencyProperty.Register(
+                nameof(Schedule),
+                typeof(Schedule),
+                typeof(TimelinePreviewControl),
+                new PropertyMetadata(default(Schedule)));
     }
 }
 


### PR DESCRIPTION
## Summary
- register TimelinePreviewControl.Schedule as a DependencyProperty to support binding
- add error-themed button style to stop actions and fix missing resource error

## Testing
- `dotnet test CellManager/CellManager.sln`

------
https://chatgpt.com/codex/tasks/task_e_68c12cf247c88323bce6bed5eda0187f