### PR TITLE
Design analyzer layout and viewmodel

### DIFF
--- a/CellManager/CellManager.Tests/CellManager.Tests.csproj
+++ b/CellManager/CellManager.Tests/CellManager.Tests.csproj
@@ -43,6 +43,8 @@
     <Compile Include="../CellManager/Messages/ScheduleChangedMessage.cs" Link="Messages/ScheduleChangedMessage.cs" />
     <Compile Include="../CellManager/Messages/ProfileChangedMessage.cs" Link="Messages/ProfileChangedMessage.cs" />
     <Compile Include="../CellManager/Messages/TestStatusChangedMessage.cs" Link="Messages/TestStatusChangedMessage.cs" />
+    <Compile Include="../CellManager/Messages/TestProfilesUpdatedMessage.cs" Link="Messages/TestProfilesUpdatedMessage.cs" />
+    <Compile Include="../CellManager/Messages/SchedulesUpdatedMessage.cs" Link="Messages/SchedulesUpdatedMessage.cs" />
     <Compile Include="../CellManager/ViewModels/ScheduleViewModel.cs" Link="ViewModels/ScheduleViewModel.cs" />
     <Compile Include="../CellManager/ViewModels/RunViewModel.cs" Link="ViewModels/RunViewModel.cs" />
   </ItemGroup>

--- a/CellManager/CellManager/MainWindow.xaml
+++ b/CellManager/CellManager/MainWindow.xaml
@@ -33,9 +33,7 @@
             </Grid>
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:AnalysisViewModel}">
-            <Grid Background="#FFFFFF">
-                <TextBlock Text="Analysis Content" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="20"/>
-            </Grid>
+            <views:AnalysisView/>
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:DataExportViewModel}">
             <Grid Background="#FFFFFF">

