### PR TITLE
Maintain cell selection after editing

### DIFF
--- a/CellManager/CellManager/ViewModels/CellLibraryViewModel.cs
+++ b/CellManager/CellManager/ViewModels/CellLibraryViewModel.cs
@@ -46,6 +46,10 @@ namespace CellManager.ViewModels
         partial void OnSelectedCellChanged(Cell value)
         {
             OnPropertyChanged(nameof(CurrentCell));
+            foreach (var cell in CellModels)
+            {
+                cell.IsActive = cell == value;
+            }
             UpdateCanExecutes();
         }
 


### PR DESCRIPTION
## Summary
- ensure the cell currently assigned to `SelectedCell` is flagged active so the toggle button remains checked after edits

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbae6ef1888323b7555729234856de