### PR TITLE
Revamp run timeline preview and current step display

### DIFF
--- a/CellManager/CellManager/ViewModels/RunViewModel.cs
+++ b/CellManager/CellManager/ViewModels/RunViewModel.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using CellManager.Models;
 using CellManager.Messages;
+using CellManager.Models.TestProfile;
 using CellManager.Services;
 
 namespace CellManager.ViewModels
@@ -20,6 +21,7 @@ namespace CellManager.ViewModels
         private bool _isViewEnabled = true;
 
         public ObservableCollection<Schedule> AvailableSchedules { get; } = new();
+        public ObservableCollection<StepTemplate> TimelineSteps { get; } = new();
 
         [ObservableProperty]
         private Schedule? _selectedSchedule;
@@ -43,6 +45,9 @@ namespace CellManager.ViewModels
         private int _currentStep;
 
         [ObservableProperty]
+        private StepTemplate? _currentTimelineStep;
+
+        [ObservableProperty]
         private string _currentProfile = string.Empty;
 
         [ObservableProperty]
@@ -58,21 +63,39 @@ namespace CellManager.ViewModels
         public RelayCommand StopCommand { get; }
 
         private readonly IScheduleRepository? _scheduleRepo;
+        private readonly IChargeProfileRepository? _chargeRepo;
+        private readonly IDischargeProfileRepository? _dischargeRepo;
+        private readonly IRestProfileRepository? _restRepo;
+        private readonly IOcvProfileRepository? _ocvRepo;
+        private readonly IEcmPulseProfileRepository? _ecmRepo;
 
-        public RunViewModel() : this(null)
+        private readonly Dictionary<int, StepTemplate> _profileTemplates = new();
+
+        public RunViewModel()
+            : this(null, null, null, null, null, null)
         {
-            AvailableSchedules.Add(new Schedule
-            {
-                Id = 1,
-                Name = "Sample Schedule",
-                TestProfileIds = new List<int> { 1, 2, 3 }
-            });
-            SelectedSchedule = AvailableSchedules.FirstOrDefault();
+            BuildDesignTimeData();
         }
 
         public RunViewModel(IScheduleRepository? scheduleRepo)
