### PR TITLE
Add loop repeat count controls to schedule editor

### DIFF
--- a/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
+++ b/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
@@ -462,6 +462,12 @@ namespace CellManager.ViewModels
                     InsertStep(endTemplate, Math.Min(value.LoopEndIndex - 1, Sequence.Count));
                 UpdateLoopIndices();
             }
+            else
+            {
+                RepeatCount = 1;
+                LoopStartIndex = 0;
+                LoopEndIndex = 0;
+            }
             DeleteScheduleCommand.NotifyCanExecuteChanged();
         }
 
@@ -474,6 +480,9 @@ namespace CellManager.ViewModels
             SelectedSchedule = sched;
             Sequence.Clear();
             ScheduleName = sched.Name;
+            RepeatCount = 1;
+            LoopStartIndex = 0;
+            LoopEndIndex = 0;
         }
 
         /// <summary>Persists the current schedule to the repository and notifies listeners.</summary>
@@ -482,6 +491,7 @@ namespace CellManager.ViewModels
             if (SelectedSchedule == null) return;
             SelectedSchedule.Name = ScheduleName;
             SelectedSchedule.TestProfileIds = Sequence.Where(s => s.Kind == StepKind.Profile).Select(s => s.Id).ToList();
+            RepeatCount = Math.Max(1, RepeatCount);
             SelectedSchedule.RepeatCount = RepeatCount;
             SelectedSchedule.LoopStartIndex = LoopStartIndex;
             SelectedSchedule.LoopEndIndex = LoopEndIndex;

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -6,6 +6,7 @@
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:vm="clr-namespace:CellManager.ViewModels"
              xmlns:converters="clr-namespace:CellManager.Converters"
+             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
              mc:Ignorable="d"
              d:DesignHeight="800" d:DesignWidth="1200">
     <UserControl.Resources>
@@ -344,6 +345,24 @@
                                 <materialDesign:PackIcon Kind="ContentSave" Width="18" Height="18" Foreground="#00589E"
                                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Button>
+                            <Border Style="{StaticResource VDivider}" Margin="8,0"/>
+                            <TextBlock Text="Loop Count:" Margin="8,0,4,0" VerticalAlignment="Center" FontWeight="Bold" FontSize="13"/>
+                            <xctk:IntegerUpDown Width="70"
+                                                Height="28"
+                                                VerticalAlignment="Center"
+                                                Value="{Binding RepeatCount, Mode=TwoWay}"
+                                                Minimum="1"
+                                                HorizontalContentAlignment="Center">
+                                <xctk:IntegerUpDown.Style>
+                                    <Style TargetType="xctk:IntegerUpDown">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding SelectedSchedule}" Value="{x:Null}">
+                                                <Setter Property="IsEnabled" Value="False"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </xctk:IntegerUpDown.Style>
+                            </xctk:IntegerUpDown>
                         </StackPanel>
                         <Grid Grid.Row="1">
                             <ListBox x:Name="SequenceList" ItemsSource="{Binding Sequence}" AllowDrop="True" Width="Auto"


### PR DESCRIPTION
## Summary
- add an integer up/down to the schedule editor so operators can set the loop repeat count directly from the UI
- reset loop metadata when creating or clearing a schedule and clamp the repeat count before saving to prevent invalid values

## Testing
- DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbbac4ae788323be8bbe700ba3f8bc