### PR TITLE
Group protection settings by category

### DIFF
--- a/CellManager/CellManager/ProtectionProfiles/1.0.json
+++ b/CellManager/CellManager/ProtectionProfiles/1.0.json
@@ -6,6 +6,7 @@
       "unit": "°C",
       "description": "Maximum charging temperature",
       "defaultSpec": "55",
+      "category": "Temperature",
       "options": ["45", "50", "55", "60"]
     },
     {
@@ -13,6 +14,7 @@
       "unit": "mV",
       "description": "Maximum voltage",
       "defaultSpec": "4200",
+      "category": "Voltage",
       "options": ["4100", "4200", "4300"]
     },
     {
@@ -20,6 +22,7 @@
       "unit": "mA",
       "description": "Maximum current",
       "defaultSpec": "2000",
+      "category": "Current",
       "options": ["1500", "2000", "2500"]
     }
   ]

--- a/CellManager/CellManager/ViewModels/ProtectionProfileLoader.cs
+++ b/CellManager/CellManager/ViewModels/ProtectionProfileLoader.cs
@@ -23,11 +23,28 @@ namespace CellManager.ViewModels
 
             var json = File.ReadAllText(path);
             var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-            var settings = JsonSerializer.Deserialize<List<ProtectionSetting>>(json, options) ?? new List<ProtectionSetting>();
-
-            foreach (var setting in settings)
+            var profile = JsonSerializer.Deserialize<ProtectionProfile>(json, options);
+            if (profile?.Settings == null)
             {
-                setting.Spec = setting.DefaultSpec;
+                return new List<ProtectionSetting>();
+            }
+
+            var settings = new List<ProtectionSetting>();
+            foreach (var s in profile.Settings)
+            {
+                var setting = new ProtectionSetting
+                {
+                    Parameter = s.Parameter,
+                    Spec = s.Spec,
+                    Unit = s.Unit,
+                    Description = s.Description,
+                    Category = s.Category
+                };
+                foreach (var option in s.Options)
+                {
+                    setting.Options.Add(option);
+                }
+                settings.Add(setting);
             }
 
             return settings;

--- a/CellManager/CellManager/ViewModels/SettingsViewModel.cs
+++ b/CellManager/CellManager/ViewModels/SettingsViewModel.cs
@@ -133,6 +133,7 @@ namespace CellManager.ViewModels
         public string Spec { get; set; } = string.Empty;
         public string Unit { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
+        public string Category { get; set; } = string.Empty;
         public ObservableCollection<string> Options { get; } = new();
     }
 
@@ -148,6 +149,7 @@ namespace CellManager.ViewModels
         [JsonPropertyName("unit")] public string Unit { get; set; } = string.Empty;
         [JsonPropertyName("description")] public string Description { get; set; } = string.Empty;
         [JsonPropertyName("defaultSpec")] public string Spec { get; set; } = string.Empty;
+        [JsonPropertyName("category")] public string Category { get; set; } = string.Empty;
         [JsonPropertyName("options")] public List<string> Options { get; set; } = new();
     }
 
@@ -175,7 +177,8 @@ namespace CellManager.ViewModels
                             Parameter = s.Parameter,
                             Spec = s.Spec,
                             Unit = s.Unit,
-                            Description = s.Description
+                            Description = s.Description,
+                            Category = s.Category
                         };
                         foreach (var option in s.Options)
                         {

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -174,6 +174,13 @@
             <ScrollViewer>
                 <StackPanel Margin="16">
                     <materialDesign:Card Margin="0,0,0,16" Padding="16">
+                        <materialDesign:Card.Resources>
+                            <CollectionViewSource x:Key="ProtectionSettingsGrouped" Source="{Binding ProtectionSettings}">
+                                <CollectionViewSource.GroupDescriptions>
+                                    <PropertyGroupDescription PropertyName="Category" />
+                                </CollectionViewSource.GroupDescriptions>
+                            </CollectionViewSource>
+                        </materialDesign:Card.Resources>
                         <StackPanel>
                             <TextBlock Text="Protection Settings"
                                        Style="{StaticResource MaterialDesignHeadline6TextBlock}"
@@ -183,7 +190,7 @@
                                      Text="{Binding FirmwareVersion}"
                                      Width="200"
                                      Margin="0,0,0,16"/>
-                            <DataGrid ItemsSource="{Binding ProtectionSettings}"
+                            <DataGrid ItemsSource="{Binding Source={StaticResource ProtectionSettingsGrouped}}"
                                       AutoGenerateColumns="False"
                                       HeadersVisibility="Column"
                                       CanUserAddRows="False"
@@ -224,6 +231,15 @@
                                         </DataGridTemplateColumn.CellTemplate>
                                     </DataGridTemplateColumn>
                                 </DataGrid.Columns>
+                                <DataGrid.GroupStyle>
+                                    <GroupStyle>
+                                        <GroupStyle.HeaderTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding Name}" FontWeight="Bold" />
+                                            </DataTemplate>
+                                        </GroupStyle.HeaderTemplate>
+                                    </GroupStyle>
+                                </DataGrid.GroupStyle>
                             </DataGrid>
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                                 <Button Content="Read" Command="{Binding ReadProtectionCommand}" Width="80" Margin="0,0,8,0"/>


### PR DESCRIPTION
## Summary
- add Category field to protection setting models and load from versioned profiles
- group settings by category in SettingsView DataGrid
- specify categories in default 1.0 protection profile

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c23f59597c8323a45e3bc48e8c3bc1