### PR TITLE
Validate firmware via protection profile configuration

### DIFF
--- a/CellManager/CellManager/ProtectionProfiles/1.0.json
+++ b/CellManager/CellManager/ProtectionProfiles/1.0.json
@@ -1,23 +1,26 @@
-[
-  {
-    "parameter": "Charge Over Temperature",
-    "unit": "°C",
-    "description": "Maximum charging temperature",
-    "defaultSpec": "55",
-    "options": ["45", "50", "55", "60"]
-  },
-  {
-    "parameter": "Over Voltage",
-    "unit": "mV",
-    "description": "Maximum voltage",
-    "defaultSpec": "4200",
-    "options": ["4100", "4200", "4300"]
-  },
-  {
-    "parameter": "Over Current",
-    "unit": "mA",
-    "description": "Maximum current",
-    "defaultSpec": "2000",
-    "options": ["1500", "2000", "2500"]
-  }
-]
+{
+  "version": "1.0",
+  "settings": [
+    {
+      "parameter": "Charge Over Temperature",
+      "unit": "°C",
+      "description": "Maximum charging temperature",
+      "defaultSpec": "55",
+      "options": ["45", "50", "55", "60"]
+    },
+    {
+      "parameter": "Over Voltage",
+      "unit": "mV",
+      "description": "Maximum voltage",
+      "defaultSpec": "4200",
+      "options": ["4100", "4200", "4300"]
+    },
+    {
+      "parameter": "Over Current",
+      "unit": "mA",
+      "description": "Maximum current",
+      "defaultSpec": "2000",
+      "options": ["1500", "2000", "2500"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- store firmware version alongside protection settings in profile files
- dynamically load protection profiles and validate firmware version
- show supported firmware versions in unsupported firmware messages

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c23e31b2a8832398dea16b0adb86bc