### PR TITLE
Add firmware-driven protection profiles

### DIFF
--- a/CellManager/CellManager/CellManager.csproj
+++ b/CellManager/CellManager/CellManager.csproj
@@ -16,6 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="ProtectionProfiles\**\*.json" CopyToOutputDirectory="Always" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="MahApps.Metro" Version="2.4.10" />
     <PackageReference Include="MaterialDesignThemes" Version="5.2.1" />

--- a/CellManager/CellManager/ProtectionProfiles/1.0.json
+++ b/CellManager/CellManager/ProtectionProfiles/1.0.json
@@ -1,0 +1,23 @@
+[
+  {
+    "parameter": "Charge Over Temperature",
+    "unit": "°C",
+    "description": "Maximum charging temperature",
+    "defaultSpec": "55",
+    "options": ["45", "50", "55", "60"]
+  },
+  {
+    "parameter": "Over Voltage",
+    "unit": "mV",
+    "description": "Maximum voltage",
+    "defaultSpec": "4200",
+    "options": ["4100", "4200", "4300"]
+  },
+  {
+    "parameter": "Over Current",
+    "unit": "mA",
+    "description": "Maximum current",
+    "defaultSpec": "2000",
+    "options": ["1500", "2000", "2500"]
+  }
+]

--- a/CellManager/CellManager/ViewModels/ProtectionProfileLoader.cs
+++ b/CellManager/CellManager/ViewModels/ProtectionProfileLoader.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace CellManager.ViewModels
+{
+    public static class ProtectionProfileLoader
+    {
+        public static IList<ProtectionSetting> Load(string firmwareVersion)
+        {
+            if (string.IsNullOrWhiteSpace(firmwareVersion))
+            {
+                return new List<ProtectionSetting>();
+            }
+
+            var baseDir = AppContext.BaseDirectory;
+            var path = Path.Combine(baseDir, "ProtectionProfiles", $"{firmwareVersion}.json");
+            if (!File.Exists(path))
+            {
+                return new List<ProtectionSetting>();
+            }
+
+            var json = File.ReadAllText(path);
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var settings = JsonSerializer.Deserialize<List<ProtectionSetting>>(json, options) ?? new List<ProtectionSetting>();
+
+            foreach (var setting in settings)
+            {
+                setting.Spec = setting.DefaultSpec;
+            }
+
+            return settings;
+        }
+    }
+}

--- a/CellManager/CellManager/ViewModels/SettingsViewModel.cs
+++ b/CellManager/CellManager/ViewModels/SettingsViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.Windows;
 
 namespace CellManager.ViewModels
@@ -89,10 +90,10 @@ namespace CellManager.ViewModels
                 return;
             }
 
-            ProtectionSettings.Clear();
-            ProtectionSettings.Add(new ProtectionSetting { Parameter = "Charge Over Temperature", Unit = "°C", Spec = "55" });
-            ProtectionSettings.Add(new ProtectionSetting { Parameter = "Over Voltage", Unit = "mV", Spec = "4200" });
-            ProtectionSettings.Add(new ProtectionSetting { Parameter = "Over Current", Unit = "mA", Spec = "2000" });
+            foreach (var setting in ProtectionSettings)
+            {
+                setting.Spec = setting.DefaultSpec;
+            }
         }
 
         private void WriteProtectionSettings()
@@ -103,13 +104,23 @@ namespace CellManager.ViewModels
                 return;
             }
 
-            // Placeholder for writing logic
+            foreach (var setting in ProtectionSettings)
+            {
+                // Placeholder for writing each setting
+            }
         }
 
         partial void OnFirmwareVersionChanged(string value)
         {
             ReadProtectionCommand.NotifyCanExecuteChanged();
             WriteProtectionCommand.NotifyCanExecuteChanged();
+
+            var profile = ProtectionProfileLoader.Load(FirmwareVersion);
+            ProtectionSettings.Clear();
+            foreach (var setting in profile)
+            {
+                ProtectionSettings.Add(setting);
+            }
         }
     }
 
@@ -125,6 +136,8 @@ namespace CellManager.ViewModels
         public string Spec { get; set; } = string.Empty;
         public string Unit { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
+        public string DefaultSpec { get; set; } = string.Empty;
+        public List<string> Options { get; set; } = new();
     }
 }
 

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -178,7 +178,7 @@
                                       Margin="0,0,0,16">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Header="Parameter" Binding="{Binding Parameter}" IsReadOnly="True"/>
-                                    <DataGridTextColumn Header="Spec" Binding="{Binding Spec}"/>
+                                    <DataGridComboBoxColumn Header="Spec" SelectedItemBinding="{Binding Spec}" ItemsSource="{Binding Options}"/>
                                     <DataGridTextColumn Header="Unit" Binding="{Binding Unit}"/>
                                     <DataGridTextColumn Header="Description" Binding="{Binding Description}" IsReadOnly="True"/>
                                 </DataGrid.Columns>


### PR DESCRIPTION
## Summary
- load protection profiles from firmware-specific JSON files
- swap spec column for combo box with predefined options
- populate protection settings based on loaded profile and defaults

## Testing
- `dotnet test CellManager/CellManager.Tests/CellManager.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c23332c9d4832390baa2b1eb9ffc86