### PR TITLE
Add numeric validation rules for cell detail inputs

### DIFF
--- a/CellManager/CellManager/Configuration/CellDetailNumericRules.cs
+++ b/CellManager/CellManager/Configuration/CellDetailNumericRules.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using CellManager.Models;
+
+namespace CellManager.Configuration
+{
+    /// <summary>
+    ///     Centralizes the numeric ranges allowed for editable number fields in the Cell Details dialog.
+    /// </summary>
+    public static class CellDetailNumericRules
+    {
+        private static readonly IReadOnlyDictionary<string, NumericFieldRule> Rules =
+            new Dictionary<string, NumericFieldRule>(StringComparer.Ordinal)
+            {
+                [nameof(Cell.RatedCapacity)] = new NumericFieldRule(
+                    nameof(Cell.RatedCapacity),
+                    "Rated capacity (mAh)",
+                    new NumericRange(minValue: 1, maxValue: 1_000_000)),
+                [nameof(Cell.NominalVoltage)] = new NumericFieldRule(
+                    nameof(Cell.NominalVoltage),
+                    "Nominal voltage (mV)",
+                    new NumericRange(minValue: 1, maxValue: 10_000)),
+                [nameof(Cell.SelfDischarge)] = new NumericFieldRule(
+                    nameof(Cell.SelfDischarge),
+                    "Self-discharge (%/month)",
+                    new NumericRange(minValue: 0, maxValue: 100)),
+                [nameof(Cell.MaxVoltage)] = new NumericFieldRule(
+                    nameof(Cell.MaxVoltage),
+                    "Max voltage (mV)",
+                    new NumericRange(minValue: 0, maxValue: 10_000)),
+                [nameof(Cell.CycleLife)] = new NumericFieldRule(
+                    nameof(Cell.CycleLife),
+                    "Cycle life (cycles)",
+                    new NumericRange(minValue: 0, maxValue: 1_000_000)),
+                [nameof(Cell.InitialACImpedance)] = new NumericFieldRule(
+                    nameof(Cell.InitialACImpedance),
+                    "Initial AC impedance (mΩ)",
+                    new NumericRange(minValue: 0, maxValue: 10_000)),
+                [nameof(Cell.InitialDCResistance)] = new NumericFieldRule(
+                    nameof(Cell.InitialDCResistance),
+                    "Initial DC resistance (mΩ)",
+                    new NumericRange(minValue: 0, maxValue: 10_000)),
+                [nameof(Cell.EnergyWh)] = new NumericFieldRule(
+                    nameof(Cell.EnergyWh),
+                    "Energy (Wh)",
+                    new NumericRange(minValue: 0, maxValue: 100_000)),
+                [nameof(Cell.Weight)] = new NumericFieldRule(
+                    nameof(Cell.Weight),
+                    "Weight (g)",
+                    new NumericRange(minValue: 0, maxValue: 10_000)),
+                [nameof(Cell.Diameter)] = new NumericFieldRule(
+                    nameof(Cell.Diameter),
+                    "Diameter (mm)",
+                    new NumericRange(minValue: 0, maxValue: 10_000)),
+                [nameof(Cell.Thickness)] = new NumericFieldRule(
+                    nameof(Cell.Thickness),
+                    "Thickness (mm)",
+                    new NumericRange(minValue: 0, maxValue: 10_000)),
+                [nameof(Cell.Width)] = new NumericFieldRule(
+                    nameof(Cell.Width),
+                    "Width (mm)",
+                    new NumericRange(minValue: 0, maxValue: 10_000)),
+                [nameof(Cell.Height)] = new NumericFieldRule(
+                    nameof(Cell.Height),
+                    "Height (mm)",
+                    new NumericRange(minValue: 0, maxValue: 10_000)),
+                [nameof(Cell.ChargingVoltage)] = new NumericFieldRule(
+                    nameof(Cell.ChargingVoltage),
+                    "Charging voltage (mV)",
+                    new NumericRange(minValue: 0, maxValue: 10_000)),
+                [nameof(Cell.CutOffCurrent_Charge)] = new NumericFieldRule(
+                    nameof(Cell.CutOffCurrent_Charge),
+                    "Cut-off current (mA)",
+                    new NumericRange(minValue: 0, maxValue: 100_000)),
+                [nameof(Cell.MaxChargingCurrent)] = new NumericFieldRule(
+                    nameof(Cell.MaxChargingCurrent),
+                    "Max charging current (mA)",
+                    new NumericRange(minValue: 0, maxValue: 100_000)),
+                [nameof(Cell.MaxChargingTemp)] = new NumericFieldRule(
+                    nameof(Cell.MaxChargingTemp),
+                    "Max charging temperature (°C)",
+                    new NumericRange(minValue: -100, maxValue: 200)),
+                [nameof(Cell.ChargeTempHigh)] = new NumericFieldRule(
+                    nameof(Cell.ChargeTempHigh),
+                    "Charge temp high (°C)",
+                    new NumericRange(minValue: -100, maxValue: 200)),
+                [nameof(Cell.ChargeTempLow)] = new NumericFieldRule(
+                    nameof(Cell.ChargeTempLow),
+                    "Charge temp low (°C)",
+                    new NumericRange(minValue: -100, maxValue: 200)),
+                [nameof(Cell.DischargeCutOffVoltage)] = new NumericFieldRule(
+                    nameof(Cell.DischargeCutOffVoltage),
+                    "Discharge cut-off voltage (mV)",
+                    new NumericRange(minValue: 0, maxValue: 10_000)),
+                [nameof(Cell.MaxDischargingCurrent)] = new NumericFieldRule(
+                    nameof(Cell.MaxDischargingCurrent),
+                    "Max discharging current (mA)",
+                    new NumericRange(minValue: 0, maxValue: 100_000)),
+                [nameof(Cell.DischargeTempHigh)] = new NumericFieldRule(
+                    nameof(Cell.DischargeTempHigh),
+                    "Discharge temp high (°C)",
+                    new NumericRange(minValue: -100, maxValue: 200)),
+                [nameof(Cell.DischargeTempLow)] = new NumericFieldRule(
+                    nameof(Cell.DischargeTempLow),
+                    "Discharge temp low (°C)",
+                    new NumericRange(minValue: -100, maxValue: 200)),
+                [nameof(Cell.ConstantCurrent_PreCharge)] = new NumericFieldRule(
+                    nameof(Cell.ConstantCurrent_PreCharge),
+                    "Constant current (mA)",
+                    new NumericRange(minValue: 0, maxValue: 100_000)),
+                [nameof(Cell.PreChargeStartVoltage)] = new NumericFieldRule(
+                    nameof(Cell.PreChargeStartVoltage),
+                    "Pre-charge start voltage (mV)",
+                    new NumericRange(minValue: 0, maxValue: 10_000)),
+                [nameof(Cell.PreChargeEndVoltage)] = new NumericFieldRule(
+                    nameof(Cell.PreChargeEndVoltage),
+                    "Pre-charge end voltage (mV)",
+                    new NumericRange(minValue: 0, maxValue: 10_000)),
+            };
+
+        public static bool TryGetRule(string propertyName, out NumericFieldRule rule)
+        {
+            if (string.IsNullOrWhiteSpace(propertyName))
+            {
+                rule = default;
+                return false;
+            }
+
+            return Rules.TryGetValue(propertyName, out rule);
+        }
+
+        public static NumericFieldRule GetRule(string propertyName)
+        {
+            if (TryGetRule(propertyName, out var rule))
+            {
+                return rule;
+            }
+
+            throw new KeyNotFoundException($"No numeric rule defined for property '{propertyName}'.");
+        }
+    }
+
+    public readonly struct NumericRange
+    {
+        public NumericRange(double minValue, double maxValue)
+        {
+            if (maxValue < minValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxValue), maxValue, "Maximum value cannot be less than the minimum value.");
+            }
+
+            MinValue = minValue;
+            MaxValue = maxValue;
+        }
+
+        public double MinValue { get; }
+        public double MaxValue { get; }
+
+        public bool Contains(double value) => value >= MinValue && value <= MaxValue;
+    }
+
+    public readonly struct NumericFieldRule
+    {
+        public NumericFieldRule(string propertyName, string displayName, NumericRange range)
+        {
+            PropertyName = propertyName ?? throw new ArgumentNullException(nameof(propertyName));
+            DisplayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
+            Range = range;
+        }
+
+        public string PropertyName { get; }
+        public string DisplayName { get; }
+        public NumericRange Range { get; }
+
+        public string CreateRangeErrorMessage()
+        {
+            var minText = FormatValue(Range.MinValue);
+            var maxText = FormatValue(Range.MaxValue);
+
+            if (double.IsNegativeInfinity(Range.MinValue) && double.IsPositiveInfinity(Range.MaxValue))
+            {
+                return string.Empty;
+            }
+
+            if (double.IsNegativeInfinity(Range.MinValue))
+            {
+                return string.Format(CultureInfo.CurrentCulture, "{0} must be {1} or less.", DisplayName, maxText);
+            }
+
+            if (double.IsPositiveInfinity(Range.MaxValue))
+            {
+                return string.Format(CultureInfo.CurrentCulture, "{0} must be {1} or greater.", DisplayName, minText);
+            }
+
+            if (Range.MinValue.Equals(Range.MaxValue))
+            {
+                return string.Format(CultureInfo.CurrentCulture, "{0} must be {1}.", DisplayName, minText);
+            }
+
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                "{0} must be between {1} and {2}.",
+                DisplayName,
+                minText,
+                maxText);
+        }
+
+        private static string FormatValue(double value)
+        {
+            return value.ToString("0.###", CultureInfo.CurrentCulture);
+        }
+    }
+}