--- a/CellManager/CellManager/ViewModels/AnalysisViewModel.cs
+++ b/CellManager/CellManager/ViewModels/AnalysisViewModel.cs
@@ -203,12 +203,19 @@ namespace CellManager.ViewModels
         private void AddMockDataset()
         {
             var index = Datasets.Count + 1;
-            var color = index % 3 switch
+            Brush color;
+            switch (index % 3)
             {
-                1 => Brushes.SteelBlue,
-                2 => Brushes.IndianRed,
-                _ => Brushes.OliveDrab
-            };
+                case 1:
+                    color = Brushes.SteelBlue;
+                    break;
+                case 2:
+                    color = Brushes.IndianRed;
+                    break;
+                default:
+                    color = Brushes.OliveDrab;
+                    break;
+            }
 
             var dataset = new AnalysisDataset($"Cycle {index}",
                 $"Imported {DateTime.Now:yyyy-MM-dd HH:mm} • 4 channels • 10k samples",

--- a/CellManager/CellManager/ViewModels/AnalysisViewModel.cs
+++ b/CellManager/CellManager/ViewModels/AnalysisViewModel.cs
@@ -1,4 +1,10 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
 namespace CellManager.ViewModels
 {
@@ -7,7 +13,564 @@ namespace CellManager.ViewModels
         public string HeaderText { get; } = "Analysis";
         public string IconName { get; } = "ChartAreaspline";
 
+        public ObservableCollection<AnalysisDataset> Datasets { get; } = new();
+        public ObservableCollection<AnalysisTemplate> SessionTemplates { get; } = new();
+        public ObservableCollection<AnalysisWarning> Warnings { get; } = new();
+        public ObservableCollection<ComparisonSeriesOption> ChartSeriesOptions { get; } = new();
+        public ObservableCollection<ChartModeOption> ChartModes { get; } = new();
+        public ObservableCollection<AnalysisOperationStatus> AutomaticAnalyses { get; } = new();
+        public ObservableCollection<AnalysisResultSummary> PinnedResults { get; } = new();
+        public ObservableCollection<SessionSnapshot> LoadedSessionHistory { get; } = new();
+        public ObservableCollection<string> NormalizationOptions { get; } = new();
+        public ObservableCollection<string> ResampleOptions { get; } = new();
+        public ObservableCollection<string> AnalysisLog { get; } = new();
+
         [ObservableProperty]
-        private bool _isViewEnabled = false;
+        private bool _isViewEnabled = true;
+
+        [ObservableProperty]
+        private AnalysisDataset? _selectedDataset;
+
+        [ObservableProperty]
+        private SessionSnapshot? _selectedSessionSnapshot;
+
+        [ObservableProperty]
+        private bool _isCompareMode;
+
+        [ObservableProperty]
+        private bool _isPinnedResultsExpanded = true;
+
+        [ObservableProperty]
+        private double _alignmentOffset;
+
+        [ObservableProperty]
+        private string? _selectedNormalization;
+
+        [ObservableProperty]
+        private string? _selectedResampleOption;
+
+        [ObservableProperty]
+        private ChartModeOption? _selectedChartMode;
+
+        [ObservableProperty]
+        private string _currentCellLabel = "No cell selected";
+
+        [ObservableProperty]
+        private string _totalTestDurationText = "0h 00m";
+
+        [ObservableProperty]
+        private string _voltageSummary = "- / - / -";
+
+        [ObservableProperty]
+        private string _currentSummary = "- / - / -";
+
+        [ObservableProperty]
+        private string _energySummary = "-";
+
+        [ObservableProperty]
+        private string _selectionSummary = "No range selected";
+
+        [ObservableProperty]
+        private string _selectionVoltageSummary = string.Empty;
+
+        [ObservableProperty]
+        private string _selectionDurationText = string.Empty;
+
+        [ObservableProperty]
+        private string _sampleRateStatus = "Not analysed";
+
+        [ObservableProperty]
+        private string _lastAnalysisTimestampText = "Never";
+
+        [ObservableProperty]
+        private string _baselineAlignmentHint = "0.0 s";
+
+        [ObservableProperty]
+        private int _loadedFileCount;
+
+        [ObservableProperty]
+        private bool _hasWarnings;
+
+
+        public IRelayCommand LoadRawCommand { get; }
+        public IRelayCommand ReloadCommand { get; }
+        public IRelayCommand SaveSessionCommand { get; }
+        public IRelayCommand RemoveSelectedDatasetCommand { get; }
+        public IRelayCommand<AnalysisDataset> RemoveDatasetCommand { get; }
+        public IRelayCommand SaveTemplateCommand { get; }
+        public IRelayCommand<AnalysisTemplate> ApplyTemplateCommand { get; }
+        public IRelayCommand<AnalysisTemplate> DeleteTemplateCommand { get; }
+        public IRelayCommand SaveComparisonPresetCommand { get; }
+        public IRelayCommand LoadComparisonPresetCommand { get; }
+        public IRelayCommand ExportReportCommand { get; }
+
+        public AnalysisViewModel()
+        {
+            LoadRawCommand = new RelayCommand(AddMockDataset);
+            ReloadCommand = new RelayCommand(() => AnalysisLog.Add("Reload requested"));
+            SaveSessionCommand = new RelayCommand(() => AnalysisLog.Add("Session saved"));
+            RemoveSelectedDatasetCommand = new RelayCommand(() =>
+            {
+                if (SelectedDataset != null)
+                {
+                    RemoveDataset(SelectedDataset);
+                }
+            });
+            RemoveDatasetCommand = new RelayCommand<AnalysisDataset>(dataset =>
+            {
+                if (dataset != null)
+                {
+                    RemoveDataset(dataset);
+                }
+            });
+            SaveTemplateCommand = new RelayCommand(SaveCurrentTemplate);
+            ApplyTemplateCommand = new RelayCommand<AnalysisTemplate>(template =>
+            {
+                if (template == null)
+                {
+                    return;
+                }
+
+                AnalysisLog.Add($"Template '{template.Name}' applied");
+                SelectedChartMode = ChartModes.FirstOrDefault(mode => mode.Name == template.PreferredChartMode);
+                SelectedNormalization = NormalizationOptions.FirstOrDefault(o => o == template.NormalizationOption);
+                SelectedResampleOption = ResampleOptions.FirstOrDefault(o => o == template.ResampleOption);
+            });
+            DeleteTemplateCommand = new RelayCommand<AnalysisTemplate>(template =>
+            {
+                if (template == null)
+                {
+                    return;
+                }
+
+                SessionTemplates.Remove(template);
+                AnalysisLog.Add($"Template '{template.Name}' removed");
+            });
+            SaveComparisonPresetCommand = new RelayCommand(() => AnalysisLog.Add("Comparison preset saved"));
+            LoadComparisonPresetCommand = new RelayCommand(() => AnalysisLog.Add("Comparison preset loaded"));
+            ExportReportCommand = new RelayCommand(() =>
+            {
+                AnalysisLog.Add("Report export queued");
+                var now = DateTime.Now;
+                LastAnalysisTimestampText = now.ToString("yyyy-MM-dd HH:mm");
+            });
+
+            Datasets.CollectionChanged += (_, __) => RefreshDerivedState();
+            Warnings.CollectionChanged += (_, __) => RefreshDerivedState();
+
+            NormalizationOptions.Add("None");
+            NormalizationOptions.Add("Baseline voltage");
+            NormalizationOptions.Add("Capacity");
+            ResampleOptions.Add("Native");
+            ResampleOptions.Add("1 s");
+            ResampleOptions.Add("100 ms");
+
+            SelectedNormalization = NormalizationOptions.FirstOrDefault();
+            SelectedResampleOption = ResampleOptions.FirstOrDefault();
+
+            ChartModes.Add(new ChartModeOption("Voltage", "ChartLine"));
+            ChartModes.Add(new ChartModeOption("Current", "TrendingDown"));
+            ChartModes.Add(new ChartModeOption("Temperature", "Thermometer"));
+            ChartModes.Add(new ChartModeOption("Custom", "Tune"));
+            SelectedChartMode = ChartModes.FirstOrDefault();
+
+            AutomaticAnalyses.Add(new AnalysisOperationStatus(
+                "ECM parameters",
+                "Compute R0, R1, C1 and quality indicators from pulse segments",
+                new RelayCommand(() => SimulateAnalysis("ECM parameters"))));
+            AutomaticAnalyses.Add(new AnalysisOperationStatus(
+                "Qmax",
+                "Estimate Qmax from discharge curves with temperature adjustment",
+                new RelayCommand(() => SimulateAnalysis("Qmax"))));
+            AutomaticAnalyses.Add(new AnalysisOperationStatus(
+                "LUT table",
+                "Generate LUT entries for SOC vs. voltage for export",
+                new RelayCommand(() => SimulateAnalysis("LUT table"))));
+
+            LoadedSessionHistory.Add(new SessionSnapshot("Current session", DateTime.Now));
+            LoadedSessionHistory.Add(new SessionSnapshot("Regression pack", DateTime.Now.AddDays(-2)));
+            SelectedSessionSnapshot = LoadedSessionHistory.FirstOrDefault();
+
+            BuildDesignTimeData();
+            RefreshDerivedState();
+        }
+
+        partial void OnAlignmentOffsetChanged(double value)
+        {
+            BaselineAlignmentHint = $"{value:F1} s";
+        }
+
+        private void AddMockDataset()
+        {
+            var index = Datasets.Count + 1;
+            var color = index % 3 switch
+            {
+                1 => Brushes.SteelBlue,
+                2 => Brushes.IndianRed,
+                _ => Brushes.OliveDrab
+            };
+
+            var dataset = new AnalysisDataset($"Cycle {index}",
+                $"Imported {DateTime.Now:yyyy-MM-dd HH:mm} • 4 channels • 10k samples",
+                color)
+            {
+                ImportedAt = DateTime.Now,
+                Notes = "Design time placeholder"
+            };
+
+            if (!Datasets.Any(d => d.IsBaseline))
+            {
+                dataset.IsBaseline = true;
+            }
+
+            Datasets.Add(dataset);
+            dataset.PropertyChanged += OnDatasetPropertyChanged;
+            SelectedDataset = dataset;
+            UpdateStatisticsFor(dataset);
+            RefreshDerivedState();
+        }
+
+        partial void OnSelectedDatasetChanged(AnalysisDataset? value)
+        {
+            if (value != null)
+            {
+                UpdateStatisticsFor(value);
+            }
+        }
+
+        private void RemoveDataset(AnalysisDataset dataset)
+        {
+            dataset.PropertyChanged -= OnDatasetPropertyChanged;
+            Datasets.Remove(dataset);
+            if (ReferenceEquals(SelectedDataset, dataset))
+            {
+                SelectedDataset = Datasets.FirstOrDefault();
+            }
+
+            if (!Datasets.Any(d => d.IsBaseline) && Datasets.FirstOrDefault() is { } first)
+            {
+                first.IsBaseline = true;
+            }
+
+            RefreshDerivedState();
+        }
+
+        private void SaveCurrentTemplate()
+        {
+            var template = new AnalysisTemplate(
+                $"Template {SessionTemplates.Count + 1}",
+                "Datasets, chart mode, and analysis parameters",
+                DateTime.Now)
+            {
+                PreferredChartMode = SelectedChartMode?.Name ?? "Voltage",
+                NormalizationOption = SelectedNormalization ?? "None",
+                ResampleOption = SelectedResampleOption ?? "Native"
+            };
+
+            SessionTemplates.Add(template);
+            AnalysisLog.Add($"Template '{template.Name}' saved");
+        }
+
+        private void SimulateAnalysis(string analysisName)
+        {
+            var status = AutomaticAnalyses.FirstOrDefault(a => a.Title == analysisName);
+            if (status == null)
+            {
+                return;
+            }
+
+            RemovePinnedResult(analysisName);
+
+            status.IsBusy = true;
+            status.Progress = 100;
+            status.StatusMessage = "Completed";
+            status.ErrorMessage = null;
+            status.LastRunAt = DateTime.Now;
+            status.LastRunText = status.LastRunAt?.ToString("yyyy-MM-dd HH:mm");
+            status.IsBusy = false;
+
+            PinnedResults.Add(new AnalysisResultSummary(
+                analysisName,
+                $"{analysisName} results • {DateTime.Now:HH:mm}",
+                new RelayCommand(() => AnalysisLog.Add($"Opened {analysisName} result")),
+                new RelayCommand(() => RemovePinnedResult(analysisName))));
+
+            status.Progress = 0;
+
+            LastAnalysisTimestampText = DateTime.Now.ToString("yyyy-MM-dd HH:mm");
+            AnalysisLog.Add($"{analysisName} analysis finished");
+        }
+
+        private void RemovePinnedResult(string analysisName)
+        {
+            var item = PinnedResults.FirstOrDefault(r => r.Title == analysisName);
+            if (item != null)
+            {
+                PinnedResults.Remove(item);
+                AnalysisLog.Add($"Removed pinned result '{analysisName}'");
+            }
+        }
+
+        private void BuildDesignTimeData()
+        {
+            if (Datasets.Count == 0)
+            {
+                var primary = new AnalysisDataset("Cycle 1", "Imported 2024-05-11 09:15 • 4 channels • 12k samples", Brushes.SteelBlue)
+                {
+                    IsBaseline = true,
+                    ImportedAt = DateTime.Now.AddDays(-1),
+                    Notes = "Reference pulse run"
+                };
+                var secondary = new AnalysisDataset("Cycle 2", "Imported 2024-05-12 10:27 • 4 channels • 12k samples", Brushes.IndianRed)
+                {
+                    ImportedAt = DateTime.Now.AddHours(-4),
+                    Notes = "Fresh measurement"
+                };
+
+                Datasets.Add(primary);
+                Datasets.Add(secondary);
+                primary.PropertyChanged += OnDatasetPropertyChanged;
+                secondary.PropertyChanged += OnDatasetPropertyChanged;
+                SelectedDataset = secondary;
+            }
+
+            if (ChartSeriesOptions.Count == 0)
+            {
+                ChartSeriesOptions.Add(new ComparisonSeriesOption("Voltage"));
+                ChartSeriesOptions.Add(new ComparisonSeriesOption("Current"));
+                ChartSeriesOptions.Add(new ComparisonSeriesOption("Temperature"));
+                ChartSeriesOptions.Add(new ComparisonSeriesOption("Capacity"));
+            }
+
+            if (Warnings.Count == 0)
+            {
+                Warnings.Add(new AnalysisWarning("Pulse segment missing headers", "Verify RAW log between 120s and 180s."));
+                Warnings.Add(new AnalysisWarning("Temperature drift detected", "Apply correction or exclude segment before ECM computation."));
+            }
+
+            if (SessionTemplates.Count == 0)
+            {
+                SessionTemplates.Add(new AnalysisTemplate("ECM regression", "Baseline + regression overlay", DateTime.Now.AddDays(-3))
+                {
+                    PreferredChartMode = "Voltage",
+                    NormalizationOption = "Baseline voltage",
+                    ResampleOption = "1 s"
+                });
+            }
+
+            if (PinnedResults.Count == 0)
+            {
+                PinnedResults.Add(new AnalysisResultSummary(
+                    "ECM parameters",
+                    "R0 2.1 mΩ • Fit error 1.2%",
+                    new RelayCommand(() => AnalysisLog.Add("Opened ECM parameters")),
+                    new RelayCommand(() => RemovePinnedResult("ECM parameters"))));
+            }
+
+            LoadedFileCount = Datasets.Count;
+            SampleRateStatus = "Aligned (1 s)";
+            TotalTestDurationText = "1h 45m";
+            VoltageSummary = "3.05 / 4.20 / 3.72 V";
+            CurrentSummary = "-8.0 / 10.0 / 0.2 A";
+            EnergySummary = "52.4 Wh";
+            SelectionSummary = "Full dataset";
+            SelectionVoltageSummary = "3.10 / 3.80 / 3.55 V";
+            SelectionDurationText = "Span: 00:30:00";
+            CurrentCellLabel = "Cell A1 • SN-4812";
+        }
+
+        private void UpdateStatisticsFor(AnalysisDataset dataset)
+        {
+            if (dataset == null)
+            {
+                return;
+            }
+
+            TotalTestDurationText = "1h 32m";
+            VoltageSummary = "3.02 / 4.18 / 3.70 V";
+            CurrentSummary = "-7.5 / 9.8 / 0.1 A";
+            EnergySummary = "50.8 Wh";
+            SelectionSummary = $"Viewing {dataset.DisplayName}";
+            SelectionVoltageSummary = "3.05 / 3.80 / 3.60 V";
+            SelectionDurationText = "Span: 00:20:00";
+        }
+
+        private void OnDatasetPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (sender is not AnalysisDataset dataset)
+            {
+                return;
+            }
+
+            if (e.PropertyName == nameof(AnalysisDataset.IsBaseline) && dataset.IsBaseline)
+            {
+                foreach (var other in Datasets.Where(d => !ReferenceEquals(d, dataset)))
+                {
+                    other.IsBaseline = false;
+                }
+            }
+
+            if (e.PropertyName == nameof(AnalysisDataset.IsIncluded))
+            {
+                AnalysisLog.Add($"{dataset.DisplayName} inclusion changed: {dataset.IsIncluded}");
+            }
+        }
+
+        private void RefreshDerivedState()
+        {
+            LoadedFileCount = Datasets.Count;
+            HasWarnings = Warnings.Count > 0;
+        }
+    }
+
+    public partial class AnalysisDataset : ObservableObject
+    {
+        public AnalysisDataset(string displayName, string metadata, Brush seriesBrush)
+        {
+            DisplayName = displayName;
+            Metadata = metadata;
+            SeriesBrush = seriesBrush;
+        }
+
+        public string DisplayName { get; }
+        public string Metadata { get; }
+        public Brush SeriesBrush { get; }
+
+        [ObservableProperty]
+        private bool _isBaseline;
+
+        [ObservableProperty]
+        private bool _isIncluded = true;
+
+        [ObservableProperty]
+        private DateTime _importedAt;
+
+        [ObservableProperty]
+        private string? _notes;
+    }
+
+    public partial class AnalysisTemplate : ObservableObject
+    {
+        public AnalysisTemplate(string name, string description, DateTime createdAt)
+        {
+            Name = name;
+            Description = description;
+            CreatedAt = createdAt;
+        }
+
+        public string Name { get; }
+        public string Description { get; }
+        public DateTime CreatedAt { get; }
+
+        [ObservableProperty]
+        private string? _preferredChartMode;
+
+        [ObservableProperty]
+        private string? _normalizationOption;
+
+        [ObservableProperty]
+        private string? _resampleOption;
+    }
+
+    public partial class AnalysisWarning : ObservableObject
+    {
+        public AnalysisWarning(string message, string suggestedAction)
+        {
+            Message = message;
+            SuggestedAction = suggestedAction;
+        }
+
+        public string Message { get; }
+        public string SuggestedAction { get; }
+    }
+
+    public partial class ComparisonSeriesOption : ObservableObject
+    {
+        public ComparisonSeriesOption(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+
+        [ObservableProperty]
+        private bool _isVisible = true;
+    }
+
+    public partial class ChartModeOption : ObservableObject
+    {
+        public ChartModeOption(string name, string icon)
+        {
+            Name = name;
+            Icon = icon;
+        }
+
+        public string Name { get; }
+        public string Icon { get; }
+    }
+
+    public partial class AnalysisOperationStatus : ObservableObject
+    {
+        public AnalysisOperationStatus(string title, string description, IRelayCommand recomputeCommand)
+        {
+            Title = title;
+            Description = description;
+            RecomputeCommand = recomputeCommand;
+        }
+
+        public string Title { get; }
+        public string Description { get; }
+        public IRelayCommand RecomputeCommand { get; }
+
+        [ObservableProperty]
+        private bool _isBusy;
+
+        [ObservableProperty]
+        private double _progress;
+
+        [ObservableProperty]
+        private string? _statusMessage = "Idle";
+
+        [ObservableProperty]
+        private string? _errorMessage;
+
+        [ObservableProperty]
+        private DateTime? _lastRunAt;
+
+        [ObservableProperty]
+        private string? _lastRunText;
+
+        public bool HasError => !string.IsNullOrWhiteSpace(ErrorMessage);
+
+        partial void OnErrorMessageChanged(string? value) => OnPropertyChanged(nameof(HasError));
+    }
+
+    public partial class AnalysisResultSummary : ObservableObject
+    {
+        public AnalysisResultSummary(string title, string subtitle, IRelayCommand openCommand, IRelayCommand removeCommand)
+        {
+            Title = title;
+            Subtitle = subtitle;
+            OpenCommand = openCommand;
+            RemoveCommand = removeCommand;
+        }
+
+        public string Title { get; }
+        public string Subtitle { get; }
+        public IRelayCommand OpenCommand { get; }
+        public IRelayCommand RemoveCommand { get; }
+    }
+
+    public partial class SessionSnapshot : ObservableObject
+    {
+        public SessionSnapshot(string title, DateTime savedAt)
+        {
+            Title = title;
+            SavedAt = savedAt;
+        }
+
+        public string Title { get; }
+        public DateTime SavedAt { get; }
+        public override string ToString() => $"{Title} • {SavedAt:yyyy-MM-dd HH:mm}";
     }
 }

