### PR TITLE
Expand duration column in schedule list to prevent clipping

### DIFF
--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -189,9 +189,9 @@
                         </ListView.ItemContainerStyle>
                         <ListView.View>
                             <GridView>
-                                <GridViewColumn Header="Script" DisplayMemberBinding="{Binding Ordering}" Width="50"/>
+                                <GridViewColumn Header="Script" DisplayMemberBinding="{Binding Ordering}" Width="45"/>
                                 <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Name}"/>
-                                <GridViewColumn Header="Duration" Width="52">
+                                <GridViewColumn Header="Duration" Width="80">
                                     <GridViewColumn.CellTemplate>
                                         <DataTemplate>
                                             <TextBlock Text="{Binding EstimatedDuration, StringFormat='{}{0:hh\\:mm\\:ss}'}"/>

--- a/CellManager/CellManager/Views/ScheduleView.xaml.cs
+++ b/CellManager/CellManager/Views/ScheduleView.xaml.cs
@@ -107,9 +107,9 @@ namespace CellManager.Views
 
             if (gridView.Columns.Count >= 3)
             {
-                gridView.Columns[0].Width = workingWidth * 0.2;
-                gridView.Columns[1].Width = workingWidth * 0.6;
-                gridView.Columns[2].Width = workingWidth * 0.2;
+                gridView.Columns[0].Width = workingWidth * 0.15;
+                gridView.Columns[1].Width = workingWidth * 0.60;
+                gridView.Columns[2].Width = workingWidth * 0.25;
             }
         }
 


### PR DESCRIPTION
## Summary
- Widen schedule list columns and adjust resize logic to give the duration field more space, avoiding truncated times.

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c3bbeb1f888323834cdaed81c76d42