### PR TITLE
Add linear calibration helper and UI

### DIFF
--- a/CellManager/CellManager.Tests/CalibrationServiceTests.cs
+++ b/CellManager/CellManager.Tests/CalibrationServiceTests.cs
@@ -1,0 +1,25 @@
+using CellManager.Services;
+using Xunit;
+
+namespace CellManager.Tests
+{
+    public class CalibrationServiceTests
+    {
+        [Fact]
+        public void CalculateLinearCalibration_ComputesGainAndOffset()
+        {
+            var result = CalibrationService.CalculateLinearCalibration(1000, 950, 4000, 3900);
+            Assert.NotNull(result);
+            var (gain, offset) = result!.Value;
+            Assert.Equal(1.016949, gain, 6);
+            Assert.Equal(33.898305, offset, 6);
+        }
+
+        [Fact]
+        public void CalculateLinearCalibration_ReturnsNullWhenMeasurementsEqual()
+        {
+            var result = CalibrationService.CalculateLinearCalibration(1000, 1000, 4000, 1000);
+            Assert.Null(result);
+        }
+    }
+}

--- a/CellManager/CellManager.Tests/CellManager.Tests.csproj
+++ b/CellManager/CellManager.Tests/CellManager.Tests.csproj
@@ -41,6 +41,7 @@
     <Compile Include="../CellManager/Models/ScheduleTimeCalculator.cs" Link="Models/ScheduleTimeCalculator.cs" />
     <Compile Include="../CellManager/Messages/CellSelectedMessage.cs" Link="Messages/CellSelectedMessage.cs" />
     <Compile Include="../CellManager/ViewModels/ScheduleViewModel.cs" Link="ViewModels/ScheduleViewModel.cs" />
+    <Compile Include="../CellManager/Services/CalibrationService.cs" Link="Services/CalibrationService.cs" />
   </ItemGroup>
 
 </Project>

--- a/CellManager/CellManager/Services/CalibrationService.cs
+++ b/CellManager/CellManager/Services/CalibrationService.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace CellManager.Services
+{
+    /// <summary>
+    /// Provides helper methods for calculating linear calibration values
+    /// from reference and measured readings.
+    /// </summary>
+    public static class CalibrationService
+    {
+        /// <summary>
+        /// Calculates a linear gain and offset given two reference points.
+        /// </summary>
+        /// <param name="referenceLow">The reference value for the low reading.</param>
+        /// <param name="actualLow">The actual measured value for the low reading.</param>
+        /// <param name="referenceHigh">The reference value for the high reading.</param>
+        /// <param name="actualHigh">The actual measured value for the high reading.</param>
+        /// <returns>
+        /// A tuple containing gain and offset that maps measured values to reference values,
+        /// or <c>null</c> if the calculation cannot be performed.
+        /// </returns>
+        public static (double Gain, double Offset)? CalculateLinearCalibration(
+            double referenceLow,
+            double actualLow,
+            double referenceHigh,
+            double actualHigh)
+        {
+            var denominator = actualHigh - actualLow;
+            if (Math.Abs(denominator) < double.Epsilon)
+            {
+                return null;
+            }
+
+            var gain = (referenceHigh - referenceLow) / denominator;
+            var offset = referenceLow - gain * actualLow;
+            return (gain, offset);
+        }
+    }
+}

--- a/CellManager/CellManager/ViewModels/SettingsViewModel.cs
+++ b/CellManager/CellManager/ViewModels/SettingsViewModel.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Windows;
 using CellManager.Messages;
+using CellManager.Services;
 
 namespace CellManager.ViewModels
 {
@@ -35,6 +36,9 @@ namespace CellManager.ViewModels
 
         [ObservableProperty]
         private string _voltageHighResult = "0";
+
+        [ObservableProperty]
+        private string _voltageCalibrationResult = string.Empty;
 
         [ObservableProperty]
         private string _currentReference = "500";
@@ -123,6 +127,25 @@ namespace CellManager.ViewModels
             }
 
             // Placeholder for writing logic
+        }
+
+        [RelayCommand]
+        private void CalculateVoltageCalibration()
+        {
+            if (double.TryParse(VoltageLowReference, out var refLow)
+                && double.TryParse(VoltageLowResult, out var resLow)
+                && double.TryParse(VoltageHighReference, out var refHigh)
+                && double.TryParse(VoltageHighResult, out var resHigh))
+            {
+                var result = CalibrationService.CalculateLinearCalibration(refLow, resLow, refHigh, resHigh);
+                VoltageCalibrationResult = result.HasValue
+                    ? $"Gain: {result.Value.Gain:F6}, Offset: {result.Value.Offset:F2}"
+                    : "Invalid input";
+            }
+            else
+            {
+                VoltageCalibrationResult = "Invalid input";
+            }
         }
 
         partial void OnFirmwareVersionChanged(string value)

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -94,6 +94,11 @@
                                                      Text="{Binding VoltageHighResult}"
                                                      Width="120"/>
                                         </StackPanel>
+                                        <Button Content="Calculate"
+                                                Command="{Binding CalculateVoltageCalibrationCommand}"
+                                                Width="80" Margin="0,8,0,0"/>
+                                        <TextBlock Text="{Binding VoltageCalibrationResult}"
+                                                   Margin="0,8,0,0"/>
                                     </StackPanel>
                                 </materialDesign:Card>
 


### PR DESCRIPTION
## Summary
- add `CalibrationService` for linear gain/offset computation from two voltage measurements
- expose calibration button and result display in settings view
- include unit tests validating calibration math

## Testing
- `dotnet test CellManager/CellManager.Tests/CellManager.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c2510d799483239c6f66481ea42ac7