+            : this(scheduleRepo, null, null, null, null, null)
+        {
+        }
+
+        public RunViewModel(
+            IScheduleRepository? scheduleRepo,
+            IChargeProfileRepository? chargeRepo,
+            IDischargeProfileRepository? dischargeRepo,
+            IRestProfileRepository? restRepo,
+            IOcvProfileRepository? ocvRepo,
+            IEcmPulseProfileRepository? ecmRepo)
         {
             _scheduleRepo = scheduleRepo;
+            _chargeRepo = chargeRepo;
+            _dischargeRepo = dischargeRepo;
+            _restRepo = restRepo;
+            _ocvRepo = ocvRepo;
+            _ecmRepo = ecmRepo;
 
             StartCommand = new RelayCommand(StartSchedule);
             PauseCommand = new RelayCommand(() => { });
@@ -80,37 +103,261 @@ namespace CellManager.ViewModels
 
             WeakReferenceMessenger.Default.Register<CellSelectedMessage>(this, (r, m) =>
             {
-                LoadSchedules(m.SelectedCell);
+                OnCellSelected(m.SelectedCell);
             });
         }
 
         private void LoadSchedules(Cell? cell)
         {
             AvailableSchedules.Clear();
-            if (_scheduleRepo == null || cell == null) return;
+            if (_scheduleRepo == null || cell == null)
+            {
+                SelectedSchedule = null;
+                return;
+            }
+
             foreach (var sched in _scheduleRepo.Load(cell.Id))
                 AvailableSchedules.Add(sched);
+
             SelectedSchedule = AvailableSchedules.FirstOrDefault();
+        }
+
+        private void OnCellSelected(Cell? cell)
+        {
+            LoadStepTemplates(cell);
+            LoadSchedules(cell);
+        }
+
+        private void LoadStepTemplates(Cell? cell)
+        {
+            _profileTemplates.Clear();
+
+            if (cell == null)
+                return;
+
+            if (_chargeRepo != null)
+            {
+                foreach (var profile in _chargeRepo.Load(cell.Id))
+                {
+                    _profileTemplates[profile.Id] = CreateProfileTemplate(
+                        profile.Id,
+                        profile.Name,
+                        "BatteryPlus",
+                        profile.PreviewText,
+                        ScheduleTimeCalculator.EstimateDuration(cell, TestProfileType.Charge, profile) ?? TimeSpan.Zero);
+                }
+            }
+
+            if (_dischargeRepo != null)
+            {
+                foreach (var profile in _dischargeRepo.Load(cell.Id))
+                {
+                    _profileTemplates[profile.Id] = CreateProfileTemplate(
+                        profile.Id,
+                        profile.Name,
+                        "BatteryMinus",
+                        profile.PreviewText,
+                        ScheduleTimeCalculator.EstimateDuration(cell, TestProfileType.Discharge, profile) ?? TimeSpan.Zero);
+                }
+            }
+
+            if (_restRepo != null)
+            {
+                foreach (var profile in _restRepo.Load(cell.Id))
+                {
+                    _profileTemplates[profile.Id] = CreateProfileTemplate(
+                        profile.Id,
+                        profile.Name,
+                        "BatteryEco",
+                        profile.PreviewText,
+                        ScheduleTimeCalculator.EstimateDuration(cell, TestProfileType.Rest, profile) ?? TimeSpan.Zero);
+                }
+            }
+
+            if (_ocvRepo != null)
+            {
+                foreach (var profile in _ocvRepo.Load(cell.Id))
+                {
+                    _profileTemplates[profile.Id] = CreateProfileTemplate(
+                        profile.Id,
+                        profile.Name,
+                        "StairsDown",
+                        profile.PreviewText,
+                        ScheduleTimeCalculator.EstimateDuration(cell, TestProfileType.OCV, profile) ?? TimeSpan.Zero);
+                }
+            }
+
+            if (_ecmRepo != null)
+            {
+                foreach (var profile in _ecmRepo.Load(cell.Id))
+                {
+                    _profileTemplates[profile.Id] = CreateProfileTemplate(
+                        profile.Id,
+                        profile.Name,
+                        "Pulse",
+                        profile.PreviewText,
+                        ScheduleTimeCalculator.EstimateDuration(cell, TestProfileType.ECM, profile) ?? TimeSpan.Zero);
+                }
+            }
+        }
+
+        private void UpdateTimelineSteps(Schedule? schedule)
+        {
+            TimelineSteps.Clear();
+
+            if (schedule == null)
+                return;
+
+            var steps = new List<StepTemplate>();
+
+            foreach (var id in schedule.TestProfileIds)
+                steps.Add(CloneTemplateForTimeline(id));
+
+            if (schedule.LoopStartIndex > 0)
+            {
+                var insertIndex = Math.Clamp(schedule.LoopStartIndex - 1, 0, steps.Count);
+                steps.Insert(insertIndex, CreateLoopStep(true));
+            }
+
+            if (schedule.LoopEndIndex > 0)
+            {
+                var insertIndex = Math.Clamp(schedule.LoopEndIndex - 1, 0, steps.Count);
+                steps.Insert(insertIndex, CreateLoopStep(false));
+            }
+
+            for (var i = 0; i < steps.Count; i++)
+                steps[i].StepNumber = i + 1;
+
+            foreach (var step in steps)
+                TimelineSteps.Add(step);
+        }
+
+        private StepTemplate CloneTemplateForTimeline(int id)
+        {
+            if (_profileTemplates.TryGetValue(id, out var template))
+                return CloneStep(template);
+
+            return new StepTemplate
+            {
+                Id = id,
+                Name = $"Profile {id}",
+                IconKind = "HelpCircleOutline",
+                Parameters = "Profile details unavailable",
+                Duration = TimeSpan.Zero,
+                Kind = StepKind.Profile
+            };
+        }
+
+        private static StepTemplate CloneStep(StepTemplate template)
+        {
+            return new StepTemplate
+            {
+                Id = template.Id,
+                Name = template.Name,
+                IconKind = template.IconKind,
+                Parameters = template.Parameters,
+                Duration = template.Duration,
+                Kind = template.Kind
+            };
+        }
+
+        private static StepTemplate CreateLoopStep(bool isStart)
+        {
+            return new StepTemplate
+            {
+                Id = 0,
+                Name = isStart ? "Loop Start" : "Loop End",
+                IconKind = "Repeat",
+                Parameters = string.Empty,
+                Duration = TimeSpan.Zero,
+                Kind = isStart ? StepKind.LoopStart : StepKind.LoopEnd
+            };
+        }
+
+        private static StepTemplate CreateProfileTemplate(int id, string? name, string iconKind, string? parameters, TimeSpan duration)
+        {
+            return new StepTemplate
+            {
+                Id = id,
+                Name = string.IsNullOrWhiteSpace(name) ? $"Profile {id}" : name,
+                IconKind = iconKind,
+                Parameters = parameters ?? string.Empty,
+                Duration = duration,
+                Kind = StepKind.Profile
+            };
+        }
+
+        private void BuildDesignTimeData()
+        {
+            _profileTemplates.Clear();
+
+            var samples = new[]
+            {
+                CreateProfileTemplate(1, "Charge", "BatteryPlus", "0.5A → 4.2V | 01:00:00", TimeSpan.FromHours(1)),
+                CreateProfileTemplate(2, "Discharge", "BatteryMinus", "0.5A → 3.0V | 00:30:00", TimeSpan.FromMinutes(30)),
+                CreateProfileTemplate(3, "Rest", "BatteryEco", "00:10:00", TimeSpan.FromMinutes(10))
+            };
+
+            foreach (var sample in samples)
+                _profileTemplates[sample.Id] = sample;
+
+            AvailableSchedules.Clear();
+            var schedule = new Schedule
+            {
+                Id = 1,
+                Name = "Sample Schedule",
+                TestProfileIds = new List<int> { 1, 2, 3 }
+            };
+            AvailableSchedules.Add(schedule);
+            SelectedSchedule = schedule;
+            RemainingTime = TimeSpan.FromTicks(TimelineSteps.Sum(s => s.Duration.Ticks));
         }
 
         private void StartSchedule()
         {
-            if (SelectedSchedule != null)
-            {
-                WeakReferenceMessenger.Default.Send(new ScheduleChangedMessage(SelectedSchedule));
+            if (SelectedSchedule == null)
+                return;
 
-                if (SelectedSchedule.TestProfileIds.Count > 0)
-                {
-                    CurrentProfile = $"Profile ID: {SelectedSchedule.TestProfileIds[0]}";
-                }
+            WeakReferenceMessenger.Default.Send(new ScheduleChangedMessage(SelectedSchedule));
 
-                WeakReferenceMessenger.Default.Send(new TestStatusChangedMessage("Testing"));
-            }
+            CurrentTimelineStep = TimelineSteps.FirstOrDefault(s => s.Kind == StepKind.Profile)
+                ?? TimelineSteps.FirstOrDefault();
+            Progress = 0;
+            ElapsedTime = TimeSpan.Zero;
+            RemainingTime = TimeSpan.FromTicks(TimelineSteps.Sum(s => s.Duration.Ticks));
+
+            WeakReferenceMessenger.Default.Send(new TestStatusChangedMessage("Testing"));
         }
 
         private void StopSchedule()
         {
+            CurrentTimelineStep = null;
+            Progress = 0;
+            ElapsedTime = TimeSpan.Zero;
+            RemainingTime = TimeSpan.Zero;
             WeakReferenceMessenger.Default.Send(new TestStatusChangedMessage(string.Empty));
+        }
+
+        partial void OnSelectedScheduleChanged(Schedule? value)
+        {
+            UpdateTimelineSteps(value);
+            RemainingTime = TimeSpan.FromTicks(TimelineSteps.Sum(s => s.Duration.Ticks));
+            ElapsedTime = TimeSpan.Zero;
+            CurrentTimelineStep = null;
+        }
+
+        partial void OnCurrentTimelineStepChanged(StepTemplate? value)
+        {
+            if (value != null)
+            {
+                CurrentProfile = $"{value.Name} (ID: {value.Id})";
+                CurrentStep = value.StepNumber;
+            }
+            else
+            {
+                CurrentProfile = string.Empty;
+                CurrentStep = 0;
+            }
         }
 
         partial void OnCurrentProfileChanged(string value)

