### PR TITLE
Center align select column and pad cell library fields

### DIFF
--- a/CellManager/CellManager/Views/CellLibary/CellLibraryView.xaml
+++ b/CellManager/CellManager/Views/CellLibary/CellLibraryView.xaml
@@ -246,15 +246,18 @@
                 <GridView>
 
                     <!-- Select Badge -->
-                    <GridViewColumn Header="Select">
+                    <GridViewColumn Header="Select" Width="70">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
-                                <ToggleButton IsChecked="{Binding IsActive}"
-                                              Command="{Binding DataContext.SelectCellCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
-                                              CommandParameter="{Binding}"
-                                              Style="{StaticResource MaterialDesignSwitchSecondaryToggleButton}"
-                                              ToolTip="MaterialDesignSwitchSecondaryToggleButton"
-                                              HorizontalAlignment="Center"/>
+                                <Grid>
+                                    <ToggleButton IsChecked="{Binding IsActive}"
+                                                  Command="{Binding DataContext.SelectCellCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
+                                                  CommandParameter="{Binding}"
+                                                  Style="{StaticResource MaterialDesignSwitchSecondaryToggleButton}"
+                                                  ToolTip="MaterialDesignSwitchSecondaryToggleButton"
+                                                  HorizontalAlignment="Center"
+                                                  VerticalAlignment="Center"/>
+                                </Grid>
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>


### PR DESCRIPTION
## Summary
- center the Select toggle in cell library list
- add left margin spacing for Cell Name, Serial Number, Part Number, Update Date, Cell Type, and Cell Manufacturer columns

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c3c87e35988323be17e895effac296