### PR TITLE
Stop auto-selecting a cell on startup

### DIFF
--- a/CellManager/CellManager/ViewModels/CellLibraryViewModel.cs
+++ b/CellManager/CellManager/ViewModels/CellLibraryViewModel.cs
@@ -93,13 +93,8 @@ namespace CellManager.ViewModels
                 }
             });
 
-            // 초기 로드 + 기본 선택
+            // 초기 로드.  첫 실행 시에는 셀을 자동으로 선택하지 않는다.
             ExecuteLoadData();
-            if (SelectedCell == null && CellModels.Count > 0)
-            {
-                SelectedCell = CellModels[0];
-                WeakReferenceMessenger.Default.Send(new CellSelectedMessage(SelectedCell));
-            }
         }
 
         /// <summary>

--- a/CellManager/CellManager/ViewModels/MainViewModel.cs
+++ b/CellManager/CellManager/ViewModels/MainViewModel.cs
@@ -86,10 +86,10 @@ namespace CellManager.ViewModels
                 SelectedCell = m.SelectedCell;
             });
 
-            // CellLibraryViewModel selects the first item during its construction, but that
-            // happens before MainViewModel registers for CellSelectedMessage.  Propagate the
-            // current selection manually so the header and feature tabs reflect the toggle
-            // state shown in the library list when the application starts.
+            // CellLibraryViewModel may restore a previously selected cell before MainViewModel
+            // registers for CellSelectedMessage.  Propagate any existing selection so the
+            // header and feature tabs stay in sync with the library list when the application
+            // starts.
             SelectedCell = cellLibraryVm.SelectedCell;
 
             WeakReferenceMessenger.Default.Register<CellAddedMessage>(this, (r, m) =>


### PR DESCRIPTION
## Summary
- avoid selecting the first cell automatically during the initial load of the cell library
- refresh the MainViewModel comment to reflect the new startup behavior while still mirroring any restored selections

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cbbec16c1083239514e27db1ad50d8