--- a/CellManager/CellManager/Views/AnalysisView.xaml
+++ b/CellManager/CellManager/Views/AnalysisView.xaml
@@ -250,9 +250,11 @@
                 <materialDesign:Card>
                     <StackPanel>
                         <TextBlock Text="Residual analysis" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,8"/>
-                        <Grid Height="180" Background="#F9FAFB" CornerRadius="6">
-                            <TextBlock Text="Residual plot placeholder" Foreground="#9CA3AF" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                        </Grid>
+                        <Border Height="180" Background="#F9FAFB" CornerRadius="6">
+                            <Grid>
+                                <TextBlock Text="Residual plot placeholder" Foreground="#9CA3AF" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Grid>
+                        </Border>
                     </StackPanel>
                 </materialDesign:Card>
             </StackPanel>

--- a/CellManager/CellManager/Views/AnalysisView.xaml
+++ b/CellManager/CellManager/Views/AnalysisView.xaml
@@ -1,0 +1,376 @@
+<UserControl x:Class="CellManager.Views.AnalysisView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:viewModels="clr-namespace:CellManager.ViewModels"
+             mc:Ignorable="d"
+             d:DesignHeight="900" d:DesignWidth="1600"
+             d:DataContext="{d:DesignInstance Type=viewModels:AnalysisViewModel, IsDesignTimeCreatable=True}">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <Style TargetType="ToggleButton" x:Key="SectionToggleButton" BasedOn="{StaticResource {x:Type ToggleButton}}">
+            <Setter Property="Margin" Value="4,0"/>
+            <Setter Property="Padding" Value="12,4"/>
+            <Setter Property="Background" Value="#F3F4F6"/>
+            <Setter Property="BorderBrush" Value="#D1D5DB"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="6"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Style.Triggers>
+                <Trigger Property="IsChecked" Value="True">
+                    <Setter Property="Background" Value="{DynamicResource PrimaryMain}"/>
+                    <Setter Property="Foreground" Value="White"/>
+                    <Setter Property="BorderBrush" Value="{DynamicResource PrimaryPressed}"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+        <DataTemplate x:Key="WarningTemplate" DataType="{x:Type viewModels:AnalysisWarning}">
+            <Border Background="#FEF3C7" BorderBrush="#FCD34D" BorderThickness="1" CornerRadius="6" Padding="8" Margin="0,4,0,0">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Orientation="Horizontal" Grid.Column="0" Margin="0,0,12,0" VerticalAlignment="Center">
+                        <materialDesign:PackIcon Kind="AlertCircle" Width="20" Height="20" Foreground="#92400E"/>
+                    </StackPanel>
+                    <StackPanel Grid.Column="1">
+                        <TextBlock Text="{Binding Message}" FontWeight="SemiBold" Foreground="#78350F"/>
+                        <TextBlock Text="{Binding SuggestedAction}" Foreground="#92400E" FontSize="12" TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </DataTemplate>
+        <DataTemplate x:Key="DatasetTemplate" DataType="{x:Type viewModels:AnalysisDataset}">
+            <Border BorderBrush="#E5E7EB" BorderThickness="1" CornerRadius="8" Padding="10" Margin="0,4,0,0">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <Ellipse Width="16" Height="16" Fill="{Binding SeriesBrush}" VerticalAlignment="Top"/>
+                    <StackPanel Grid.Column="1" Margin="12,0,0,0">
+                        <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold"/>
+                        <TextBlock Text="{Binding Metadata}" Foreground="#6B7280" FontSize="12" TextWrapping="Wrap"/>
+                        <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                            <CheckBox Content="Baseline" IsChecked="{Binding IsBaseline, Mode=TwoWay}"/>
+                            <CheckBox Content="Include" IsChecked="{Binding IsIncluded, Mode=TwoWay}" Margin="12,0,0,0"/>
+                        </StackPanel>
+                    </StackPanel>
+                    <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top">
+                        <Button Command="{Binding DataContext.RemoveDatasetCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                CommandParameter="{Binding}" Style="{StaticResource MaterialDesignToolForegroundButton}">
+                            <StackPanel Orientation="Horizontal">
+                                <materialDesign:PackIcon Kind="Delete" Width="16" Height="16"/>
+                                <TextBlock Text="Remove" Margin="4,0,0,0"/>
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </DataTemplate>
+        <DataTemplate x:Key="TemplateItemTemplate" DataType="{x:Type viewModels:AnalysisTemplate}">
+            <Border BorderThickness="1" BorderBrush="#E5E7EB" CornerRadius="8" Padding="8" Margin="0,4,0,0">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel>
+                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
+                        <TextBlock Text="{Binding Description}" Foreground="#6B7280" FontSize="12" TextWrapping="Wrap"/>
+                        <TextBlock Text="{Binding CreatedAt, StringFormat='Saved {0:yyyy-MM-dd HH:mm}'}" Foreground="#9CA3AF" FontSize="11"/>
+                    </StackPanel>
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Top">
+                        <Button Command="{Binding DataContext.ApplyTemplateCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                CommandParameter="{Binding}" Style="{StaticResource PrimaryActionButton}" Margin="0,0,4,0">Apply</Button>
+                        <Button Command="{Binding DataContext.DeleteTemplateCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                CommandParameter="{Binding}" Style="{StaticResource MaterialDesignToolForegroundButton}">Delete</Button>
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </DataTemplate>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header ribbon -->
+        <materialDesign:Card Grid.Row="0" Margin="8">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Orientation="Horizontal">
+                    <materialDesign:PackIcon Kind="ChartAreaspline" Width="26" Height="26" Margin="0,0,12,0"/>
+                    <StackPanel Margin="0,0,12,0">
+                        <TextBlock Text="Analyzer" FontSize="20" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding CurrentCellLabel}" Foreground="#6B7280"/>
+                    </StackPanel>
+                    <ToggleButton Content="Compare mode" Margin="12,0,0,0" IsChecked="{Binding IsCompareMode}" Style="{StaticResource SectionToggleButton}"/>
+                    <ToggleButton Content="Show pinned" Margin="8,0,0,0" IsChecked="{Binding IsPinnedResultsExpanded}" Style="{StaticResource SectionToggleButton}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Grid.Column="1" HorizontalAlignment="Right">
+                    <ComboBox Width="220" Margin="0,0,8,0" ItemsSource="{Binding LoadedSessionHistory}" SelectedItem="{Binding SelectedSessionSnapshot}" DisplayMemberPath="Title"/>
+                    <Button Content="Load RAW..." Command="{Binding LoadRawCommand}" Style="{StaticResource PrimaryActionButton}"/>
+                    <Button Content="Reload" Margin="8,0,0,0" Command="{Binding ReloadCommand}"/>
+                    <Button Content="Save Session" Margin="8,0,0,0" Command="{Binding SaveSessionCommand}"/>
+                </StackPanel>
+            </Grid>
+        </materialDesign:Card>
+
+        <!-- Body -->
+        <Grid Grid.Row="1" Margin="0,0,0,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="340"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="360"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Left column: data management -->
+            <StackPanel Grid.Column="0">
+                <materialDesign:Card>
+                    <StackPanel>
+                        <DockPanel Margin="0,0,0,8">
+                            <TextBlock DockPanel.Dock="Left" Text="Datasets" FontSize="16" FontWeight="SemiBold"/>
+                            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+                                <Button Content="Add file" Margin="0,0,6,0" Command="{Binding LoadRawCommand}" Style="{StaticResource PrimaryActionButton}"/>
+                                <Button Content="Remove" Command="{Binding RemoveSelectedDatasetCommand}"/>
+                            </StackPanel>
+                        </DockPanel>
+                        <ListBox ItemsSource="{Binding Datasets}" SelectedItem="{Binding SelectedDataset}" ItemTemplate="{StaticResource DatasetTemplate}"/>
+                        <Separator Margin="0,12"/>
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <TextBlock Text="Baseline alignment" FontWeight="SemiBold"/>
+                            <TextBlock Text="{Binding BaselineAlignmentHint}" Foreground="#6B7280" Margin="8,0,0,0"/>
+                        </StackPanel>
+                        <Slider Minimum="-120" Maximum="120" Value="{Binding AlignmentOffset}" Margin="0,8,0,0"/>
+                    </StackPanel>
+                </materialDesign:Card>
+
+                <materialDesign:Card Visibility="{Binding IsCompareMode, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <StackPanel>
+                        <TextBlock Text="Comparison options" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                            <StackPanel Width="140">
+                                <TextBlock Text="Normalize" FontWeight="SemiBold"/>
+                                <ComboBox ItemsSource="{Binding NormalizationOptions}" SelectedItem="{Binding SelectedNormalization}"/>
+                            </StackPanel>
+                            <StackPanel Margin="16,0,0,0" Width="140">
+                                <TextBlock Text="Resample" FontWeight="SemiBold"/>
+                                <ComboBox ItemsSource="{Binding ResampleOptions}" SelectedItem="{Binding SelectedResampleOption}"/>
+                            </StackPanel>
+                        </StackPanel>
+                        <TextBlock Text="Series visibility" FontWeight="SemiBold"/>
+                        <ItemsControl ItemsSource="{Binding ChartSeriesOptions}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <CheckBox Content="{Binding Name}" IsChecked="{Binding IsVisible, Mode=TwoWay}" Margin="0,4,0,0"/>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                        <StackPanel Orientation="Horizontal" Margin="0,12,0,0" HorizontalAlignment="Right">
+                            <Button Content="Save preset" Margin="0,0,6,0" Command="{Binding SaveComparisonPresetCommand}" Style="{StaticResource PrimaryActionButton}"/>
+                            <Button Content="Load preset" Command="{Binding LoadComparisonPresetCommand}"/>
+                        </StackPanel>
+                    </StackPanel>
+                </materialDesign:Card>
+
+                <materialDesign:Card>
+                    <StackPanel>
+                        <DockPanel>
+                            <TextBlock DockPanel.Dock="Left" Text="Session templates" FontSize="16" FontWeight="SemiBold"/>
+                            <Button DockPanel.Dock="Right" Content="Save current setup" Margin="8,0,0,0" Command="{Binding SaveTemplateCommand}" Style="{StaticResource PrimaryActionButton}"/>
+                        </DockPanel>
+                        <ListBox ItemsSource="{Binding SessionTemplates}" ItemTemplate="{StaticResource TemplateItemTemplate}"/>
+                    </StackPanel>
+                </materialDesign:Card>
+            </StackPanel>
+
+            <!-- Center column: charts -->
+            <StackPanel Grid.Column="1">
+                <materialDesign:Card>
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <TabControl Grid.Row="0" Margin="0,0,0,8" SelectedItem="{Binding SelectedChartMode}" ItemsSource="{Binding ChartModes}">
+                            <TabControl.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel Orientation="Horizontal" Margin="8,0">
+                                        <materialDesign:PackIcon Kind="{Binding Icon}" Width="16" Height="16" Margin="0,0,4,0"/>
+                                        <TextBlock Text="{Binding Name}"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </TabControl.ItemTemplate>
+                            <TabControl.ContentTemplate>
+                                <DataTemplate>
+                                    <Grid Background="#F9FAFB" Height="340" Margin="0,0,0,8">
+                                        <TextBlock Text="Interactive chart placeholder" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#9CA3AF"/>
+                                        <Border HorizontalAlignment="Right" VerticalAlignment="Top" Margin="12" Padding="12" Background="#FFFFFF" BorderBrush="#D1D5DB" BorderThickness="1" CornerRadius="8">
+                                            <StackPanel>
+                                                <TextBlock Text="Selection" FontWeight="SemiBold"/>
+                                                <TextBlock Text="{Binding DataContext.SelectionSummary, RelativeSource={RelativeSource AncestorType=TabControl}}" FontSize="12"/>
+                                                <TextBlock Text="{Binding DataContext.SelectionDurationText, RelativeSource={RelativeSource AncestorType=TabControl}}" FontSize="12"/>
+                                            </StackPanel>
+                                        </Border>
+                                    </Grid>
+                                </DataTemplate>
+                            </TabControl.ContentTemplate>
+                        </TabControl>
+                        <Expander Grid.Row="1" Header="Context timelines" IsExpanded="True">
+                            <ItemsControl ItemsSource="{Binding Datasets}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border Background="#EEF2FF" BorderBrush="#E5E7EB" BorderThickness="1" CornerRadius="4" Padding="8" Margin="0,4,0,0">
+                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
+                                                <Ellipse Width="12" Height="12" Fill="{Binding SeriesBrush}" Margin="0,0,8,0"/>
+                                                <TextBlock Text="{Binding DisplayName}" Width="160"/>
+                                                <TextBlock Text="Sparkline placeholder" Foreground="#9CA3AF"/>
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </Expander>
+                    </Grid>
+                </materialDesign:Card>
+
+                <materialDesign:Card>
+                    <StackPanel>
+                        <TextBlock Text="Residual analysis" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,8"/>
+                        <Grid Height="180" Background="#F9FAFB" CornerRadius="6">
+                            <TextBlock Text="Residual plot placeholder" Foreground="#9CA3AF" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Grid>
+                    </StackPanel>
+                </materialDesign:Card>
+            </StackPanel>
+
+            <!-- Right column: insights -->
+            <StackPanel Grid.Column="2">
+                <materialDesign:Card Visibility="{Binding HasWarnings, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <StackPanel>
+                        <TextBlock Text="Data quality checks" FontSize="16" FontWeight="SemiBold"/>
+                        <ItemsControl ItemsSource="{Binding Warnings}" ItemTemplate="{StaticResource WarningTemplate}"/>
+                    </StackPanel>
+                </materialDesign:Card>
+
+                <materialDesign:Card>
+                    <StackPanel>
+                        <TextBlock Text="Summary" FontSize="16" FontWeight="SemiBold"/>
+                        <Grid Margin="0,8,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Text="Duration" Grid.Row="0" Grid.Column="0" Foreground="#6B7280"/>
+                            <TextBlock Text="{Binding TotalTestDurationText}" Grid.Row="0" Grid.Column="1" FontWeight="SemiBold"/>
+                            <TextBlock Text="Voltage (min / max / avg)" Grid.Row="1" Grid.Column="0" Foreground="#6B7280"/>
+                            <TextBlock Text="{Binding VoltageSummary}" Grid.Row="1" Grid.Column="1" FontWeight="SemiBold"/>
+                            <TextBlock Text="Current (min / max / avg)" Grid.Row="2" Grid.Column="0" Foreground="#6B7280"/>
+                            <TextBlock Text="{Binding CurrentSummary}" Grid.Row="2" Grid.Column="1" FontWeight="SemiBold"/>
+                            <TextBlock Text="Energy throughput" Grid.Row="3" Grid.Column="0" Foreground="#6B7280"/>
+                            <TextBlock Text="{Binding EnergySummary}" Grid.Row="3" Grid.Column="1" FontWeight="SemiBold"/>
+                        </Grid>
+                        <Separator Margin="0,12"/>
+                        <TextBlock Text="Selection" FontSize="14" FontWeight="SemiBold"/>
+                        <TextBlock Text="{Binding SelectionSummary}" Foreground="#6B7280"/>
+                        <TextBlock Text="{Binding SelectionVoltageSummary}" FontWeight="SemiBold"/>
+                    </StackPanel>
+                </materialDesign:Card>
+
+                <materialDesign:Card>
+                    <StackPanel>
+                        <DockPanel>
+                            <TextBlock Text="Automatic analysis" DockPanel.Dock="Left" FontSize="16" FontWeight="SemiBold"/>
+                            <Button DockPanel.Dock="Right" Content="Export report" Command="{Binding ExportReportCommand}" Style="{StaticResource PrimaryActionButton}"/>
+                        </DockPanel>
+                        <ItemsControl ItemsSource="{Binding AutomaticAnalyses}" Margin="0,8,0,0">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type viewModels:AnalysisOperationStatus}">
+                                    <Border BorderBrush="#E5E7EB" BorderThickness="1" CornerRadius="8" Padding="10" Margin="0,4,0,0">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+                                            <StackPanel>
+                                                <TextBlock Text="{Binding Title}" FontWeight="SemiBold"/>
+                                                <TextBlock Text="{Binding Description}" Foreground="#6B7280" FontSize="12" TextWrapping="Wrap"/>
+                                                <ProgressBar Value="{Binding Progress}" Minimum="0" Maximum="100" Height="6" Margin="0,8,0,0" Visibility="{Binding IsBusy, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                                <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                                                    <TextBlock Text="{Binding StatusMessage}" Margin="0,0,12,0" FontSize="12" Foreground="#4B5563"/>
+                                                    <TextBlock Text="{Binding LastRunText}" FontSize="12" Foreground="#9CA3AF"/>
+                                                </StackPanel>
+                                                <TextBlock Text="{Binding ErrorMessage}" Foreground="#B91C1C" FontSize="12" Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                            </StackPanel>
+                                            <Button Grid.Column="1" Content="Recompute" Command="{Binding RecomputeCommand}" Style="{StaticResource PrimaryActionButton}" VerticalAlignment="Top"/>
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                        <Expander Header="Pinned results" IsExpanded="{Binding IsPinnedResultsExpanded}" Margin="0,12,0,0">
+                            <ItemsControl ItemsSource="{Binding PinnedResults}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="{x:Type viewModels:AnalysisResultSummary}">
+                                        <Border BorderBrush="#E5E7EB" BorderThickness="1" CornerRadius="8" Padding="8" Margin="0,4,0,0">
+                                            <StackPanel>
+                                                <TextBlock Text="{Binding Title}" FontWeight="SemiBold"/>
+                                                <TextBlock Text="{Binding Subtitle}" Foreground="#6B7280" FontSize="12"/>
+                                                <StackPanel Orientation="Horizontal" Margin="0,6,0,0" HorizontalAlignment="Right">
+                                                    <Button Content="Open" Margin="0,0,8,0" Command="{Binding OpenCommand}"/>
+                                                    <Button Content="Remove" Command="{Binding RemoveCommand}"/>
+                                                </StackPanel>
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </Expander>
+                    </StackPanel>
+                </materialDesign:Card>
+
+                <materialDesign:Card>
+                    <StackPanel>
+                        <TextBlock Text="Analysis log" FontSize="16" FontWeight="SemiBold"/>
+                        <ListBox ItemsSource="{Binding AnalysisLog}" Height="140"/>
+                    </StackPanel>
+                </materialDesign:Card>
+            </StackPanel>
+        </Grid>
+
+        <!-- Status bar -->
+        <StatusBar Grid.Row="2">
+            <StatusBarItem>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="Files:" Margin="0,0,8,0" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding LoadedFileCount}" Margin="0,0,8,0"/>
+                    <Border Style="{StaticResource VDivider}" Margin="8,0"/>
+                    <TextBlock Text="Sample rate" FontWeight="SemiBold" Margin="8,0,8,0"/>
+                    <TextBlock Text="{Binding SampleRateStatus}" Margin="0,0,8,0"/>
+                    <Border Style="{StaticResource VDivider}" Margin="8,0"/>
+                    <TextBlock Text="Last analysis" FontWeight="SemiBold" Margin="8,0,8,0"/>
+                    <TextBlock Text="{Binding LastAnalysisTimestampText}" Margin="0,0,8,0"/>
+                </StackPanel>
+            </StatusBarItem>
+        </StatusBar>
+    </Grid>
+</UserControl>

--- a/CellManager/CellManager/Views/AnalysisView.xaml.cs
+++ b/CellManager/CellManager/Views/AnalysisView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace CellManager.Views
+{
+    public partial class AnalysisView : UserControl
+    {
+        public AnalysisView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the analyzer tab placeholder with a Material Design layout that covers session management, visualization, insights, and export actions
- expand `AnalysisViewModel` with observable collections, commands, and sample data to drive the new UI, including automatic analysis statuses and report export hooks
- update `MainWindow.xaml` to host the new analyzer view

## Testing
- `dotnet build` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2a92fe388323b9c3fd0b0021542e