### PR TITLE
Show board version and running schedule in status bar

### DIFF
--- a/CellManager/CellManager/MainWindow.xaml
+++ b/CellManager/CellManager/MainWindow.xaml
@@ -94,7 +94,16 @@
         <Border Grid.Row="0" Grid.ColumnSpan="2" Background="#F8F8F8" BorderBrush="#E0E0E0" BorderThickness="1,1,1,1">
             <StackPanel Orientation="Horizontal" Margin="20,10">
                 <materialDesign:PackIcon Kind="DeveloperBoard" />
-                <TextBlock Text="{Binding BoardStatus}" VerticalAlignment="Center" Margin="0,0,50,0"/>
+                <TextBlock Text="{Binding BoardStatus}" VerticalAlignment="Center" Margin="0,0,20,0"/>
+
+                <materialDesign:PackIcon Kind="Information" />
+                <TextBlock Text="{Binding BoardVersion}" VerticalAlignment="Center" Margin="0,0,20,0"/>
+
+                <materialDesign:PackIcon Kind="CalendarClock" />
+                <TextBlock Text="{Binding CurrentSchedule}" VerticalAlignment="Center" Margin="0,0,20,0"/>
+
+                <materialDesign:PackIcon Kind="ClipboardText" />
+                <TextBlock Text="{Binding CurrentProfile}" VerticalAlignment="Center" Margin="0,0,20,0"/>
 
                 <materialDesign:PackIcon Kind="Battery" />
                 <TextBlock Text="{Binding SelectedCell.DisplayNameAndId}" VerticalAlignment="Center" Foreground="#007ACC" FontWeight="Bold"/>

--- a/CellManager/CellManager/Messages/BoardVersionChangedMessage.cs
+++ b/CellManager/CellManager/Messages/BoardVersionChangedMessage.cs
@@ -1,0 +1,11 @@
+using CommunityToolkit.Mvvm.Messaging.Messages;
+
+namespace CellManager.Messages
+{
+    public class BoardVersionChangedMessage : ValueChangedMessage<string>
+    {
+        public BoardVersionChangedMessage(string version) : base(version) { }
+
+        public string Version => Value;
+    }
+}

--- a/CellManager/CellManager/Messages/ProfileChangedMessage.cs
+++ b/CellManager/CellManager/Messages/ProfileChangedMessage.cs
@@ -1,0 +1,11 @@
+using CommunityToolkit.Mvvm.Messaging.Messages;
+
+namespace CellManager.Messages
+{
+    public class ProfileChangedMessage : ValueChangedMessage<string>
+    {
+        public ProfileChangedMessage(string profile) : base(profile) { }
+
+        public string Profile => Value;
+    }
+}

--- a/CellManager/CellManager/Messages/ScheduleChangedMessage.cs
+++ b/CellManager/CellManager/Messages/ScheduleChangedMessage.cs
@@ -1,0 +1,12 @@
+using CellManager.Models;
+using CommunityToolkit.Mvvm.Messaging.Messages;
+
+namespace CellManager.Messages
+{
+    public class ScheduleChangedMessage : ValueChangedMessage<Schedule?>
+    {
+        public ScheduleChangedMessage(Schedule? schedule) : base(schedule) { }
+
+        public Schedule? Schedule => Value;
+    }
+}

--- a/CellManager/CellManager/ViewModels/MainViewModel.cs
+++ b/CellManager/CellManager/ViewModels/MainViewModel.cs
@@ -27,6 +27,9 @@ namespace CellManager.ViewModels
 
         [ObservableProperty] private string _boardStatus = "Disconnected";
         [ObservableProperty] private string _serverStatus = "Disconnected";
+        [ObservableProperty] private string _boardVersion = string.Empty;
+        [ObservableProperty] private string _currentSchedule = string.Empty;
+        [ObservableProperty] private string _currentProfile = string.Empty;
 
         [ObservableProperty] private ObservableCollection<ObservableObject> _navigationItems = new();
         [ObservableProperty] private ObservableObject _currentViewModel;