--- a/CellManager/CellManager/Configuration/CellDetailTextRules.cs
+++ b/CellManager/CellManager/Configuration/CellDetailTextRules.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using CellManager.Models;
+
+namespace CellManager.Configuration
+{
+    /// <summary>
+    ///     Centralizes the allowed text ranges for user editable fields within the Cell Details dialog.
+    /// </summary>
+    public static class CellDetailTextRules
+    {
+        private static readonly IReadOnlyDictionary<string, TextFieldRule> Rules =
+            new Dictionary<string, TextFieldRule>(StringComparer.Ordinal)
+            {
+                [nameof(Cell.ModelName)] = new TextFieldRule(
+                    nameof(Cell.ModelName),
+                    "Model name",
+                    new TextRange(minLength: 1, maxLength: 100)),
+                [nameof(Cell.Manufacturer)] = new TextFieldRule(
+                    nameof(Cell.Manufacturer),
+                    "Manufacturer",
+                    new TextRange(minLength: 0, maxLength: 100)),
+                [nameof(Cell.SerialNumber)] = new TextFieldRule(
+                    nameof(Cell.SerialNumber),
+                    "Serial number",
+                    new TextRange(minLength: 0, maxLength: 100)),
+                [nameof(Cell.PartNumber)] = new TextFieldRule(
+                    nameof(Cell.PartNumber),
+                    "Part number",
+                    new TextRange(minLength: 0, maxLength: 100)),
+                [nameof(Cell.CellType)] = new TextFieldRule(
+                    nameof(Cell.CellType),
+                    "Cell type",
+                    new TextRange(minLength: 0, maxLength: 60)),
+                [nameof(Cell.ExpansionBehavior)] = new TextFieldRule(
+                    nameof(Cell.ExpansionBehavior),
+                    "Expansion behavior",
+                    new TextRange(minLength: 0, maxLength: 500)),
+            };
+
+        public static int ModelNameMaxLength => Rules[nameof(Cell.ModelName)].Range.MaxLength;
+        public static int ManufacturerMaxLength => Rules[nameof(Cell.Manufacturer)].Range.MaxLength;
+        public static int SerialNumberMaxLength => Rules[nameof(Cell.SerialNumber)].Range.MaxLength;
+        public static int PartNumberMaxLength => Rules[nameof(Cell.PartNumber)].Range.MaxLength;
+        public static int CellTypeMaxLength => Rules[nameof(Cell.CellType)].Range.MaxLength;
+        public static int ExpansionBehaviorMaxLength => Rules[nameof(Cell.ExpansionBehavior)].Range.MaxLength;
+
+        public static bool TryGetRule(string propertyName, out TextFieldRule rule)
+        {
+            if (string.IsNullOrWhiteSpace(propertyName))
+            {
+                rule = default;
+                return false;
+            }
+
+            return Rules.TryGetValue(propertyName, out rule);
+        }
+    }
+
+    public readonly struct TextRange
+    {
+        public TextRange(int minLength, int maxLength)
+        {
+            if (minLength < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minLength), minLength, "Minimum length cannot be negative.");
+            }
+
+            if (maxLength < minLength)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, "Maximum length cannot be less than the minimum length.");
+            }
+
+            MinLength = minLength;
+            MaxLength = maxLength;
+        }
+
+        public int MinLength { get; }
+        public int MaxLength { get; }
+
+        public bool Contains(string? value)
+        {
+            int length = string.IsNullOrEmpty(value) ? 0 : value.Length;
+            return length >= MinLength && length <= MaxLength;
+        }
+    }
+
+    public readonly struct TextFieldRule
+    {
+        public TextFieldRule(string propertyName, string displayName, TextRange range)
+        {
+            PropertyName = propertyName ?? throw new ArgumentNullException(nameof(propertyName));
+            DisplayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
+            Range = range;
+        }
+
+        public string PropertyName { get; }
+        public string DisplayName { get; }
+        public TextRange Range { get; }
+
+        public string CreateLengthErrorMessage()
+        {
+            if (Range.MaxLength == int.MaxValue)
+            {
+                return string.Empty;
+            }
+
+            if (Range.MinLength > 0)
+            {
+                return $"{DisplayName} must be between {Range.MinLength} and {Range.MaxLength} characters.";
+            }
+
+            return $"{DisplayName} must be {Range.MaxLength} characters or fewer.";
+        }
+    }
+}