--- a/CellManager/CellManager/Views/Controls/TimelinePreviewControl.xaml
+++ b/CellManager/CellManager/Views/Controls/TimelinePreviewControl.xaml
@@ -5,40 +5,66 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:converters="clr-namespace:CellManager.Converters"
+             xmlns:vm="clr-namespace:CellManager.ViewModels"
              mc:Ignorable="d"
              d:DesignHeight="200" d:DesignWidth="400">
     <UserControl.Resources>
         <converters:IsNotLastItemConverter x:Key="IsNotLastItemConverter"/>
     </UserControl.Resources>
-    <Border BorderBrush="#E0E0E0" BorderThickness="1" Background="#FAFAFA" CornerRadius="4" Padding="4">
-        <ItemsControl ItemsSource="{Binding Schedule.TestProfileIds, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                      HorizontalAlignment="Stretch" ClipToBounds="True" AlternationCount="1000">
-            <ItemsControl.ItemsPanel>
-                <ItemsPanelTemplate>
-                    <StackPanel Orientation="Horizontal" Height="40"/>
-                </ItemsPanelTemplate>
-            </ItemsControl.ItemsPanel>
-            <ItemsControl.ItemTemplate>
-                <DataTemplate>
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <Border Margin="1" Padding="2" Width="50" Height="32"
-                                Background="{DynamicResource PrimaryHueLightBrush}"
-                                BorderBrush="Black" BorderThickness="1" CornerRadius="0">
-                            <TextBlock Text="{Binding}" FontSize="10" Foreground="Black"
-                                       HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                        </Border>
-                        <materialDesign:PackIcon Kind="ChevronRight" Width="14" Height="14" Margin="4,0" VerticalAlignment="Center">
-                            <materialDesign:PackIcon.Visibility>
-                                <MultiBinding Converter="{StaticResource IsNotLastItemConverter}">
-                                    <Binding RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=ContentPresenter}" Path="(ItemsControl.AlternationIndex)"/>
-                                    <Binding RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=ItemsControl}" Path="Items.Count"/>
-                                </MultiBinding>
-                            </materialDesign:PackIcon.Visibility>
-                        </materialDesign:PackIcon>
-                    </StackPanel>
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ItemsControl>
-    </Border>
+    <ItemsControl ItemsSource="{Binding Steps, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                  HorizontalAlignment="Stretch"
+                  ClipToBounds="True"
+                  AlternationCount="1000">
+        <ItemsControl.ItemsPanel>
+            <ItemsPanelTemplate>
+                <StackPanel Orientation="Horizontal" Height="40"/>
+            </ItemsPanelTemplate>
+        </ItemsControl.ItemsPanel>
+        <ItemsControl.ItemTemplate>
+            <DataTemplate>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <Border Margin="1" Padding="4,2" MinWidth="70" Height="32"
+                            Background="{DynamicResource PrimaryHueLightBrush}"
+                            BorderBrush="#E5E7EB" BorderThickness="1" CornerRadius="4">
+                        <Border.ToolTip>
+                            <StackPanel>
+                                <TextBlock Text="{Binding StepNumber, StringFormat=Step {0}}"/>
+                                <TextBlock Text="{Binding Id, StringFormat=ID\: {0}}"/>
+                                <TextBlock Text="{Binding Name, StringFormat=Name\: {0}}"/>
+                                <TextBlock Text="{Binding Parameters, StringFormat=Params\: {0}}"/>
+                                <TextBlock Text="{Binding Duration, StringFormat='Duration\: {0:hh\\:mm\\:ss}'}"/>
+                            </StackPanel>
+                        </Border.ToolTip>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+                            <materialDesign:PackIcon Kind="{Binding IconKind}" Width="16" Height="16" Margin="0,0,4,0"/>
+                            <TextBlock FontSize="11" FontWeight="SemiBold" Foreground="Black">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Text" Value="{Binding Id}"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Kind}" Value="{x:Static vm:StepKind.LoopStart}">
+                                                <Setter Property="Text" Value="Start"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding Kind}" Value="{x:Static vm:StepKind.LoopEnd}">
+                                                <Setter Property="Text" Value="End"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </StackPanel>
+                    </Border>
+                    <materialDesign:PackIcon Kind="ChevronRight" Width="14" Height="14" Margin="4,0" VerticalAlignment="Center">
+                        <materialDesign:PackIcon.Visibility>
+                            <MultiBinding Converter="{StaticResource IsNotLastItemConverter}">
+                                <Binding RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=ContentPresenter}" Path="(ItemsControl.AlternationIndex)"/>
+                                <Binding RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=ItemsControl}" Path="Items.Count"/>
+                            </MultiBinding>
+                        </materialDesign:PackIcon.Visibility>
+                    </materialDesign:PackIcon>
+                </StackPanel>
+            </DataTemplate>
+        </ItemsControl.ItemTemplate>
+    </ItemsControl>
 </UserControl>
 

