### PR TITLE
Add basic Run tab simulation and tests

### DIFF
--- a/CellManager/CellManager.Tests/CellManager.Tests.csproj
+++ b/CellManager/CellManager.Tests/CellManager.Tests.csproj
@@ -40,7 +40,8 @@
     <Compile Include="../CellManager/Services/SQLiteScheduleRepository.cs" Link="Services/SQLiteScheduleRepository.cs" />
     <Compile Include="../CellManager/Models/ScheduleTimeCalculator.cs" Link="Models/ScheduleTimeCalculator.cs" />
     <Compile Include="../CellManager/Messages/CellSelectedMessage.cs" Link="Messages/CellSelectedMessage.cs" />
-    <Compile Include="../CellManager/ViewModels/ScheduleViewModel.cs" Link="ViewModels/ScheduleViewModel.cs" />
-  </ItemGroup>
+      <Compile Include="../CellManager/ViewModels/ScheduleViewModel.cs" Link="ViewModels/ScheduleViewModel.cs" />
+      <Compile Include="../CellManager/ViewModels/RunViewModel.cs" Link="ViewModels/RunViewModel.cs" />
+    </ItemGroup>
 
-</Project>
+  </Project>

--- a/CellManager/CellManager.Tests/RunViewModelTests.cs
+++ b/CellManager/CellManager.Tests/RunViewModelTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using CellManager.Models;
+using CellManager.ViewModels;
+
+namespace CellManager.Tests
+{
+    public class RunViewModelTests
+    {
+        [Fact]
+        public async Task StartCommand_BeginsProgress()
+        {
+            var vm = new RunViewModel();
+            var sched = new Schedule { Name = "Test", EstimatedDuration = TimeSpan.FromSeconds(1) };
+            vm.AvailableSchedules.Add(sched);
+            vm.SelectedSchedule = sched;
+            vm.StartCommand.Execute(null);
+            await Task.Delay(300);
+            Assert.True(vm.Progress > 0);
+        }
+
+        [Fact]
+        public async Task StopCommand_ResetsProgress()
+        {
+            var vm = new RunViewModel();
+            var sched = new Schedule { Name = "Test", EstimatedDuration = TimeSpan.FromSeconds(1) };
+            vm.AvailableSchedules.Add(sched);
+            vm.SelectedSchedule = sched;
+            vm.StartCommand.Execute(null);
+            await Task.Delay(300);
+            vm.StopCommand.Execute(null);
+            Assert.Equal(0, vm.Progress);
+            Assert.Equal(TimeSpan.Zero, vm.ElapsedTime);
+        }
+    }
+}

--- a/CellManager/CellManager/ViewModels/RunViewModel.cs
+++ b/CellManager/CellManager/ViewModels/RunViewModel.cs
@@ -1,18 +1,32 @@
 using System;
 using System.Collections.ObjectModel;
+using System.Linq;
+using System.Timers;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using CellManager.Messages;
 using CellManager.Models;
