### PR TITLE
Fix white text in Settings tab content

### DIFF
--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -31,14 +31,14 @@
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsSelected" Value="True">
                                     <Setter TargetName="Border" Property="Background" Value="{StaticResource PrimaryMain}"/>
-                                    <Setter TargetName="ContentSite" Property="Foreground" Value="White"/>
+                                    <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="White"/>
                                 </Trigger>
                                 <Trigger Property="IsMouseOver" Value="True">
                                     <Setter TargetName="Border" Property="Background" Value="{StaticResource PrimaryHover}"/>
-                                    <Setter TargetName="ContentSite" Property="Foreground" Value="White"/>
+                                    <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="White"/>
                                 </Trigger>
                                 <Trigger Property="IsEnabled" Value="False">
-                                    <Setter TargetName="ContentSite" Property="Foreground" Value="#9E9E9E"/>
+                                    <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="#9E9E9E"/>
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>


### PR DESCRIPTION
## Summary
- keep tab content text visible by limiting foreground changes to tab headers

## Testing
- `dotnet test CellManager/CellManager.Tests/CellManager.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c3bcd7221083238e75f14b9b1a8b28