--- a/CellManager/CellManager/Views/Controls/TimelinePreviewControl.xaml.cs
+++ b/CellManager/CellManager/Views/Controls/TimelinePreviewControl.xaml.cs
@@ -1,6 +1,7 @@
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
-using CellManager.Models;
+using CellManager.ViewModels;
 
 namespace CellManager.Views.Controls
 {
@@ -12,20 +13,20 @@ namespace CellManager.Views.Controls
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="Schedule"/> displayed by this control.
+        /// Gets or sets the timeline steps rendered by the preview.
         /// </summary>
-        public Schedule? Schedule
+        public IEnumerable<StepTemplate>? Steps
         {
-            get => (Schedule?)GetValue(ScheduleProperty);
-            set => SetValue(ScheduleProperty, value);
+            get => (IEnumerable<StepTemplate>?)GetValue(StepsProperty);
+            set => SetValue(StepsProperty, value);
         }
 
-        public static readonly DependencyProperty ScheduleProperty =
+        public static readonly DependencyProperty StepsProperty =
             DependencyProperty.Register(
-                nameof(Schedule),
-                typeof(Schedule),
+                nameof(Steps),
+                typeof(IEnumerable<StepTemplate>),
                 typeof(TimelinePreviewControl),
-                new PropertyMetadata(default(Schedule)));
+                new PropertyMetadata(null));
     }
 }
 

