### PR TITLE
Add option-based templates for protection settings

### DIFF
--- a/CellManager/CellManager/Converters/SpecTemplateSelector.cs
+++ b/CellManager/CellManager/Converters/SpecTemplateSelector.cs
@@ -1,0 +1,21 @@
+using System.Windows;
+using System.Windows.Controls;
+using CellManager.ViewModels;
+
+namespace CellManager.Converters
+{
+    public class SpecTemplateSelector : DataTemplateSelector
+    {
+        public DataTemplate TextBoxTemplate { get; set; } = null!;
+        public DataTemplate ComboBoxTemplate { get; set; } = null!;
+
+        public override DataTemplate SelectTemplate(object item, DependencyObject container)
+        {
+            if (item is ProtectionSetting setting && setting.Options.Count > 0)
+            {
+                return ComboBoxTemplate;
+            }
+            return TextBoxTemplate;
+        }
+    }
+}

--- a/CellManager/CellManager/ViewModels/SettingsViewModel.cs
+++ b/CellManager/CellManager/ViewModels/SettingsViewModel.cs
@@ -90,7 +90,13 @@ namespace CellManager.ViewModels
             }
 
             ProtectionSettings.Clear();
-            ProtectionSettings.Add(new ProtectionSetting { Parameter = "Charge Over Temperature", Unit = "°C", Spec = "55" });
+            ProtectionSettings.Add(new ProtectionSetting
+            {
+                Parameter = "Charge Over Temperature",
+                Unit = "°C",
+                Spec = "55",
+                Options = new() { "50", "55", "60" }
+            });
             ProtectionSettings.Add(new ProtectionSetting { Parameter = "Over Voltage", Unit = "mV", Spec = "4200" });
             ProtectionSettings.Add(new ProtectionSetting { Parameter = "Over Current", Unit = "mA", Spec = "2000" });
         }
@@ -125,6 +131,7 @@ namespace CellManager.ViewModels
         public string Spec { get; set; } = string.Empty;
         public string Unit { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
+        public ObservableCollection<string> Options { get; } = new();
     }
 }
 

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -4,6 +4,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:converters="clr-namespace:CellManager.Converters"
              mc:Ignorable="d"
              d:DesignHeight="600" d:DesignWidth="800">
     <TabControl Margin="16"
@@ -44,6 +45,17 @@
                     </Setter.Value>
                 </Setter>
             </Style>
+
+            <DataTemplate x:Key="SpecTextBoxTemplate">
+                <TextBox Text="{Binding Spec, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+            </DataTemplate>
+            <DataTemplate x:Key="SpecComboBoxTemplate">
+                <ComboBox ItemsSource="{Binding Options}"
+                          SelectedItem="{Binding Spec, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+            </DataTemplate>
+            <converters:SpecTemplateSelector x:Key="SpecTemplateSelector"
+                                             TextBoxTemplate="{StaticResource SpecTextBoxTemplate}"
+                                             ComboBoxTemplate="{StaticResource SpecComboBoxTemplate}"/>
         </TabControl.Resources>
         <TabItem Header="Board Calibration">
             <ScrollViewer>
@@ -177,10 +189,40 @@
                                       CanUserAddRows="False"
                                       Margin="0,0,0,16">
                                 <DataGrid.Columns>
-                                    <DataGridTextColumn Header="Parameter" Binding="{Binding Parameter}" IsReadOnly="True"/>
-                                    <DataGridTextColumn Header="Spec" Binding="{Binding Spec}"/>
-                                    <DataGridTextColumn Header="Unit" Binding="{Binding Unit}"/>
-                                    <DataGridTextColumn Header="Description" Binding="{Binding Description}" IsReadOnly="True"/>
+                                    <DataGridTemplateColumn Header="Parameter" IsReadOnly="True">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding Parameter}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
+                                    <DataGridTemplateColumn Header="Spec"
+                                                            CellEditingTemplateSelector="{StaticResource SpecTemplateSelector}">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding Spec}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
+                                    <DataGridTemplateColumn Header="Unit">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding Unit}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                        <DataGridTemplateColumn.CellEditingTemplate>
+                                            <DataTemplate>
+                                                <TextBox Text="{Binding Unit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellEditingTemplate>
+                                    </DataGridTemplateColumn>
+                                    <DataGridTemplateColumn Header="Description" IsReadOnly="True">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding Description}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">


### PR DESCRIPTION
## Summary
- Support option lists in `ProtectionSetting`
- Render Spec column with TextBox or ComboBox based on available options
- Preserve edits by binding selections back to `Spec`

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c237e698b4832380dd041a87dd0c80