### PR TITLE
Fix sequence drag-drop misclassification

### DIFF
--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -348,6 +348,7 @@
                         <Grid Grid.Row="1">
                             <ListBox x:Name="SequenceList" ItemsSource="{Binding Sequence}" AllowDrop="True" Width="Auto"
          PreviewMouseLeftButtonDown="ScheduleList_PreviewMouseLeftButtonDown"
+         PreviewMouseLeftButtonUp="ScheduleList_PreviewMouseLeftButtonUp"
          PreviewMouseMove="ScheduleList_PreviewMouseMove"
          Drop="ScheduleList_Drop" DragOver="ScheduleList_DragOver" DragLeave="ScheduleList_DragLeave">
                                 <ListBox.Style>
@@ -510,6 +511,7 @@
                                         <ItemsControl ItemsSource="{Binding Steps}" ItemTemplate="{StaticResource StepTemplateItem}"
                                                               Margin="45,-5,4,8"
                                                               PreviewMouseLeftButtonDown="ProfileList_PreviewMouseLeftButtonDown"
+                                                              PreviewMouseLeftButtonUp="ProfileList_PreviewMouseLeftButtonUp"
                                                               PreviewMouseMove="ProfileList_PreviewMouseMove"/>
                                     </Expander>
                                 </materialDesign:Card>

--- a/CellManager/CellManager/Views/ScheduleView.xaml.cs
+++ b/CellManager/CellManager/Views/ScheduleView.xaml.cs
@@ -10,6 +10,8 @@ namespace CellManager.Views
 {
     public partial class ScheduleView : UserControl
     {
+        private const string DragSourceFormat = "ScheduleView_IsFromSequence";
+
         private Point _dragStart;
         private InsertionAdorner? _insertionAdorner;
         private DragAdorner? _dragAdorner;
@@ -83,7 +85,10 @@ namespace CellManager.Views
             var index = GetInsertIndex(list, e.GetPosition(list));
             var step = (StepTemplate)e.Data.GetData(typeof(StepTemplate));
 
-            if (vm.Sequence.Contains(step))
+            var isFromSequence = e.Data.GetDataPresent(DragSourceFormat) &&
+                                 e.Data.GetData(DragSourceFormat) is bool fromSequence && fromSequence;
+
+            if (isFromSequence)
                 vm.MoveStep(step, index);
             else
                 vm.InsertStep(step, index);
@@ -200,6 +205,7 @@ namespace CellManager.Views
         private void BeginDrag(ItemsControl source, FrameworkElement item, StepTemplate step, DragDropEffects effect)
         {
             var data = new DataObject(typeof(StepTemplate), step);
+            data.SetData(DragSourceFormat, effect == DragDropEffects.Move);
             _dragScope = Window.GetWindow(this)?.Content as UIElement;
             if (_dragScope != null)
             {

--- a/CellManager/CellManager/Views/ScheduleView.xaml.cs
+++ b/CellManager/CellManager/Views/ScheduleView.xaml.cs
@@ -137,9 +137,8 @@ namespace CellManager.Views
             {
                 if (list.ItemContainerGenerator.ContainerFromIndex(i) is FrameworkElement item)
                 {
-                    var bounds = VisualTreeHelper.GetDescendantBounds(item);
                     var topLeft = item.TranslatePoint(new Point(), list);
-                    var rect = new Rect(topLeft, bounds.Size);
+                    var rect = new Rect(topLeft, item.RenderSize);
                     if (rect.Contains(position))
                     {
                         if (orientation == Orientation.Horizontal)
@@ -168,9 +167,8 @@ namespace CellManager.Views
             {
                 if (list.ItemContainerGenerator.ContainerFromIndex(i) is FrameworkElement item)
                 {
-                    var bounds = VisualTreeHelper.GetDescendantBounds(item);
                     var topLeft = item.TranslatePoint(new Point(), list);
-                    var rect = new Rect(topLeft, bounds.Size);
+                    var rect = new Rect(topLeft, item.RenderSize);
                     if (rect.Contains(point)) return item;
                 }
             }


### PR DESCRIPTION
## Summary
- add an explicit drag source flag to drag data so drops know if they originate from the sequence list
- update drop handling to rely on the drag source flag so reorders do not block adding new sequence steps

## Testing
- Not Run (dotnet not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca0600f7548323872d14916df981b5