--- a/CellManager/CellManager/Views/RunView.xaml
+++ b/CellManager/CellManager/Views/RunView.xaml
@@ -6,9 +6,13 @@
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:local="clr-namespace:CellManager.Views.Controls"
              xmlns:viewModels="clr-namespace:CellManager.ViewModels"
+             xmlns:converters="clr-namespace:CellManager.Converters"
              mc:Ignorable="d"
              d:DesignHeight="800" d:DesignWidth="1200"
              d:DataContext="{d:DesignInstance Type=viewModels:RunViewModel, IsDesignTimeCreatable=True}">
+    <UserControl.Resources>
+        <converters:NullOrEmptyToPlaceholderConverter x:Key="NullOrEmptyToPlaceholderConverter"/>
+    </UserControl.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -48,7 +52,7 @@
             <GroupBox Grid.Column="0" Margin="0,0,8,0">
                 <StackPanel>
                     <TextBlock Text="Timeline Preview" FontWeight="Bold" FontSize="15"/>
-                    <local:TimelinePreviewControl Schedule="{Binding SelectedSchedule}"/>
+                    <local:TimelinePreviewControl Steps="{Binding TimelineSteps}"/>
                 </StackPanel>
             </GroupBox>
 
@@ -63,23 +67,53 @@
             </GroupBox>
         </Grid>
 