@@ -54,6 +57,7 @@ namespace CellManager.ViewModels
             _scheduleVm = scheduleVm;
             _runVm = runVm;
             _serverStatusService = serverStatusService;
+            BoardVersion = settingsVm.FirmwareVersion;
 
             NavigationItems.Add(homeVm);
             NavigationItems.Add(cellLibraryVm);
@@ -89,6 +93,21 @@ namespace CellManager.ViewModels
                 var target = AvailableCells.FirstOrDefault(c => c.Id == m.DeletedCell.Id);
                 if (target != null) AvailableCells.Remove(target);
                 if (SelectedCell?.Id == m.DeletedCell.Id) SelectedCell = null;
+            });
+
+            WeakReferenceMessenger.Default.Register<BoardVersionChangedMessage>(this, (r, m) =>
+            {
+                BoardVersion = m.Version;
+            });
+
+            WeakReferenceMessenger.Default.Register<ScheduleChangedMessage>(this, (r, m) =>
+            {
+                CurrentSchedule = m.Schedule?.DisplayNameAndId ?? string.Empty;
+            });
+
+            WeakReferenceMessenger.Default.Register<ProfileChangedMessage>(this, (r, m) =>
+            {
+                CurrentProfile = m.Profile;
             });
         }
 

--- a/CellManager/CellManager/ViewModels/RunViewModel.cs
+++ b/CellManager/CellManager/ViewModels/RunViewModel.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using CellManager.Models;
+using CellManager.Messages;
 
 namespace CellManager.ViewModels
 {
@@ -38,6 +40,9 @@ namespace CellManager.ViewModels
         private int _currentStep;
 
         [ObservableProperty]
+        private string _currentProfile = string.Empty;
+
+        [ObservableProperty]
         private TimeSpan _elapsedTime;
 
         [ObservableProperty]
@@ -51,9 +56,27 @@ namespace CellManager.ViewModels
 
         public RunViewModel()
         {
-            StartCommand = new RelayCommand(() => { });
+            StartCommand = new RelayCommand(StartSchedule);
             PauseCommand = new RelayCommand(() => { });
             StopCommand = new RelayCommand(() => { });
+        }
+
+        private void StartSchedule()
+        {
+            if (SelectedSchedule != null)
+            {
+                WeakReferenceMessenger.Default.Send(new ScheduleChangedMessage(SelectedSchedule));
+
+                if (SelectedSchedule.TestProfileIds.Count > 0)
+                {
+                    CurrentProfile = $"Profile ID: {SelectedSchedule.TestProfileIds[0]}";
+                }
+            }
+        }
+
+        partial void OnCurrentProfileChanged(string value)
+        {
+            WeakReferenceMessenger.Default.Send(new ProfileChangedMessage(value));
         }
     }
 }

--- a/CellManager/CellManager/ViewModels/SettingsViewModel.cs
+++ b/CellManager/CellManager/ViewModels/SettingsViewModel.cs
@@ -1,11 +1,13 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Windows;
+using CellManager.Messages;
 
 namespace CellManager.ViewModels
 {
@@ -62,7 +64,7 @@ namespace CellManager.ViewModels
 
         // Firmware
         [ObservableProperty]
-        private string _firmwareVersion = string.Empty;
+        private string _firmwareVersion = "1.0";
 
         public ObservableCollection<BoardSettingData> BoardSettingsData { get; } = new()
         {
@@ -118,6 +120,7 @@ namespace CellManager.ViewModels
         {
             ReadProtectionCommand.NotifyCanExecuteChanged();
             WriteProtectionCommand.NotifyCanExecuteChanged();
+            WeakReferenceMessenger.Default.Send(new BoardVersionChangedMessage(value));
         }
     }
 


### PR DESCRIPTION
## Summary
- add board version, schedule, and profile info to MainWindow status bar
- track board version and running schedule/profile in MainViewModel
- broadcast status updates through new messenger messages

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2465cf3908323a52f82567b58e26e