### PR TITLE
feat: versioned protection profiles

### DIFF
--- a/CellManager/CellManager/CellManager.csproj
+++ b/CellManager/CellManager/CellManager.csproj
@@ -30,4 +30,10 @@
     <PackageReference Include="Extended.Wpf.Toolkit" Version="4.5.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="ProtectionProfiles\**\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/CellManager/CellManager/ProtectionProfiles/1.0.json
+++ b/CellManager/CellManager/ProtectionProfiles/1.0.json
@@ -1,0 +1,5 @@
+[
+  {"parameter": "Charge Over Temperature", "spec": "55", "unit": "°C", "description": ""},
+  {"parameter": "Over Voltage", "spec": "4200", "unit": "mV", "description": ""},
+  {"parameter": "Over Current", "spec": "2000", "unit": "mA", "description": ""}
+]

--- a/CellManager/CellManager/Services/ProtectionProfileLoader.cs
+++ b/CellManager/CellManager/Services/ProtectionProfileLoader.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using CellManager.ViewModels;
+
+namespace CellManager.Services
+{
+    public class ProtectionProfileLoader
+    {
+        private readonly string _profilesPath;
+
+        public ProtectionProfileLoader()
+        {
+            _profilesPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ProtectionProfiles");
+        }
+
+        public bool Exists(string version)
+        {
+            var filePath = Path.Combine(_profilesPath, $"{version}.json");
+            return File.Exists(filePath);
+        }
+
+        public IEnumerable<ProtectionSetting>? Load(string version)
+        {
+            var filePath = Path.Combine(_profilesPath, $"{version}.json");
+            if (!File.Exists(filePath))
+            {
+                return null;
+            }
+
+            var json = File.ReadAllText(filePath);
+            return JsonSerializer.Deserialize<List<ProtectionSetting>>(json);
+        }
+
+        public IEnumerable<string> GetAvailableVersions()
+        {
+            if (!Directory.Exists(_profilesPath))
+            {
+                return Array.Empty<string>();
+            }
+
+            return Directory.GetFiles(_profilesPath, "*.json")
+                .Select(Path.GetFileNameWithoutExtension);
+        }
+    }
+}

--- a/CellManager/CellManager/ViewModels/SettingsViewModel.cs
+++ b/CellManager/CellManager/ViewModels/SettingsViewModel.cs
@@ -1,5 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using System.Collections.ObjectModel;
+using System.Windows;
+using CellManager.Services;
 
 namespace CellManager.ViewModels
 {
@@ -54,17 +57,83 @@ namespace CellManager.ViewModels
         [ObservableProperty]
         private bool _enableDarkTheme;
 
+        // Protection profile
+        [ObservableProperty]
+        private string _protectionSheetVersion = string.Empty;
+
         public ObservableCollection<BoardSettingData> BoardSettingsData { get; } = new()
         {
             new BoardSettingData { Parameter = "Firmware Version", Value = "1.0" },
             new BoardSettingData { Parameter = "Serial Number", Value = "123456" }
         };
+
+        public ObservableCollection<ProtectionSetting> ProtectionSettings { get; } = new();
+
+        public RelayCommand ReadProtectionCommand { get; }
+        public RelayCommand WriteProtectionCommand { get; }
+
+        private readonly ProtectionProfileLoader _profileLoader = new();
+
+        public SettingsViewModel()
+        {
+            ReadProtectionCommand = new RelayCommand(ReadProtectionSettings, CanReadWriteProtection);
+            WriteProtectionCommand = new RelayCommand(WriteProtectionSettings, CanReadWriteProtection);
+        }
+
+        private bool CanReadWriteProtection() => _profileLoader.Exists(ProtectionSheetVersion);
+
+        private void ReadProtectionSettings()
+        {
+            if (!CanReadWriteProtection())
+            {
+                MessageBox.Show("Unsupported protection sheet version.");
+                return;
+            }
+
+            var profile = _profileLoader.Load(ProtectionSheetVersion);
+            if (profile == null)
+            {
+                MessageBox.Show("Failed to load protection profile.");
+                return;
+            }
+
+            ProtectionSettings.Clear();
+            foreach (var item in profile)
+            {
+                ProtectionSettings.Add(item);
+            }
+        }
+
+        private void WriteProtectionSettings()
+        {
+            if (!CanReadWriteProtection())
+            {
+                MessageBox.Show("Unsupported protection sheet version.");
+                return;
+            }
+
+            // Placeholder for writing logic
+        }
+
+        partial void OnProtectionSheetVersionChanged(string value)
+        {
+            ReadProtectionCommand.NotifyCanExecuteChanged();
+            WriteProtectionCommand.NotifyCanExecuteChanged();
+        }
     }
 
     public class BoardSettingData
     {
         public string Parameter { get; set; } = string.Empty;
         public string Value { get; set; } = string.Empty;
+    }
+
+    public class ProtectionSetting
+    {
+        public string Parameter { get; set; } = string.Empty;
+        public string Spec { get; set; } = string.Empty;
+        public string Unit { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
     }
 }
 

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -158,6 +158,41 @@
             </ScrollViewer>
         </TabItem>
 
+        <TabItem Header="Protection">
+            <ScrollViewer>
+                <StackPanel Margin="16">
+                    <materialDesign:Card Margin="0,0,0,16" Padding="16">
+                        <StackPanel>
+                            <TextBlock Text="Protection Settings"
+                                       Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                                       Margin="0,0,0,16"/>
+                            <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                     materialDesign:HintAssist.Hint="Protection Sheet Version"
+                                     Text="{Binding ProtectionSheetVersion}"
+                                     Width="200"
+                                     Margin="0,0,0,16"/>
+                            <DataGrid ItemsSource="{Binding ProtectionSettings}"
+                                      AutoGenerateColumns="False"
+                                      HeadersVisibility="Column"
+                                      CanUserAddRows="False"
+                                      Margin="0,0,0,16">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Header="Parameter" Binding="{Binding Parameter}" IsReadOnly="True"/>
+                                    <DataGridTextColumn Header="Spec" Binding="{Binding Spec}"/>
+                                    <DataGridTextColumn Header="Unit" Binding="{Binding Unit}"/>
+                                    <DataGridTextColumn Header="Description" Binding="{Binding Description}" IsReadOnly="True"/>
+                                </DataGrid.Columns>
+                            </DataGrid>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                <Button Content="Read" Command="{Binding ReadProtectionCommand}" Width="80" Margin="0,0,8,0"/>
+                                <Button Content="Write" Command="{Binding WriteProtectionCommand}" Width="80"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </materialDesign:Card>
+                </StackPanel>
+            </ScrollViewer>
+        </TabItem>
+
         <TabItem Header="System">
             <ScrollViewer>
                 <StackPanel Margin="16">


### PR DESCRIPTION
## Summary
- load protection settings from versioned profile files
- gate read/write actions on selected protection sheet version
- package profile data with application

## Testing
- `dotnet test CellManager/CellManager.sln`

------
https://chatgpt.com/codex/tasks/task_e_68c22f583dac8323ba9f24a32fdc777c