-        <!-- Controls -->
-        <GroupBox Grid.Row="2" Grid.ColumnSpan="2" Margin="8">
-            <StackPanel>
-                <TextBlock Text="Controls" FontWeight="Bold" FontSize="15"/>
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,4">
-                    <Button Content="Start" Command="{Binding StartCommand}" Style="{StaticResource PrimaryActionButton}" Margin="0,0,8,0"/>
-                    <Button Content="Pause" Command="{Binding PauseCommand}" Margin="0,0,8,0"/>
-                    <Button Content="Stop" Command="{Binding StopCommand}" Style="{StaticResource ErrorActionButton}"/>
-                    <ProgressBar Width="200" Height="18" Margin="16,0,0,0" Value="{Binding Progress}" Maximum="100"/>
+        <!-- Controls and current step details -->
+        <Grid Grid.Row="2" Grid.ColumnSpan="2" Margin="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="340"/>
+            </Grid.ColumnDefinitions>
+
+            <GroupBox Grid.Column="0" Margin="0,0,8,0">
+                <StackPanel>
+                    <TextBlock Text="Controls" FontWeight="Bold" FontSize="15"/>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,4">
+                        <Button Content="Start" Command="{Binding StartCommand}" Style="{StaticResource PrimaryActionButton}" Margin="0,0,8,0"/>
+                        <Button Content="Pause" Command="{Binding PauseCommand}" Margin="0,0,8,0"/>
+                        <Button Content="Stop" Command="{Binding StopCommand}" Style="{StaticResource ErrorActionButton}"/>
+                        <ProgressBar Width="200" Height="18" Margin="16,0,0,0" Value="{Binding Progress}" Maximum="100"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,4,0,0">
+                        <TextBlock Text="{Binding CurrentStep, StringFormat='Step: {0}'}" Margin="0,0,16,0"/>
+                        <TextBlock Text="{Binding ElapsedTime, StringFormat='Elapsed: {0:hh\\:mm\\:ss}'}" Margin="0,0,16,0"/>
+                        <TextBlock Text="{Binding RemainingTime, StringFormat='Remaining: {0:hh\\:mm\\:ss}'}"/>
+                    </StackPanel>
                 </StackPanel>
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,4,0,0">
-                    <TextBlock Text="{Binding CurrentStep, StringFormat='Step: {0}'}" Margin="0,0,16,0"/>
-                    <TextBlock Text="{Binding ElapsedTime, StringFormat='Elapsed: {0:hh\\:mm\\:ss}'}" Margin="0,0,16,0"/>
-                    <TextBlock Text="{Binding RemainingTime, StringFormat='Remaining: {0:hh\\:mm\\:ss}'}"/>
+            </GroupBox>
+
+            <GroupBox Grid.Column="1" Margin="8,0,0,0">
+                <StackPanel>
+                    <TextBlock Text="Current Step" FontWeight="Bold" FontSize="15"/>
+                    <StackPanel Margin="0,8,0,0">
+                        <TextBlock Text="{Binding CurrentTimelineStep.Name, TargetNullValue='No active step'}" FontSize="14" FontWeight="SemiBold"/>
+                        <TextBlock Margin="0,4,0,0">
+                            <Run Text="Step: "/>
+                            <Run Text="{Binding CurrentTimelineStep.StepNumber, TargetNullValue='-'}"/>
+                            <Run Text="   •   Profile ID: "/>
+                            <Run Text="{Binding CurrentTimelineStep.Id, TargetNullValue='-'}"/>
+                        </TextBlock>
+                        <TextBlock Margin="0,4,0,0">
+                            <Run Text="Parameters: "/>
+                            <Run Text="{Binding CurrentTimelineStep.Parameters, Converter={StaticResource NullOrEmptyToPlaceholderConverter}, ConverterParameter='-'}"/>
+                        </TextBlock>
+                        <TextBlock Margin="0,4,0,0">
+                            <Run Text="Duration: "/>
+                            <Run Text="{Binding CurrentTimelineStep.Duration, TargetNullValue='-:--:--', StringFormat={}{0:hh\\:mm\\:ss}}"/>
+                        </TextBlock>
+                    </StackPanel>
                 </StackPanel>
-            </StackPanel>
-        </GroupBox>
+            </GroupBox>
+        </Grid>
 
         <!-- Run logs -->
         <GroupBox Grid.Row="3" Grid.ColumnSpan="2" Margin="8">


### PR DESCRIPTION
## Summary
- update the reusable timeline preview control to render schedule steps with the same styling and tooltips used in the schedule tab
- enhance the run view model to build timeline step details from repositories and expose the active step information
- refresh the run view layout to show the redesigned timeline preview and add a card summarizing the current step

## Testing
- `dotnet test CellManager/CellManager.sln` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca151c138483239a0e61c9abc10857