### PR TITLE
Remove time hint text in test setup profile views

### DIFF
--- a/CellManager/CellManager/Views/TestSetup/ChargeProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/ChargeProfileDetailView.xaml
@@ -119,8 +119,6 @@
                             <controls:TimeSpanEditor Hours="{Binding ChargeHours, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"
                                                      Minutes="{Binding ChargeMinutes, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"
                                                      Seconds="{Binding ChargeSeconds, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"/>
-                            <TextBlock Style="{StaticResource RangeHintTextBlockStyle}"
-                                       Text="{config:TestProfileRangeHint ProfileType={x:Static tp:TestProfileType.Charge}, FieldNames='ChargeHours, ChargeMinutes, ChargeSeconds'}"/>
                         </StackPanel>
                     </Grid>
                 </StackPanel>

--- a/CellManager/CellManager/Views/TestSetup/DischargeProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/DischargeProfileDetailView.xaml
@@ -111,8 +111,6 @@
                             <controls:TimeSpanEditor Hours="{Binding DischargeHours, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"
                                                      Minutes="{Binding DischargeMinutes, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"
                                                      Seconds="{Binding DischargeSeconds, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"/>
-                            <TextBlock Style="{StaticResource RangeHintTextBlockStyle}"
-                                       Text="{config:TestProfileRangeHint ProfileType={x:Static tp:TestProfileType.Discharge}, FieldNames='DischargeHours, DischargeMinutes, DischargeSeconds'}"/>
                         </StackPanel>
                     </Grid>
                 </StackPanel>

--- a/CellManager/CellManager/Views/TestSetup/RestProfileDetailView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/RestProfileDetailView.xaml
@@ -38,8 +38,6 @@
                             <controls:TimeSpanEditor Hours="{Binding RestHours, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"
                                                      Minutes="{Binding RestMinutes, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"
                                                      Seconds="{Binding RestSeconds, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}"/>
-                            <TextBlock Style="{StaticResource RangeHintTextBlockStyle}"
-                                       Text="{config:TestProfileRangeHint ProfileType={x:Static tp:TestProfileType.Rest}, FieldNames='RestHours, RestMinutes, RestSeconds'}"/>
                         </StackPanel>
                     </Grid>
                 </StackPanel>


### PR DESCRIPTION
## Summary
- remove range hint text blocks for the time editors in charge, discharge, and rest profile detail views

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbbdaf487c8323a18d8d968ff60922