### PR TITLE
Hide loop count controls without loop start

### DIFF
--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -345,8 +345,33 @@
                                 <materialDesign:PackIcon Kind="ContentSave" Width="18" Height="18" Foreground="#00589E"
                                                          HorizontalAlignment="Center" VerticalAlignment="Center"/>
                             </Button>
-                            <Border Style="{StaticResource VDivider}" Margin="8,0"/>
-                            <TextBlock Text="Loop Count:" Margin="8,0,4,0" VerticalAlignment="Center" FontWeight="Bold" FontSize="13"/>
+                            <Border Margin="8,0">
+                                <Border.Style>
+                                    <Style TargetType="Border" BasedOn="{StaticResource VDivider}">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding LoopStartIndex}" Value="0">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                            </Border>
+                            <TextBlock Text="Loop Count:"
+                                       Margin="8,0,4,0"
+                                       VerticalAlignment="Center"
+                                       FontWeight="Bold"
+                                       FontSize="13">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding LoopStartIndex}" Value="0">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
                             <xctk:IntegerUpDown Width="70"
                                                 Height="28"
                                                 VerticalAlignment="Center"
@@ -355,9 +380,13 @@
                                                 HorizontalContentAlignment="Center">
                                 <xctk:IntegerUpDown.Style>
                                     <Style TargetType="xctk:IntegerUpDown">
+                                        <Setter Property="Visibility" Value="Visible"/>
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding SelectedSchedule}" Value="{x:Null}">
                                                 <Setter Property="IsEnabled" Value="False"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding LoopStartIndex}" Value="0">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>


### PR DESCRIPTION
## Summary
- hide the loop count divider, label, and selector when the selected schedule has no loop start step
- collapse the controls through data triggers bound to LoopStartIndex so they only appear when a loop start exists

## Testing
- `dotnet build CellManager/CellManager.sln` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc1fae0988323935b707ab000682c