--- a/CellManager/CellManager/ViewModels/CellDetailsViewModel.cs
+++ b/CellManager/CellManager/ViewModels/CellDetailsViewModel.cs
@@ -1,9 +1,11 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Input;
+using CellManager.Configuration;
 using CellManager.Models;
 using CellManager.Services;
 
@@ -11,6 +13,42 @@ namespace CellManager.ViewModels
 {
     public partial class CellDetailsViewModel : ObservableObject, IDataErrorInfo
     {
+        private static readonly IReadOnlyList<string> ValidatedProperties = new[]
+        {
+            nameof(Cell.ModelName),
+            nameof(Cell.RatedCapacity),
+            nameof(Cell.NominalVoltage),
+            nameof(Cell.Manufacturer),
+            nameof(Cell.SerialNumber),
+            nameof(Cell.PartNumber),
+            nameof(Cell.CellType),
+            nameof(Cell.ExpansionBehavior),
+            nameof(Cell.SelfDischarge),
+            nameof(Cell.MaxVoltage),
+            nameof(Cell.CycleLife),
+            nameof(Cell.InitialACImpedance),
+            nameof(Cell.InitialDCResistance),
+            nameof(Cell.EnergyWh),
+            nameof(Cell.Weight),
+            nameof(Cell.Diameter),
+            nameof(Cell.Thickness),
+            nameof(Cell.Width),
+            nameof(Cell.Height),
+            nameof(Cell.ChargingVoltage),
+            nameof(Cell.CutOffCurrent_Charge),
+            nameof(Cell.MaxChargingCurrent),
+            nameof(Cell.MaxChargingTemp),
+            nameof(Cell.ChargeTempHigh),
+            nameof(Cell.ChargeTempLow),
+            nameof(Cell.DischargeCutOffVoltage),
+            nameof(Cell.MaxDischargingCurrent),
+            nameof(Cell.DischargeTempHigh),
+            nameof(Cell.DischargeTempLow),
+            nameof(Cell.ConstantCurrent_PreCharge),
+            nameof(Cell.PreChargeStartVoltage),
+            nameof(Cell.PreChargeEndVoltage)
+        };
+
         private readonly ICellRepository _cellRepository;
 
         [ObservableProperty]
@@ -53,10 +91,21 @@ namespace CellManager.ViewModels
             window.Close();
         }
 
-        private bool HasErrors =>
-            !string.IsNullOrEmpty(this[nameof(Cell.ModelName)]) ||
-            !string.IsNullOrEmpty(this[nameof(Cell.RatedCapacity)]) ||
-            !string.IsNullOrEmpty(this[nameof(Cell.NominalVoltage)]);
+        private bool HasErrors
+        {
+            get
+            {
+                foreach (var property in ValidatedProperties)
+                {
+                    if (!string.IsNullOrEmpty(this[property]))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
 
         public string Error => null;
 
@@ -64,17 +113,104 @@ namespace CellManager.ViewModels
         {
             get
             {
-                return columnName switch
+                var normalizedColumnName = NormalizeColumnName(columnName);
+
+                return normalizedColumnName switch
                 {
-                    nameof(Cell.ModelName) or "ModelName" =>
-                        string.IsNullOrWhiteSpace(Cell?.ModelName) ? "Model name is required" : null,
-                    nameof(Cell.RatedCapacity) or "RatedCapacity" =>
-                        Cell?.RatedCapacity <= 0 ? "Rated capacity must be greater than 0" : null,
-                    nameof(Cell.NominalVoltage) or "NominalVoltage" =>
-                        Cell?.NominalVoltage <= 0 ? "Nominal voltage must be greater than 0" : null,
-                    _ => null,
+                    nameof(Cell.ModelName) =>
+                        string.IsNullOrWhiteSpace(Cell?.ModelName)
+                            ? "Model name is required"
+                            : ValidateStringLength(normalizedColumnName),
+                    nameof(Cell.Manufacturer) =>
+                        ValidateStringLength(normalizedColumnName),
+                    nameof(Cell.SerialNumber) =>
+                        ValidateStringLength(normalizedColumnName),
+                    nameof(Cell.PartNumber) =>
+                        ValidateStringLength(normalizedColumnName),
+                    nameof(Cell.CellType) =>
+                        ValidateStringLength(normalizedColumnName),
+                    nameof(Cell.ExpansionBehavior) =>
+                        ValidateStringLength(normalizedColumnName),
+                    _ => ValidateNumericRange(normalizedColumnName),
                 };
             }
         }
+
+        private static string NormalizeColumnName(string columnName)
+        {
+            if (string.IsNullOrWhiteSpace(columnName))
+            {
+                return string.Empty;
+            }
+
+            const string cellPrefix = "Cell.";
+            return columnName.StartsWith(cellPrefix, StringComparison.Ordinal)
+                ? columnName.Substring(cellPrefix.Length)
+                : columnName;
+        }
+
+        private string ValidateStringLength(string propertyName)
+        {
+            if (!CellDetailTextRules.TryGetRule(propertyName, out var rule))
+            {
+                return null;
+            }
+
+            var value = GetStringValue(propertyName);
+            return rule.Range.Contains(value) ? null : rule.CreateLengthErrorMessage();
+        }
+
+        private string ValidateNumericRange(string propertyName)
+        {
+            if (!CellDetailNumericRules.TryGetRule(propertyName, out var rule))
+            {
+                return null;
+            }
+
+            var value = GetNumericValue(propertyName);
+            return rule.Range.Contains(value) ? null : rule.CreateRangeErrorMessage();
+        }
+
+        private string GetStringValue(string propertyName) => propertyName switch
+        {
+            nameof(Cell.ModelName) => Cell?.ModelName ?? string.Empty,
+            nameof(Cell.Manufacturer) => Cell?.Manufacturer ?? string.Empty,
+            nameof(Cell.SerialNumber) => Cell?.SerialNumber ?? string.Empty,
+            nameof(Cell.PartNumber) => Cell?.PartNumber ?? string.Empty,
+            nameof(Cell.CellType) => Cell?.CellType ?? string.Empty,
+            nameof(Cell.ExpansionBehavior) => Cell?.ExpansionBehavior ?? string.Empty,
+            _ => string.Empty,
+        };
+
+        private double GetNumericValue(string propertyName) => propertyName switch
+        {
+            nameof(Cell.RatedCapacity) => Cell?.RatedCapacity ?? 0,
+            nameof(Cell.NominalVoltage) => Cell?.NominalVoltage ?? 0,
+            nameof(Cell.SelfDischarge) => Cell?.SelfDischarge ?? 0,
+            nameof(Cell.MaxVoltage) => Cell?.MaxVoltage ?? 0,
+            nameof(Cell.CycleLife) => Cell?.CycleLife ?? 0,
+            nameof(Cell.InitialACImpedance) => Cell?.InitialACImpedance ?? 0,
+            nameof(Cell.InitialDCResistance) => Cell?.InitialDCResistance ?? 0,
+            nameof(Cell.EnergyWh) => Cell?.EnergyWh ?? 0,
+            nameof(Cell.Weight) => Cell?.Weight ?? 0,
+            nameof(Cell.Diameter) => Cell?.Diameter ?? 0,
+            nameof(Cell.Thickness) => Cell?.Thickness ?? 0,
+            nameof(Cell.Width) => Cell?.Width ?? 0,
+            nameof(Cell.Height) => Cell?.Height ?? 0,
+            nameof(Cell.ChargingVoltage) => Cell?.ChargingVoltage ?? 0,
+            nameof(Cell.CutOffCurrent_Charge) => Cell?.CutOffCurrent_Charge ?? 0,
+            nameof(Cell.MaxChargingCurrent) => Cell?.MaxChargingCurrent ?? 0,
+            nameof(Cell.MaxChargingTemp) => Cell?.MaxChargingTemp ?? 0,
+            nameof(Cell.ChargeTempHigh) => Cell?.ChargeTempHigh ?? 0,
+            nameof(Cell.ChargeTempLow) => Cell?.ChargeTempLow ?? 0,
+            nameof(Cell.DischargeCutOffVoltage) => Cell?.DischargeCutOffVoltage ?? 0,
+            nameof(Cell.MaxDischargingCurrent) => Cell?.MaxDischargingCurrent ?? 0,
+            nameof(Cell.DischargeTempHigh) => Cell?.DischargeTempHigh ?? 0,
+            nameof(Cell.DischargeTempLow) => Cell?.DischargeTempLow ?? 0,
+            nameof(Cell.ConstantCurrent_PreCharge) => Cell?.ConstantCurrent_PreCharge ?? 0,
+            nameof(Cell.PreChargeStartVoltage) => Cell?.PreChargeStartVoltage ?? 0,
+            nameof(Cell.PreChargeEndVoltage) => Cell?.PreChargeEndVoltage ?? 0,
+            _ => 0,
+        };
     }
 }

--- a/CellManager/CellManager/Views/CellLibary/CellDetailsView.xaml
+++ b/CellManager/CellManager/Views/CellLibary/CellDetailsView.xaml
@@ -4,10 +4,18 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="clr-namespace:CellManager.ViewModels"
+        xmlns:config="clr-namespace:CellManager.Configuration"
         xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
         mc:Ignorable="d"
         Title="Cell Details" Height="650" Width="800"
         WindowStartupLocation="CenterScreen">
+
+    <Window.Resources>
+        <Style x:Key="ValidationTextBoxStyle" TargetType="TextBox">
+            <Setter Property="ToolTip"
+                    Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+        </Style>
+    </Window.Resources>
 
     <Grid>
         <Grid.RowDefinitions>
@@ -35,17 +43,28 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <TextBlock Grid.Row="0" Grid.Column="0" Text="Model Name" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Cell.ModelName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"
-                                     ToolTip="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                            <TextBox Grid.Row="0" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.ModelName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"
+                                     MaxLength="{x:Static config:CellDetailTextRules.ModelNameMaxLength}"/>
 
                             <TextBlock Grid.Row="1" Grid.Column="0" Text="Manufacturer" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Cell.Manufacturer, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="1" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.Manufacturer, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"
+                                     MaxLength="{x:Static config:CellDetailTextRules.ManufacturerMaxLength}"/>
 
                             <TextBlock Grid.Row="2" Grid.Column="0" Text="Serial Number" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Cell.SerialNumber, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="2" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.SerialNumber, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"
+                                     MaxLength="{x:Static config:CellDetailTextRules.SerialNumberMaxLength}"/>
 
                             <TextBlock Grid.Row="3" Grid.Column="0" Text="Part Number" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Cell.PartNumber, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="3" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.PartNumber, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"
+                                     MaxLength="{x:Static config:CellDetailTextRules.PartNumberMaxLength}"/>
                         </Grid>
                     </StackPanel>
                 </Border>
@@ -69,30 +88,44 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <TextBlock Grid.Row="0" Grid.Column="0" Text="Rated Capacity (mAh)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Cell.RatedCapacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"
-                                     ToolTip="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                            <TextBox Grid.Row="0" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.RatedCapacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="0" Grid.Column="3" Text="Nominal Voltage (mV)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="0" Grid.Column="4" Text="{Binding Cell.NominalVoltage, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"
-                                     ToolTip="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                            <TextBox Grid.Row="0" Grid.Column="4"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.NominalVoltage, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="1" Grid.Column="0" Text="Self-Discharge (%/month)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Cell.SelfDischarge, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="1" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.SelfDischarge, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="1" Grid.Column="3" Text="Max Voltage (mV)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="1" Grid.Column="4" Text="{Binding Cell.MaxVoltage, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="1" Grid.Column="4"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.MaxVoltage, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="2" Grid.Column="0" Text="Cycle Life" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Cell.CycleLife, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="2" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.CycleLife, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="2" Grid.Column="3" Text="Initial AC Impedance (mΩ)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="2" Grid.Column="4" Text="{Binding Cell.InitialACImpedance, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="2" Grid.Column="4"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.InitialACImpedance, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="3" Grid.Column="0" Text="Initial DC Resistance (mΩ)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Cell.InitialDCResistance, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="3" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.InitialDCResistance, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="3" Grid.Column="3" Text="Energy (Wh)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="3" Grid.Column="4" Text="{Binding Cell.EnergyWh, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="3" Grid.Column="4"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.EnergyWh, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
                         </Grid>
                     </StackPanel>
                 </Border>
@@ -115,25 +148,41 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <TextBlock Grid.Row="0" Grid.Column="0" Text="Cell Type" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Cell.CellType, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="0" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.CellType, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"
+                                     MaxLength="{x:Static config:CellDetailTextRules.CellTypeMaxLength}"/>
 
                             <TextBlock Grid.Row="0" Grid.Column="3" Text="Weight (g)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="0" Grid.Column="4" Text="{Binding Cell.Weight, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="0" Grid.Column="4"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.Weight, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="1" Grid.Column="0" Text="Diameter (mm)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Cell.Diameter, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="1" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.Diameter, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="1" Grid.Column="3" Text="Thickness (mm)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="1" Grid.Column="4" Text="{Binding Cell.Thickness, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="1" Grid.Column="4"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.Thickness, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="2" Grid.Column="0" Text="Width (mm)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Cell.Width, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="2" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.Width, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="2" Grid.Column="3" Text="Height (mm)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="2" Grid.Column="4" Text="{Binding Cell.Height, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="2" Grid.Column="4"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.Height, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="3" Grid.Column="0" Text="Expansion Behavior" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Cell.ExpansionBehavior, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="3" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.ExpansionBehavior, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"
+                                     MaxLength="{x:Static config:CellDetailTextRules.ExpansionBehaviorMaxLength}"/>
                         </Grid>
                     </StackPanel>
                 </Border>
@@ -156,22 +205,34 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <TextBlock Grid.Row="0" Grid.Column="0" Text="Charging Voltage (mV)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Cell.ChargingVoltage, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="0" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.ChargingVoltage, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="0" Grid.Column="3" Text="Cut-off Current (mA)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="0" Grid.Column="4" Text="{Binding Cell.CutOffCurrent_Charge, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="0" Grid.Column="4"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.CutOffCurrent_Charge, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="1" Grid.Column="0" Text="Max Charging Current (mA)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Cell.MaxChargingCurrent, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="1" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.MaxChargingCurrent, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="1" Grid.Column="3" Text="Max Charging Temp (°C)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="1" Grid.Column="4" Text="{Binding Cell.MaxChargingTemp, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="1" Grid.Column="4"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.MaxChargingTemp, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="2" Grid.Column="0" Text="Charge Temp High (°C)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Cell.ChargeTempHigh, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="2" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.ChargeTempHigh, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="2" Grid.Column="3" Text="Charge Temp Low (°C)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="2" Grid.Column="4" Text="{Binding Cell.ChargeTempLow, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="2" Grid.Column="4"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.ChargeTempLow, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                         </Grid>
                     </StackPanel>
@@ -195,16 +256,24 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <TextBlock Grid.Row="0" Grid.Column="0" Text="Discharge Cut-off Voltage (mV)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Cell.DischargeCutOffVoltage, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="0" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.DischargeCutOffVoltage, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="0" Grid.Column="3" Text="Max Discharging Current (mA)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="0" Grid.Column="4" Text="{Binding Cell.MaxDischargingCurrent, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="0" Grid.Column="4"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.MaxDischargingCurrent, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="1" Grid.Column="0" Text="Discharge Temp High (°C)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Cell.DischargeTempHigh, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="1" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.DischargeTempHigh, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="1" Grid.Column="3" Text="Discharge Temp Low (°C)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="1" Grid.Column="4" Text="{Binding Cell.DischargeTempLow, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="1" Grid.Column="4"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.DischargeTempLow, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
                         </Grid>
                     </StackPanel>
                 </Border>
@@ -226,13 +295,19 @@
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <TextBlock Grid.Row="0" Grid.Column="0" Text="Constant Current (mA)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Cell.ConstantCurrent_PreCharge, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="0" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.ConstantCurrent_PreCharge, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="1" Grid.Column="0" Text="Pre charge Start Voltage (mV)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Cell.PreChargeStartVoltage, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="1" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.PreChargeStartVoltage, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
 
                             <TextBlock Grid.Row="2" Grid.Column="0" Text="Pre charge End Voltage (mV)" Margin="0,5,10,5"/>
-                            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Cell.PreChargeEndVoltage, Mode=TwoWay}"/>
+                            <TextBox Grid.Row="2" Grid.Column="1"
+                                     Style="{StaticResource ValidationTextBoxStyle}"
+                                     Text="{Binding Cell.PreChargeEndVoltage, Mode=TwoWay, ValidatesOnDataErrors=True}"/>
                         </Grid>
                     </StackPanel>
                 </Border>


### PR DESCRIPTION
## Summary
- add a configuration catalog of numeric ranges that can be shared by cell detail bindings and validation logic
- validate all numeric fields in `CellDetailsViewModel` against the centralized ranges alongside the existing text-length rules
- update the cell details view bindings to surface validation feedback for every text and numeric input using the shared rules

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb5339ee008323884269e28ba25224