### PR TITLE
Simplify add and save icons

### DIFF
--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -79,11 +79,10 @@
                             <!-- 오른쪽: 버튼 -->
                         </Grid.ColumnDefinitions>
                         <TextBlock Grid.Column="0" Text="Schedules List" FontWeight="Bold" FontSize="15" VerticalAlignment="Top" HorizontalAlignment="Left"/>
-                        <Button Grid.Column="1" Style="{StaticResource PrimaryActionButton}" Padding="6"
+                        <Button Grid.Column="1" Width="32" Height="32" Background="White" Padding="0"
                                 Command="{Binding AddScheduleCommand}" VerticalAlignment="Center" HorizontalAlignment="Right">
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
-                                <materialDesign:PackIcon Kind="Plus" Width="18" Height="18" Foreground="#00589E"/>
-                            </StackPanel>
+                            <materialDesign:PackIcon Kind="Plus" Width="18" Height="18" Foreground="#00589E"
+                                                         HorizontalAlignment="Center" VerticalAlignment="Center"/>
                         </Button>
                     </Grid>
                     <ListView x:Name="ScheduleList" DockPanel.Dock="Bottom"
@@ -290,9 +289,10 @@
                                     </Style>
                                 </TextBox.Style>
                             </TextBox>
-                            <Button Command="{Binding SaveScheduleCommand}" Padding="2" Height="25">
+                            <Button Command="{Binding SaveScheduleCommand}" Width="32" Height="32" Padding="0">
                                 <Button.Style>
-                                    <Style BasedOn="{StaticResource PrimaryActionButton}" TargetType="Button">
+                                    <Style TargetType="Button">
+                                        <Setter Property="Background" Value="White"/>
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding SelectedSchedule}" Value="{x:Null}">
                                                 <Setter Property="IsEnabled" Value="False"/>
@@ -300,7 +300,8 @@
                                         </Style.Triggers>
                                     </Style>
                                 </Button.Style>
-                                <materialDesign:PackIcon Kind="ContentSave" Width="18" Height="18" Foreground="#00589E"/>
+                                <materialDesign:PackIcon Kind="ContentSave" Width="18" Height="18" Foreground="#00589E"
+                                                         HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Button>
                         </StackPanel>
                         <Grid>

--- a/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
@@ -44,12 +44,10 @@
                             </StackPanel>
 
                             <!-- 버튼 -->
-                            <Button Grid.Column="1"
-                    Style="{StaticResource PrimaryActionButton}"
-                    Command="{Binding AddChargeProfileCommand}" Padding="6">
-                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                    <materialDesign:PackIcon Kind="Plus" Width="18" Height="18" Foreground="#00589E"/>
-                                </StackPanel>
+                            <Button Grid.Column="1" Width="32" Height="32" Background="White" Padding="0"
+                                    Command="{Binding AddChargeProfileCommand}" VerticalAlignment="Center" HorizontalAlignment="Right">
+                                <materialDesign:PackIcon Kind="Plus" Width="18" Height="18" Foreground="#00589E"
+                                                         HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Button>
                         </Grid>
                         <ListBox Style="{StaticResource ProfileListBox}"
@@ -152,12 +150,10 @@
                             </StackPanel>
 
                             <!-- 버튼 -->
-                            <Button Grid.Column="1"
-                    Style="{StaticResource PrimaryActionButton}"
-                    Command="{Binding AddDischargeProfileCommand}" Padding="6">
-                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                    <materialDesign:PackIcon Kind="Plus" Width="18" Height="18" Foreground="#00589E"/>
-                                </StackPanel>
+                            <Button Grid.Column="1" Width="32" Height="32" Background="White" Padding="0"
+                                    Command="{Binding AddDischargeProfileCommand}" VerticalAlignment="Center" HorizontalAlignment="Right">
+                                <materialDesign:PackIcon Kind="Plus" Width="18" Height="18" Foreground="#00589E"
+                                                         HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Button>
                         </Grid>
                         <ListBox Style="{StaticResource ProfileListBox}"
@@ -260,12 +256,10 @@
                             </StackPanel>
 
                             <!-- 버튼 -->
-                            <Button Grid.Column="1"
-                    Style="{StaticResource PrimaryActionButton}"
-                    Command="{Binding AddRestProfileCommand}" Padding="6">
-                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                    <materialDesign:PackIcon Kind="Plus" Width="18" Height="18" Foreground="#00589E"/>
-                                </StackPanel>
+                            <Button Grid.Column="1" Width="32" Height="32" Background="White" Padding="0"
+                                    Command="{Binding AddRestProfileCommand}" VerticalAlignment="Center" HorizontalAlignment="Right">
+                                <materialDesign:PackIcon Kind="Plus" Width="18" Height="18" Foreground="#00589E"
+                                                         HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Button>
                         </Grid>
                         <ListBox Style="{StaticResource ProfileListBox}"
@@ -351,12 +345,10 @@
                             </StackPanel>
 
                             <!-- 버튼 -->
-                            <Button Grid.Column="1"
-                    Style="{StaticResource PrimaryActionButton}"
-                    Command="{Binding AddOcvProfileCommand}" Padding="6">
-                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                    <materialDesign:PackIcon Kind="Plus" Width="18" Height="18" Foreground="#00589E"/>
-                                </StackPanel>
+                            <Button Grid.Column="1" Width="32" Height="32" Background="White" Padding="0"
+                                    Command="{Binding AddOcvProfileCommand}" VerticalAlignment="Center" HorizontalAlignment="Right">
+                                <materialDesign:PackIcon Kind="Plus" Width="18" Height="18" Foreground="#00589E"
+                                                         HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Button>
                         </Grid>
                         <ListBox Style="{StaticResource ProfileListBox}"
@@ -442,12 +434,10 @@
                             </StackPanel>
 
                             <!-- 버튼 -->
-                            <Button Grid.Column="1"
-                    Style="{StaticResource PrimaryActionButton}"
-                    Command="{Binding AddEcmProfileCommand}" Padding="6">
-                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                    <materialDesign:PackIcon Kind="Plus" Width="18" Height="18" Foreground="#00589E"/>
-                                </StackPanel>
+                            <Button Grid.Column="1" Width="32" Height="32" Background="White" Padding="0"
+                                    Command="{Binding AddEcmProfileCommand}" VerticalAlignment="Center" HorizontalAlignment="Right">
+                                <materialDesign:PackIcon Kind="Plus" Width="18" Height="18" Foreground="#00589E"
+                                                         HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Button>
                         </Grid>
                         <ListBox Style="{StaticResource ProfileListBox}"


### PR DESCRIPTION
## Summary
- Show blue plus icons for adding schedules and test profiles
- Simplify schedule save button to a single blue disk icon

## Testing
- `dotnet test CellManager/CellManager.sln`

------
https://chatgpt.com/codex/tasks/task_e_68c3c3bd7260832392b6f8d019e3ff46