### PR TITLE
feat: add configurable board data

### DIFF
--- a/CellManager/CellManager/BoardDataProfiles/boarddata.json
+++ b/CellManager/CellManager/BoardDataProfiles/boarddata.json
@@ -1,0 +1,26 @@
+{
+  "settings": [
+    { "parameter": "SMBus Slave Address", "unit": "", "description": "", "defaultSpec": "", "category": "System Information" },
+    { "parameter": "Board Name", "unit": "", "description": "", "defaultSpec": "", "category": "System Information" },
+    { "parameter": "Serial Number", "unit": "", "description": "", "defaultSpec": "", "category": "System Information" },
+    { "parameter": "Consumption Current of Discharge", "unit": "mA", "description": "", "defaultSpec": "", "category": "System Information" },
+    { "parameter": "Mask Current", "unit": "mA", "description": "", "defaultSpec": "", "category": "System Information" },
+    { "parameter": "-40degC", "unit": "Ω", "description": "", "defaultSpec": "", "category": "Thermistor resistance Table" },
+    { "parameter": "-30degC", "unit": "Ω", "description": "", "defaultSpec": "", "category": "Thermistor resistance Table" },
+    { "parameter": "-20degC", "unit": "Ω", "description": "", "defaultSpec": "", "category": "Thermistor resistance Table" },
+    { "parameter": "-10degC", "unit": "Ω", "description": "", "defaultSpec": "", "category": "Thermistor resistance Table" },
+    { "parameter": "0degC", "unit": "Ω", "description": "", "defaultSpec": "", "category": "Thermistor resistance Table" },
+    { "parameter": "10degC", "unit": "Ω", "description": "", "defaultSpec": "", "category": "Thermistor resistance Table" },
+    { "parameter": "20degC", "unit": "Ω", "description": "", "defaultSpec": "", "category": "Thermistor resistance Table" },
+    { "parameter": "30degC", "unit": "Ω", "description": "", "defaultSpec": "", "category": "Thermistor resistance Table" },
+    { "parameter": "40degC", "unit": "Ω", "description": "", "defaultSpec": "", "category": "Thermistor resistance Table" },
+    { "parameter": "50degC", "unit": "Ω", "description": "", "defaultSpec": "", "category": "Thermistor resistance Table" },
+    { "parameter": "60degC", "unit": "Ω", "description": "", "defaultSpec": "", "category": "Thermistor resistance Table" },
+    { "parameter": "70degC", "unit": "Ω", "description": "", "defaultSpec": "", "category": "Thermistor resistance Table" },
+    { "parameter": "80degC", "unit": "Ω", "description": "", "defaultSpec": "", "category": "Thermistor resistance Table" },
+    { "parameter": "90degC", "unit": "Ω", "description": "", "defaultSpec": "", "category": "Thermistor resistance Table" },
+    { "parameter": "100degC", "unit": "Ω", "description": "", "defaultSpec": "", "category": "Thermistor resistance Table" },
+    { "parameter": "110degC", "unit": "Ω", "description": "", "defaultSpec": "", "category": "Thermistor resistance Table" },
+    { "parameter": "120degC", "unit": "Ω", "description": "", "defaultSpec": "", "category": "Thermistor resistance Table" }
+  ]
+}

--- a/CellManager/CellManager/CellManager.csproj
+++ b/CellManager/CellManager/CellManager.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <None Include="ProtectionProfiles\**\*.json" CopyToOutputDirectory="Always" />
+    <None Include="BoardDataProfiles\**\*.json" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -150,20 +150,71 @@
             <ScrollViewer>
                 <StackPanel Margin="16">
                     <materialDesign:Card Margin="0,0,0,16" Padding="16">
+                        <materialDesign:Card.Resources>
+                            <CollectionViewSource x:Key="BoardDataSettingsGrouped" Source="{Binding BoardDataSettings}">
+                                <CollectionViewSource.GroupDescriptions>
+                                    <PropertyGroupDescription PropertyName="Category" />
+                                </CollectionViewSource.GroupDescriptions>
+                            </CollectionViewSource>
+                        </materialDesign:Card.Resources>
                         <StackPanel>
                             <TextBlock Text="Board Settings Data"
                                        Style="{StaticResource MaterialDesignHeadline6TextBlock}"
                                        Margin="0,0,0,16"/>
-                            <DataGrid ItemsSource="{Binding BoardSettingsData}"
+                            <DataGrid ItemsSource="{Binding Source={StaticResource BoardDataSettingsGrouped}}"
                                       AutoGenerateColumns="False"
                                       HeadersVisibility="Column"
                                       CanUserAddRows="False"
-                                      Margin="0,0,0,8">
+                                      Margin="0,0,0,16">
                                 <DataGrid.Columns>
-                                    <DataGridTextColumn Header="Parameter" Binding="{Binding Parameter}"/>
-                                    <DataGridTextColumn Header="Value" Binding="{Binding Value}"/>
+                                    <DataGridTemplateColumn Header="Parameter Name" IsReadOnly="True">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding Parameter}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
+                                    <DataGridTemplateColumn Header="Spec" CellEditingTemplateSelector="{StaticResource SpecTemplateSelector}">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding Spec}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
+                                    <DataGridTemplateColumn Header="Unit">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding Unit}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                        <DataGridTemplateColumn.CellEditingTemplate>
+                                            <DataTemplate>
+                                                <TextBox Text="{Binding Unit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellEditingTemplate>
+                                    </DataGridTemplateColumn>
+                                    <DataGridTemplateColumn Header="Description" IsReadOnly="True">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding Description}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
                                 </DataGrid.Columns>
+                                <DataGrid.GroupStyle>
+                                    <GroupStyle>
+                                        <GroupStyle.HeaderTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding Name}" FontWeight="Bold" />
+                                            </DataTemplate>
+                                        </GroupStyle.HeaderTemplate>
+                                    </GroupStyle>
+                                </DataGrid.GroupStyle>
                             </DataGrid>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                <Button Content="Read" Command="{Binding ReadBoardDataCommand}" Width="80" Margin="0,0,8,0"/>
+                                <Button Content="Write" Command="{Binding WriteBoardDataCommand}" Width="80"/>
+                            </StackPanel>
                         </StackPanel>
                     </materialDesign:Card>
                 </StackPanel>


### PR DESCRIPTION
## Summary
- load Board Data from external JSON profiles
- allow editing Board Data with read/write commands
- expose Board Data table with spec/unit/description columns

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c245f0733883239f5bd12566b62265