### PR TITLE
Add settings view with configurable options

### DIFF
--- a/CellManager/CellManager/MainWindow.xaml
+++ b/CellManager/CellManager/MainWindow.xaml
@@ -43,9 +43,7 @@
             </Grid>
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:SettingsViewModel}">
-            <Grid Background="#FFFFFF">
-                <TextBlock Text="Settings Content" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="20"/>
-            </Grid>
+            <views:SettingsView/>
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:HelpViewModel}">
             <Grid Background="#FFFFFF">

--- a/CellManager/CellManager/ViewModels/SettingsViewModel.cs
+++ b/CellManager/CellManager/ViewModels/SettingsViewModel.cs
@@ -9,5 +9,23 @@ namespace CellManager.ViewModels
 
         [ObservableProperty]
         private bool _isViewEnabled = true;
+
+        // Board configuration
+        [ObservableProperty]
+        private string _boardPort = string.Empty;
+
+        // Default paths
+        [ObservableProperty]
+        private string _dataExportPath = string.Empty;
+
+        [ObservableProperty]
+        private string _profilePath = string.Empty;
+
+        // Feature toggles
+        [ObservableProperty]
+        private bool _enableAdvancedFeatures;
+
+        [ObservableProperty]
+        private bool _enableDarkTheme;
     }
 }

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -1,0 +1,35 @@
+<UserControl x:Class="CellManager.Views.SettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             mc:Ignorable="d"
+             d:DesignHeight="600" d:DesignWidth="800">
+    <ScrollViewer>
+        <StackPanel Margin="16">
+            <GroupBox Header="Board Settings" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="Board Port" Margin="0,0,0,4"/>
+                    <TextBox Text="{Binding BoardPort}" Width="200"/>
+                </StackPanel>
+            </GroupBox>
+
+            <GroupBox Header="Paths" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="Data Export Path" Margin="0,0,0,4"/>
+                    <TextBox Text="{Binding DataExportPath}" Width="300"/>
+                    <TextBlock Text="Profile Path" Margin="0,8,0,4"/>
+                    <TextBox Text="{Binding ProfilePath}" Width="300"/>
+                </StackPanel>
+            </GroupBox>
+
+            <GroupBox Header="Features">
+                <StackPanel>
+                    <CheckBox Content="Enable Advanced Features" IsChecked="{Binding EnableAdvancedFeatures}" Margin="0,0,0,4"/>
+                    <CheckBox Content="Enable Dark Theme" IsChecked="{Binding EnableDarkTheme}"/>
+                </StackPanel>
+            </GroupBox>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml.cs
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace CellManager.Views
+{
+    public partial class SettingsView : UserControl
+    {
+        public SettingsView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create SettingsView with board, path, and feature controls
- bind configurable properties in SettingsViewModel
- render SettingsView in MainWindow

## Testing
- `dotnet test CellManager/CellManager.sln`

------
https://chatgpt.com/codex/tasks/task_e_68c1340e9f7083239eacd03f97b0ff70