### PR TITLE
Update cell type selection to use combo box

### DIFF
--- a/CellManager/CellManager/Views/CellLibary/CellDetailsView.xaml
+++ b/CellManager/CellManager/Views/CellLibary/CellDetailsView.xaml
@@ -166,10 +166,14 @@
                             </Grid.RowDefinitions>
                             <TextBlock Grid.Row="0" Grid.Column="0" Text="Cell Type" Style="{StaticResource FormLabelTextStyle}"/>
                             <StackPanel Grid.Row="0" Grid.Column="1" Style="{StaticResource FormFieldStackStyle}">
-                                <TextBox Style="{StaticResource ValidationTextBoxStyle}"
-                                         materialDesign:HintAssist.HelperText="{config:CellDetailTextRangeHint PropertyName='CellType'}"
-                                         Text="{Binding Cell.CellType, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"
-                                         MaxLength="{x:Static config:CellDetailTextRules.CellTypeMaxLength}"/>
+                                <ComboBox Style="{StaticResource ValidationComboBoxStyle}"
+                                          materialDesign:HintAssist.HelperText="{config:CellDetailTextRangeHint PropertyName='CellType'}"
+                                          SelectedValuePath="Content"
+                                          SelectedValue="{Binding Cell.CellType, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}">
+                                    <ComboBoxItem Content="Cylindrical"/>
+                                    <ComboBoxItem Content="Prismatic"/>
+                                    <ComboBoxItem Content="Pouch"/>
+                                </ComboBox>
                             </StackPanel>
 
                             <TextBlock Grid.Row="0" Grid.Column="3" Text="Weight (g)" Style="{StaticResource FormLabelTextStyle}"/>

--- a/CellManager/CellManager/Views/Shared/FormStyles.xaml
+++ b/CellManager/CellManager/Views/Shared/FormStyles.xaml
@@ -9,6 +9,13 @@
         <Setter Property="materialDesign:ValidationAssist.OnlyShowOnFocus" Value="False"/>
     </Style>
 
+    <Style x:Key="ValidationComboBoxStyle" TargetType="ComboBox" BasedOn="{StaticResource {x:Type ComboBox}}">
+        <Setter Property="Margin" Value="0"/>
+        <Setter Property="ToolTipService.IsEnabled" Value="False"/>
+        <Setter Property="materialDesign:ValidationAssist.UsePopup" Value="False"/>
+        <Setter Property="materialDesign:ValidationAssist.OnlyShowOnFocus" Value="False"/>
+    </Style>
+
     <Style TargetType="controls:TimeSpanEditor">
         <Setter Property="Margin" Value="0"/>
         <Setter Property="ToolTipService.IsEnabled" Value="False"/>


### PR DESCRIPTION
## Summary
- replace the Cell Type text field with a combo box limited to Cylindrical, Prismatic, or Pouch options
- add a shared validation combo box style so the new control follows existing form styling

## Testing
- dotnet test CellManager/CellManager.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbba21f3c4832399653fb0532ff7cd