### PR TITLE
Align run schedule labels with script numbers

### DIFF
--- a/CellManager/CellManager/Models/Schedule.cs
+++ b/CellManager/CellManager/Models/Schedule.cs
@@ -8,6 +8,8 @@ namespace CellManager.Models
     public partial class Schedule : ObservableObject
     {
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(DisplayNameAndId))]
+        [NotifyPropertyChangedFor(nameof(DisplayNameAndScript))]
         private int _id;
 
         [ObservableProperty]
@@ -15,12 +17,14 @@ namespace CellManager.Models
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(DisplayNameAndId))]
+        [NotifyPropertyChangedFor(nameof(DisplayNameAndScript))]
         private string _name;
 
         [ObservableProperty]
         private List<int> _testProfileIds = new();
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(DisplayNameAndScript))]
         private int _ordering;
 
         [ObservableProperty]
@@ -39,5 +43,14 @@ namespace CellManager.Models
         private TimeSpan _estimatedDuration;
 
         public string DisplayNameAndId => $"ID: {Id} - {Name}";
+
+        public string DisplayNameAndScript
+        {
+            get
+            {
+                var scriptNumber = Ordering > 0 ? Ordering : Id;
+                return $"Script {scriptNumber} - {Name}";
+            }
+        }
     }
 }

--- a/CellManager/CellManager/Views/RunView.xaml
+++ b/CellManager/CellManager/Views/RunView.xaml
@@ -38,7 +38,7 @@
             <ComboBox Grid.Column="1"
                       ItemsSource="{Binding AvailableSchedules}"
                       SelectedItem="{Binding SelectedSchedule}"
-                      DisplayMemberPath="DisplayNameAndId"
+                      DisplayMemberPath="DisplayNameAndScript"
                       Margin="8,0,0,0"/>
         </Grid>
 


### PR DESCRIPTION
## Summary
- add a DisplayNameAndScript helper on schedules that uses the script ordering value
- bind the run tab's schedule selector to the new script-based label so numbering matches the schedule list

## Testing
- `dotnet build CellManager/CellManager.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ca22399b1083239f390bd7ea4ab706