+using CellManager.Services;
 
 namespace CellManager.ViewModels
 {
     public partial class RunViewModel : ObservableObject
     {
+        private readonly IScheduleRepository? _scheduleRepo;
+        private readonly Random _random = new();
+        private Timer? _timer;
+        private bool _isPaused;
+        private DateTime _startTime;
+
         public string HeaderText { get; } = "Run";
         public string IconName { get; } = "Play";
 
         [ObservableProperty]
         private bool _isViewEnabled = true;
+
+        [ObservableProperty]
+        private bool _isRunning;
 
         public ObservableCollection<Schedule> AvailableSchedules { get; } = new();
 
@@ -49,11 +63,108 @@ namespace CellManager.ViewModels
         public RelayCommand PauseCommand { get; }
         public RelayCommand StopCommand { get; }
 
-        public RunViewModel()
+        public RunViewModel() : this(null) { }
+
+        public RunViewModel(IScheduleRepository? scheduleRepo)
         {
-            StartCommand = new RelayCommand(() => { });
-            PauseCommand = new RelayCommand(() => { });
-            StopCommand = new RelayCommand(() => { });
+            _scheduleRepo = scheduleRepo;
+
+            StartCommand = new RelayCommand(Start, () => !IsRunning && SelectedSchedule != null);
+            PauseCommand = new RelayCommand(TogglePause, () => IsRunning);
+            StopCommand = new RelayCommand(Stop, () => IsRunning);
+
+            if (_scheduleRepo == null)
+            {
+                // Provide a demo schedule for design-time or tests
+                AvailableSchedules.Add(new Schedule { Id = 1, Name = "Demo", EstimatedDuration = TimeSpan.FromSeconds(5) });
+                SelectedSchedule = AvailableSchedules.FirstOrDefault();
+            }
+            else
+            {
+                WeakReferenceMessenger.Default.Register<CellSelectedMessage>(this, (r, m) =>
+                {
+                    LoadSchedules(m.SelectedCell.Id);
+                });
+            }
         }
+
+        private void LoadSchedules(int cellId)
+        {
+            AvailableSchedules.Clear();
+            if (_scheduleRepo == null) return;
+            foreach (var sched in _scheduleRepo.Load(cellId))
+                AvailableSchedules.Add(sched);
+            SelectedSchedule = AvailableSchedules.FirstOrDefault();
+        }
+
+        private void Start()
+        {
+            if (SelectedSchedule == null) return;
+            RunLogs.Add($"Started {SelectedSchedule.Name}");
+            _startTime = DateTime.Now;
+            _timer = new Timer(200);
+            _timer.Elapsed += OnTimer;
+            _timer.Start();
+            IsRunning = true;
+            UpdateCommandStates();
+        }
+
+        private void OnTimer(object? sender, ElapsedEventArgs e)
+        {
+            if (_isPaused || SelectedSchedule == null) return;
+
+            var elapsed = DateTime.Now - _startTime;
+            ElapsedTime = elapsed;
+            var total = SelectedSchedule.EstimatedDuration.TotalSeconds;
+            if (total > 0)
+            {
+                Progress = Math.Min(100, elapsed.TotalSeconds / total * 100);
+                RemainingTime = TimeSpan.FromSeconds(Math.Max(0, total - elapsed.TotalSeconds));
+            }
+
+            // Update mock board metrics
+            BoardVoltage = 3.0 + _random.NextDouble();
+            BoardCurrent = 0.5 + _random.NextDouble();
+            BoardTemperature = 25 + _random.NextDouble() * 5;
+            IsBoardConnected = true;
+
+            if (Progress >= 100)
+            {
+                RunLogs.Add($"Completed {SelectedSchedule.Name}");
+                Stop();
+            }
+        }
+
+        private void TogglePause()
+        {
+            _isPaused = !_isPaused;
+            RunLogs.Add(_isPaused ? "Paused" : "Resumed");
+        }
+
+        private void Stop()
+        {
+            _timer?.Stop();
+            _timer?.Dispose();
+            _timer = null;
+            IsRunning = false;
+            _isPaused = false;
+            Progress = 0;
+            CurrentStep = 0;
+            ElapsedTime = TimeSpan.Zero;
+            RemainingTime = TimeSpan.Zero;
+            UpdateCommandStates();
+        }
+
+        private void UpdateCommandStates()
+        {
+            StartCommand.NotifyCanExecuteChanged();
+            PauseCommand.NotifyCanExecuteChanged();
+            StopCommand.NotifyCanExecuteChanged();
+        }
+
+        partial void OnSelectedScheduleChanged(Schedule? value) => StartCommand.NotifyCanExecuteChanged();
+
+        partial void OnIsRunningChanged(bool value) => UpdateCommandStates();
     }
 }
+


### PR DESCRIPTION
## Summary
- implement RunViewModel with start/pause/stop, schedule loading, and mock board metrics
- add RunViewModel unit tests

## Testing
- `dotnet test CellManager/CellManager.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c12fd2d9848323bd3fae992615c53e