### PR TITLE
Add consistent tab headers using group boxes

### DIFF
--- a/CellManager/CellManager/Views/CellLibary/CellLibraryView.xaml
+++ b/CellManager/CellManager/Views/CellLibary/CellLibraryView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="CellManager.Views.CellLibary.CellLibraryView"
+<UserControl x:Class="CellManager.Views.CellLibary.CellLibraryView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -51,51 +51,59 @@
     </Style>
     </UserControl.Resources>
     
-    <Grid Margin="20">
+    <Grid Margin="12">
         <Grid.RowDefinitions>
-            <RowDefinition Height="40"/>
-            <RowDefinition Height="10"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="200"/>
-        </Grid.ColumnDefinitions>
-        <Border Grid.Row="0" Grid.Column="0"  BorderBrush="Gray" BorderThickness="1" CornerRadius="5" Padding="5" Background="White" HorizontalAlignment="Stretch" VerticalAlignment="Bottom">
-            <Grid>
-                <TextBlock Text="Search &amp; Filter" Margin="8" VerticalAlignment="Center" Foreground="Gray" Opacity="0.6" IsHitTestVisible="False" >
-                    <TextBlock.Style>
-                        <Style TargetType="TextBlock">
-                            <Setter Property="Visibility" Value="Collapsed"/>
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding SearchText}" Value="">
-                                    <Setter Property="Visibility" Value="Visible"/>
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding SearchText}" Value="{x:Null}">
-                                    <Setter Property="Visibility" Value="Visible"/>
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </TextBlock.Style>
-                </TextBlock>
-                <TextBox Padding="5" BorderThickness="0" Background="Transparent" VerticalAlignment="Center" materialDesign:TextFieldAssist.UnderlineBrush="#1E88E5"
-                         Text="{Binding SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-            </Grid>
-        </Border>
-        <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal"  Margin="0,0,0,0" HorizontalAlignment="Right" >
-            <Button Style="{StaticResource PrimaryActionButton}"
-        Command="{Binding NewCellCommand}" Width="180">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" >
-                    <materialDesign:PackIcon Kind="LibraryAdd"
-                                            Width="18"
-                                            Height="18"
-                                            Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"/>
-                    <TextBlock Text=" Create Cell Library"/>
-                </StackPanel>
-            </Button>
-        </StackPanel>
 
-        <ListView Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" x:Name="lv_cells" ItemsSource="{Binding FilteredCells}" SizeChanged="ListView_SizeChanged" >
+        <GroupBox Grid.Row="0" Margin="0,0,0,8">
+            <GroupBox.Header>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <materialDesign:PackIcon Kind="BatteryMedium" Width="20" Height="20" Margin="0,0,6,0"/>
+                    <TextBlock Text="Cell Library" FontWeight="SemiBold" FontSize="16"/>
+                </StackPanel>
+            </GroupBox.Header>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Border Grid.Column="0" BorderBrush="Gray" BorderThickness="1" CornerRadius="5" Padding="5" Background="White" Margin="0,0,12,0">
+                    <Grid>
+                        <TextBlock Text="Search &amp; Filter" Margin="8" VerticalAlignment="Center" Foreground="Gray" Opacity="0.6" IsHitTestVisible="False">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding SearchText}" Value="">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding SearchText}" Value="{x:Null}">
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                        <TextBox Padding="5" BorderThickness="0" Background="Transparent" VerticalAlignment="Center" materialDesign:TextFieldAssist.UnderlineBrush="#1E88E5"
+                                 Text="{Binding SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                    </Grid>
+                </Border>
+                <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                    <Button Style="{StaticResource PrimaryActionButton}"
+                            Command="{Binding NewCellCommand}" Width="180">
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <materialDesign:PackIcon Kind="LibraryAdd" Width="18" Height="18" Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"/>
+                            <TextBlock Text=" Create Cell Library"/>
+                        </StackPanel>
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </GroupBox>
+
+
+<ListView Grid.Row="1" Margin="0,8,0,0" x:Name="lv_cells" ItemsSource="{Binding FilteredCells}" SizeChanged="ListView_SizeChanged" >
 
             <ListView.Resources>
                 <!-- GridViewColumnHeader 스타일을 Items 컬렉션과 분리하여 정의 -->

--- a/CellManager/CellManager/Views/CellLibary/CellLibraryView.xaml
+++ b/CellManager/CellManager/Views/CellLibary/CellLibraryView.xaml
@@ -57,19 +57,21 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <GroupBox Grid.Row="0" Margin="0,0,0,8">
-            <GroupBox.Header>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <materialDesign:PackIcon Kind="BatteryMedium" Width="20" Height="20" Margin="0,0,6,0"/>
-                    <TextBlock Text="Cell Library" FontWeight="SemiBold" FontSize="16"/>
-                </StackPanel>
-            </GroupBox.Header>
+        <materialDesign:Card Grid.Row="0" Margin="0,0,0,8" Padding="12">
             <Grid>
                 <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <Border Grid.Column="0" BorderBrush="Gray" BorderThickness="1" CornerRadius="5" Padding="5" Background="White" Margin="0,0,12,0">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <materialDesign:PackIcon Kind="BatteryMedium" Width="26" Height="26" Margin="0,0,12,0"/>
+                    <StackPanel>
+                        <TextBlock Text="Cell Library" FontSize="20" FontWeight="Bold"/>
+                        <TextBlock Text="Search and manage cell definitions." Foreground="#6B7280"/>
+                    </StackPanel>
+                </StackPanel>
+                <Border Grid.Column="1" BorderBrush="Gray" BorderThickness="1" CornerRadius="5" Padding="5" Background="White" Margin="24,0,12,0" VerticalAlignment="Center">
                     <Grid>
                         <TextBlock Text="Search &amp; Filter" Margin="8" VerticalAlignment="Center" Foreground="Gray" Opacity="0.6" IsHitTestVisible="False">
                             <TextBlock.Style>
@@ -90,7 +92,7 @@
                                  Text="{Binding SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                     </Grid>
                 </Border>
-                <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                <StackPanel Grid.Column="2" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
                     <Button Style="{StaticResource PrimaryActionButton}"
                             Command="{Binding NewCellCommand}" Width="180">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
@@ -100,7 +102,7 @@
                     </Button>
                 </StackPanel>
             </Grid>
-        </GroupBox>
+        </materialDesign:Card>
 
 
 <ListView Grid.Row="1" Margin="0,8,0,0" x:Name="lv_cells" ItemsSource="{Binding FilteredCells}" SizeChanged="ListView_SizeChanged" >

--- a/CellManager/CellManager/Views/HelpView.xaml
+++ b/CellManager/CellManager/Views/HelpView.xaml
@@ -3,10 +3,16 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes">
     <ScrollViewer>
-        <StackPanel Margin="20">
-            <TextBlock Text="Help &amp; Support"
-                       Style="{StaticResource MaterialDesignHeadline6TextBlock}"
-                       Margin="0,0,0,16"/>
+        <StackPanel Margin="12">
+            <GroupBox Margin="0,0,0,12">
+                <GroupBox.Header>
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <materialDesign:PackIcon Kind="HelpCircle" Width="20" Height="20" Margin="0,0,6,0"/>
+                        <TextBlock Text="Help &amp; Support" FontWeight="SemiBold" FontSize="16"/>
+                    </StackPanel>
+                </GroupBox.Header>
+                <TextBlock Text="Find documentation, FAQs, and contact options below." Foreground="#6B7280"/>
+            </GroupBox>
 
             <materialDesign:Card Margin="0,0,0,16" Padding="16">
                 <StackPanel>

--- a/CellManager/CellManager/Views/HelpView.xaml
+++ b/CellManager/CellManager/Views/HelpView.xaml
@@ -4,15 +4,15 @@
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes">
     <ScrollViewer>
         <StackPanel Margin="12">
-            <GroupBox Margin="0,0,0,12">
-                <GroupBox.Header>
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <materialDesign:PackIcon Kind="HelpCircle" Width="20" Height="20" Margin="0,0,6,0"/>
-                        <TextBlock Text="Help &amp; Support" FontWeight="SemiBold" FontSize="16"/>
+            <materialDesign:Card Margin="0,0,0,12" Padding="16">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <materialDesign:PackIcon Kind="HelpCircle" Width="26" Height="26" Margin="0,0,12,0"/>
+                    <StackPanel>
+                        <TextBlock Text="Help &amp; Support" FontSize="20" FontWeight="Bold"/>
+                        <TextBlock Text="Find documentation, FAQs, and contact options below." Foreground="#6B7280"/>
                     </StackPanel>
-                </GroupBox.Header>
-                <TextBlock Text="Find documentation, FAQs, and contact options below." Foreground="#6B7280"/>
-            </GroupBox>
+                </StackPanel>
+            </materialDesign:Card>
 
             <materialDesign:Card Margin="0,0,0,16" Padding="16">
                 <StackPanel>

--- a/CellManager/CellManager/Views/HomeView.xaml
+++ b/CellManager/CellManager/Views/HomeView.xaml
@@ -2,108 +2,127 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes">
-    <Grid Margin="20">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="2*"/>
-            <ColumnDefinition Width="*"/>
-        </Grid.ColumnDefinitions>
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
 
-        <!-- Board image placeholder -->
-        <Border Background="#EEEEEE" CornerRadius="4" Margin="0,0,20,0">
-            <TextBlock Text="Board Image" Foreground="#888888" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="20"/>
-        </Border>
+        <GroupBox Grid.Row="0" Margin="0,0,0,8">
+            <GroupBox.Header>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <materialDesign:PackIcon Kind="Home" Width="20" Height="20" Margin="0,0,6,0"/>
+                    <TextBlock Text="Home" FontWeight="SemiBold" FontSize="16"/>
+                </StackPanel>
+            </GroupBox.Header>
+            <TextBlock Text="Monitor connection and board status from the cards below."
+                       Foreground="#6B7280"
+                       Margin="2,0,0,0"/>
+        </GroupBox>
 
-        <!-- Right side with status information -->
-        <StackPanel Grid.Column="1">
-            <materialDesign:Card Margin="0,0,0,10" Padding="10">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <materialDesign:PackIcon Kind="Database" Width="32" Height="32" Margin="0,0,10,0"/>
-                    <StackPanel>
-                        <TextBlock Text="MySQL Server" FontWeight="Bold" FontSize="20"/>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="Status: " FontWeight="SemiBold"/>
-                            <TextBlock Text="{Binding DataContext.ServerStatus, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
-                        </StackPanel>
-                    </StackPanel>
-                </StackPanel>
-            </materialDesign:Card>
+        <Grid Grid.Row="1" Margin="0,8,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
 
-            <materialDesign:Card Margin="0,0,0,10" Padding="10">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <materialDesign:PackIcon Kind="DeveloperBoard" Width="32" Height="32" Margin="0,0,10,0"/>
-                    <StackPanel>
-                        <TextBlock Text="Board" FontWeight="Bold" FontSize="20"/>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="Connection: " FontWeight="SemiBold"/>
-                            <TextBlock Text="{Binding DataContext.Connetection, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="Mode: " FontWeight="SemiBold"/>
-                            <TextBlock Text="{Binding DataContext.BoardStatus, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="HW Version: " FontWeight="SemiBold"/>
-                            <TextBlock Text="{Binding DataContext.HWversion, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="FW Version: " FontWeight="SemiBold"/>
-                            <TextBlock Text="{Binding DataContext.FWversion, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
-                        </StackPanel>
-                    </StackPanel>
-                </StackPanel>
-            </materialDesign:Card>
-            
-            <materialDesign:Card Margin="0,0,0,10" Padding="10">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <materialDesign:PackIcon Kind="Battery" Width="32" Height="32" Margin="0,0,10,0"/>
-                    <StackPanel>
-                        <TextBlock Text="Cell" FontWeight="Bold" FontSize="20"/>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="Voltage: " FontWeight="SemiBold"/>
-                            <TextBlock Text="{Binding DataContext.Voltage, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
-                        </StackPanel>
-                    </StackPanel>
-                </StackPanel>
-            </materialDesign:Card>
-          
-            <materialDesign:Card Margin="0,0,0,10" Padding="10">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <materialDesign:PackIcon Kind="CalendarClock" Width="32" Height="32" Margin="0,0,10,0"/>
-                    <StackPanel>
-                        <TextBlock Text="Schedule Execution" FontWeight="Bold" FontSize="20"/>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="Active Schedule: " FontWeight="SemiBold"/>
-                            <TextBlock Text="{Binding DataContext.Connetection, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="Active Profile: " FontWeight="SemiBold"/>
-                            <TextBlock Text="{Binding DataContext.Connetection, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="Estimated Start Time: " FontWeight="SemiBold"/>
-                            <TextBlock Text="{Binding DataContext.Connetection, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="Estimated End Time: " FontWeight="SemiBold"/>
-                            <TextBlock Text="{Binding DataContext.Connetection, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="Run Time: " FontWeight="SemiBold"/>
-                            <TextBlock Text="{Binding DataContext.Connetection, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
-                        </StackPanel>
-                    </StackPanel>
-                </StackPanel>
-            </materialDesign:Card>
+            <!-- Board image placeholder -->
+            <Border Background="#EEEEEE" CornerRadius="4" Margin="0,0,20,0">
+                <TextBlock Text="Board Image" Foreground="#888888" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="20"/>
+            </Border>
 
-            <materialDesign:Card Margin="0,0,0,10" Padding="10">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <materialDesign:PackIcon Kind="HelpCircle" Width="32" Height="32" Margin="0,0,10,0"/>
-                    <StackPanel>
-                        <TextBlock Text="What is the order of the cell's evaluation? " FontWeight="Bold"/>
-                        <TextBlock Text="{Binding DataContext.AvailableCells.Count, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Evaluationmethod }"/>
+            <!-- Right side with status information -->
+            <StackPanel Grid.Column="1">
+                <materialDesign:Card Margin="0,0,0,10" Padding="10">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <materialDesign:PackIcon Kind="Database" Width="32" Height="32" Margin="0,0,10,0"/>
+                        <StackPanel>
+                            <TextBlock Text="MySQL Server" FontWeight="Bold" FontSize="20"/>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Status: " FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding DataContext.ServerStatus, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
+                            </StackPanel>
+                        </StackPanel>
                     </StackPanel>
-                </StackPanel>
-            </materialDesign:Card>
-        </StackPanel>
+                </materialDesign:Card>
+
+                <materialDesign:Card Margin="0,0,0,10" Padding="10">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <materialDesign:PackIcon Kind="DeveloperBoard" Width="32" Height="32" Margin="0,0,10,0"/>
+                        <StackPanel>
+                            <TextBlock Text="Board" FontWeight="Bold" FontSize="20"/>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Connection: " FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding DataContext.Connetection, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Mode: " FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding DataContext.BoardStatus, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="HW Version: " FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding DataContext.HWversion, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="FW Version: " FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding DataContext.FWversion, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </StackPanel>
+                </materialDesign:Card>
+
+                <materialDesign:Card Margin="0,0,0,10" Padding="10">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <materialDesign:PackIcon Kind="Battery" Width="32" Height="32" Margin="0,0,10,0"/>
+                        <StackPanel>
+                            <TextBlock Text="Cell" FontWeight="Bold" FontSize="20"/>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Voltage: " FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding DataContext.Voltage, RelativeSource={RelativeSource AncestorType=Window},FallbackValue=Unknown}"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </StackPanel>
+                </materialDesign:Card>
+
+                <materialDesign:Card Margin="0,0,0,10" Padding="10">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <materialDesign:PackIcon Kind="CalendarClock" Width="32" Height="32" Margin="0,0,10,0"/>
+                        <StackPanel>
+                            <TextBlock Text="Schedule Execution" FontWeight="Bold" FontSize="20"/>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Active Schedule: " FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding DataContext.Connetection, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Active Profile: " FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding DataContext.Connetection, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Estimated Start Time: " FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding DataContext.Connetection, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Estimated End Time: " FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding DataContext.Connetection, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Run Time: " FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding DataContext.Connetection, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Unknown}"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </StackPanel>
+                </materialDesign:Card>
+
+                <materialDesign:Card Margin="0,0,0,10" Padding="10">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <materialDesign:PackIcon Kind="HelpCircle" Width="32" Height="32" Margin="0,0,10,0"/>
+                        <StackPanel>
+                            <TextBlock Text="What is the order of the cell's evaluation? " FontWeight="Bold"/>
+                            <TextBlock Text="{Binding DataContext.AvailableCells.Count, RelativeSource={RelativeSource AncestorType=Window}, FallbackValue=Evaluationmethod }"/>
+                        </StackPanel>
+                    </StackPanel>
+                </materialDesign:Card>
+            </StackPanel>
+        </Grid>
     </Grid>
 </UserControl>

--- a/CellManager/CellManager/Views/HomeView.xaml
+++ b/CellManager/CellManager/Views/HomeView.xaml
@@ -8,17 +8,15 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <GroupBox Grid.Row="0" Margin="0,0,0,8">
-            <GroupBox.Header>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <materialDesign:PackIcon Kind="Home" Width="20" Height="20" Margin="0,0,6,0"/>
-                    <TextBlock Text="Home" FontWeight="SemiBold" FontSize="16"/>
+        <materialDesign:Card Grid.Row="0" Margin="0,0,0,8" Padding="12">
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                <materialDesign:PackIcon Kind="Home" Width="26" Height="26" Margin="0,0,12,0"/>
+                <StackPanel>
+                    <TextBlock Text="Home" FontSize="20" FontWeight="Bold"/>
+                    <TextBlock Text="Monitor connection and board status from the cards below." Foreground="#6B7280"/>
                 </StackPanel>
-            </GroupBox.Header>
-            <TextBlock Text="Monitor connection and board status from the cards below."
-                       Foreground="#6B7280"
-                       Margin="2,0,0,0"/>
-        </GroupBox>
+            </StackPanel>
+        </materialDesign:Card>
 
         <Grid Grid.Row="1" Margin="0,8,0,0">
             <Grid.ColumnDefinitions>

--- a/CellManager/CellManager/Views/RunView.xaml
+++ b/CellManager/CellManager/Views/RunView.xaml
@@ -26,21 +26,29 @@
         </Grid.ColumnDefinitions>
 
         <!-- Header and schedule selection -->
-        <Grid Grid.Row="0" Grid.ColumnSpan="2" Margin="8">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="240"/>
-            </Grid.ColumnDefinitions>
-            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                <materialDesign:PackIcon Kind="Play" Width="24" Height="24" Margin="0,0,8,0"/>
-                <TextBlock Text="RUN" FontSize="20" FontWeight="Bold"/>
-            </StackPanel>
-            <ComboBox Grid.Column="1"
-                      ItemsSource="{Binding AvailableSchedules}"
-                      SelectedItem="{Binding SelectedSchedule}"
-                      DisplayMemberPath="DisplayNameAndScript"
-                      Margin="8,0,0,0"/>
-        </Grid>
+        <GroupBox Grid.Row="0" Grid.ColumnSpan="2" Margin="8,8,8,0">
+            <GroupBox.Header>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <materialDesign:PackIcon Kind="Play" Width="20" Height="20" Margin="0,0,6,0"/>
+                    <TextBlock Text="Run" FontWeight="SemiBold" FontSize="16"/>
+                </StackPanel>
+            </GroupBox.Header>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="240"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Orientation="Vertical" Margin="0,0,12,0">
+                    <TextBlock Text="Selected schedule" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding SelectedSchedule.DisplayNameAndScript, TargetNullValue='No schedule selected'}" Foreground="#6B7280" TextWrapping="Wrap"/>
+                </StackPanel>
+                <ComboBox Grid.Column="1"
+                          ItemsSource="{Binding AvailableSchedules}"
+                          SelectedItem="{Binding SelectedSchedule}"
+                          DisplayMemberPath="DisplayNameAndScript"
+                          Margin="0"/>
+            </Grid>
+        </GroupBox>
 
         <!-- Timeline preview and board status -->
         <Grid Grid.Row="1" Grid.ColumnSpan="2" Margin="8">

--- a/CellManager/CellManager/Views/RunView.xaml
+++ b/CellManager/CellManager/Views/RunView.xaml
@@ -26,29 +26,32 @@
         </Grid.ColumnDefinitions>
 
         <!-- Header and schedule selection -->
-        <GroupBox Grid.Row="0" Grid.ColumnSpan="2" Margin="8,8,8,0">
-            <GroupBox.Header>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <materialDesign:PackIcon Kind="Play" Width="20" Height="20" Margin="0,0,6,0"/>
-                    <TextBlock Text="Run" FontWeight="SemiBold" FontSize="16"/>
-                </StackPanel>
-            </GroupBox.Header>
+        <materialDesign:Card Grid.Row="0" Grid.ColumnSpan="2" Margin="8,8,8,0" Padding="12">
             <Grid>
                 <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="240"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel Orientation="Vertical" Margin="0,0,12,0">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <materialDesign:PackIcon Kind="Play" Width="26" Height="26" Margin="0,0,12,0"/>
+                    <StackPanel>
+                        <TextBlock Text="Run" FontSize="20" FontWeight="Bold"/>
+                        <TextBlock Text="Prepare and control schedule execution." Foreground="#6B7280"/>
+                    </StackPanel>
+                </StackPanel>
+                <StackPanel Grid.Column="1" Margin="24,0,12,0" VerticalAlignment="Center">
                     <TextBlock Text="Selected schedule" FontWeight="SemiBold"/>
                     <TextBlock Text="{Binding SelectedSchedule.DisplayNameAndScript, TargetNullValue='No schedule selected'}" Foreground="#6B7280" TextWrapping="Wrap"/>
                 </StackPanel>
-                <ComboBox Grid.Column="1"
+                <ComboBox Grid.Column="2"
                           ItemsSource="{Binding AvailableSchedules}"
                           SelectedItem="{Binding SelectedSchedule}"
                           DisplayMemberPath="DisplayNameAndScript"
-                          Margin="0"/>
+                          Margin="0"
+                          VerticalAlignment="Center"/>
             </Grid>
-        </GroupBox>
+        </materialDesign:Card>
 
         <!-- Timeline preview and board status -->
         <Grid Grid.Row="1" Grid.ColumnSpan="2" Margin="8">

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -52,19 +52,25 @@
         </Grid.RowDefinitions>
 
         <!-- Cell info status bar -->
-        <GroupBox Grid.Row="0" Margin="0,0,0,8" Padding="12">
-            <GroupBox.Header>
+        <materialDesign:Card Grid.Row="0" Margin="0,0,0,8" Padding="12">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <materialDesign:PackIcon Kind="Calendar" Width="20" Height="20" Margin="0,0,6,0"/>
-                    <TextBlock Text="Schedule" FontWeight="SemiBold" FontSize="16"/>
+                    <materialDesign:PackIcon Kind="Calendar" Width="26" Height="26" Margin="0,0,12,0"/>
+                    <StackPanel>
+                        <TextBlock Text="Schedule" FontSize="20" FontWeight="Bold"/>
+                        <TextBlock Text="Review the active cell details and assigned schedules." Foreground="#6B7280"/>
+                    </StackPanel>
                 </StackPanel>
-            </GroupBox.Header>
 
-            <TextBlock FontSize="14"
-             TextWrapping="NoWrap"
-             TextTrimming="CharacterEllipsis"
-             VerticalAlignment="Center"
-             ToolTipService.ShowDuration="60000" Margin="0">
+                <TextBlock Grid.Column="1" FontSize="14"
+                           TextWrapping="NoWrap"
+                           TextTrimming="CharacterEllipsis"
+                           VerticalAlignment="Center"
+                           ToolTipService.ShowDuration="60000" Margin="24,0,0,0">
     <!-- 선택 셀: 타이틀(가장 강조) -->
     <Run Text="{Binding SelectedCell.DisplayNameAndId, Mode=OneWay}"
          FontWeight="SemiBold" Foreground="{StaticResource TitleBrush}"/>
@@ -89,21 +95,22 @@
     <Run Text="   •   " Foreground="{StaticResource SepBrush}"/>
 
     <Run Text="Updated " Foreground="{StaticResource MetaLabelBrush}"/>
-    <Run Text="{Binding SelectedCell.LastUpdated, StringFormat={}{0:yyyy-MM-dd HH:mm}}" 
+    <Run Text="{Binding SelectedCell.LastUpdated, StringFormat={}{0:yyyy-MM-dd HH:mm}}"
          Foreground="{StaticResource MetaValueBrush}"/>
 
     <!-- 전체 원문 툴팁(잘릴 때 대비) -->
-                <TextBlock.ToolTip>
-                    <TextBlock>
+                    <TextBlock.ToolTip>
+                        <TextBlock>
         <Run Text="{Binding SelectedCell.DisplayNameAndId, Mode=OneWay}"/>
         <Run Text="  |  SN: "/><Run Text="{Binding SelectedCell.SerialNumber}"/>
         <Run Text="  |  Type: "/><Run Text="{Binding SelectedCell.CellType}"/>
         <Run Text="  |  MFR: "/><Run Text="{Binding SelectedCell.Manufacturer}"/>
         <Run Text="  |  Updated: "/><Run Text="{Binding SelectedCell.LastUpdated, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}"/>
-                    </TextBlock>
-                </TextBlock.ToolTip>
+                        </TextBlock>
+                    </TextBlock.ToolTip>
   </TextBlock>
-        </GroupBox>
+            </Grid>
+        </materialDesign:Card>
 
         <!-- Main content -->
         <Grid Grid.Row="2">

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -46,18 +46,25 @@
 
     <Grid Margin="20">
         <Grid.RowDefinitions>
-            <RowDefinition Height="30"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="15"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
         <!-- Cell info status bar -->
-        <GroupBox Grid.Row="0" Margin="0" Padding="0">
+        <GroupBox Grid.Row="0" Margin="0,0,0,8" Padding="12">
+            <GroupBox.Header>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <materialDesign:PackIcon Kind="Calendar" Width="20" Height="20" Margin="0,0,6,0"/>
+                    <TextBlock Text="Schedule" FontWeight="SemiBold" FontSize="16"/>
+                </StackPanel>
+            </GroupBox.Header>
+
             <TextBlock FontSize="14"
              TextWrapping="NoWrap"
              TextTrimming="CharacterEllipsis"
              VerticalAlignment="Center"
-             ToolTipService.ShowDuration="60000" Margin="20,0,0,0">
+             ToolTipService.ShowDuration="60000" Margin="0">
     <!-- 선택 셀: 타이틀(가장 강조) -->
     <Run Text="{Binding SelectedCell.DisplayNameAndId, Mode=OneWay}"
          FontWeight="SemiBold" Foreground="{StaticResource TitleBrush}"/>

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -13,15 +13,15 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <GroupBox Grid.Row="0">
-            <GroupBox.Header>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <materialDesign:PackIcon Kind="Cog" Width="20" Height="20" Margin="0,0,6,0"/>
-                    <TextBlock Text="Settings" FontWeight="SemiBold" FontSize="16"/>
+        <materialDesign:Card Grid.Row="0" Padding="12" Margin="0,0,0,8">
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                <materialDesign:PackIcon Kind="Cog" Width="26" Height="26" Margin="0,0,12,0"/>
+                <StackPanel>
+                    <TextBlock Text="Settings" FontSize="20" FontWeight="Bold"/>
+                    <TextBlock Text="Configure board calibration, firmware, and defaults." Foreground="#6B7280"/>
                 </StackPanel>
-            </GroupBox.Header>
-            <TextBlock Text="Configure board calibration, firmware, and defaults." Foreground="#6B7280"/>
-        </GroupBox>
+            </StackPanel>
+        </materialDesign:Card>
 
         <TabControl Grid.Row="1" Margin="0,8,0,0"
                         Background="Transparent"

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -7,422 +7,439 @@
              xmlns:converters="clr-namespace:CellManager.Converters"
              mc:Ignorable="d"
              d:DesignHeight="600" d:DesignWidth="800">
-    <TabControl Margin="16"
-                Background="Transparent"
-                materialDesign:TabAssist.HasFilledTab="True">
-        <TabControl.Resources>
-            <Style TargetType="TabItem">
-                <Setter Property="Margin" Value="0,0,8,0"/>
-                <Setter Property="Padding" Value="12,6"/>
-                <Setter Property="Foreground" Value="{StaticResource HeaderForegroundBrush}"/>
-                <Setter Property="FontWeight" Value="SemiBold"/>
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="TabItem">
-                            <Border x:Name="Border"
-                                    Background="Transparent"
-                                    CornerRadius="4"
-                                    Padding="{TemplateBinding Padding}">
-                                <ContentPresenter x:Name="ContentSite"
-                                                  VerticalAlignment="Center"
-                                                  HorizontalAlignment="Center"
-                                                  ContentSource="Header"/>
-                            </Border>
-                            <ControlTemplate.Triggers>
-                                <Trigger Property="IsSelected" Value="True">
-                                    <Setter TargetName="Border" Property="Background" Value="{StaticResource PrimaryMain}"/>
-                                    <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="White"/>
-                                </Trigger>
-                                <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="Border" Property="Background" Value="{StaticResource PrimaryHover}"/>
-                                    <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="White"/>
-                                </Trigger>
-                                <Trigger Property="IsEnabled" Value="False">
-                                    <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="#9E9E9E"/>
-                                </Trigger>
-                            </ControlTemplate.Triggers>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
 
-            <DataTemplate x:Key="SpecTextBoxTemplate">
-                <TextBox Text="{Binding Spec, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-            </DataTemplate>
-            <DataTemplate x:Key="SpecComboBoxTemplate">
-                <ComboBox ItemsSource="{Binding Options}"
-                          SelectedItem="{Binding Spec, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-            </DataTemplate>
-            <converters:SpecTemplateSelector x:Key="SpecTemplateSelector"
-                                             TextBoxTemplate="{StaticResource SpecTextBoxTemplate}"
-                                             ComboBoxTemplate="{StaticResource SpecComboBoxTemplate}"/>
-        </TabControl.Resources>
-        <TabItem Header="Board Calibration">
-            <ScrollViewer>
-                <StackPanel Margin="16">
-                    <materialDesign:Card Margin="0,0,0,16" Padding="16">
-                        <StackPanel>
-                            <TextBlock Text="Board Calibration"
-                                       Style="{StaticResource MaterialDesignHeadline6TextBlock}"
-                                       Margin="0,0,0,16"/>
-                            <StackPanel Orientation="Horizontal">
-                                <!-- Voltage card -->
-                                <materialDesign:Card Padding="16" Width="300" Margin="0,0,16,0">
-                                    <StackPanel>
-                                        <TextBlock Text="Voltage"
-                                                   Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                                                   Margin="0,0,0,8"/>
-                                        <TextBlock Text="Low Side" FontWeight="Bold"/>
-                                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-                                            <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                     materialDesign:HintAssist.Hint="Reference [mV]"
-                                                     Text="{Binding VoltageLowReference}"
-                                                     Width="120" Margin="0,0,8,0"/>
-                                            <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                     materialDesign:HintAssist.Hint="Result"
-                                                     Text="{Binding VoltageLowResult}"
-                                                     Width="120"/>
-                                        </StackPanel>
-                                        <TextBlock Text="High Side" FontWeight="Bold" Margin="0,8,0,0"/>
-                                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-                                            <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                     materialDesign:HintAssist.Hint="Reference [mV]"
-                                                     Text="{Binding VoltageHighReference}"
-                                                     Width="120" Margin="0,0,8,0"/>
-                                            <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                     materialDesign:HintAssist.Hint="Result"
-                                                     Text="{Binding VoltageHighResult}"
-                                                     Width="120"/>
-                                        </StackPanel>
+        <GroupBox Grid.Row="0">
+            <GroupBox.Header>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <materialDesign:PackIcon Kind="Cog" Width="20" Height="20" Margin="0,0,6,0"/>
+                    <TextBlock Text="Settings" FontWeight="SemiBold" FontSize="16"/>
+                </StackPanel>
+            </GroupBox.Header>
+            <TextBlock Text="Configure board calibration, firmware, and defaults." Foreground="#6B7280"/>
+        </GroupBox>
+
+        <TabControl Grid.Row="1" Margin="0,8,0,0"
+                        Background="Transparent"
+                        materialDesign:TabAssist.HasFilledTab="True">
+                <TabControl.Resources>
+                    <Style TargetType="TabItem">
+                        <Setter Property="Margin" Value="0,0,8,0"/>
+                        <Setter Property="Padding" Value="12,6"/>
+                        <Setter Property="Foreground" Value="{StaticResource HeaderForegroundBrush}"/>
+                        <Setter Property="FontWeight" Value="SemiBold"/>
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="TabItem">
+                                    <Border x:Name="Border"
+                                            Background="Transparent"
+                                            CornerRadius="4"
+                                            Padding="{TemplateBinding Padding}">
+                                        <ContentPresenter x:Name="ContentSite"
+                                                          VerticalAlignment="Center"
+                                                          HorizontalAlignment="Center"
+                                                          ContentSource="Header"/>
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsSelected" Value="True">
+                                            <Setter TargetName="Border" Property="Background" Value="{StaticResource PrimaryMain}"/>
+                                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="White"/>
+                                        </Trigger>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter TargetName="Border" Property="Background" Value="{StaticResource PrimaryHover}"/>
+                                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="White"/>
+                                        </Trigger>
+                                        <Trigger Property="IsEnabled" Value="False">
+                                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="#9E9E9E"/>
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+
+                    <DataTemplate x:Key="SpecTextBoxTemplate">
+                        <TextBox Text="{Binding Spec, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                    </DataTemplate>
+                    <DataTemplate x:Key="SpecComboBoxTemplate">
+                        <ComboBox ItemsSource="{Binding Options}"
+                                  SelectedItem="{Binding Spec, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                    </DataTemplate>
+                    <converters:SpecTemplateSelector x:Key="SpecTemplateSelector"
+                                                     TextBoxTemplate="{StaticResource SpecTextBoxTemplate}"
+                                                     ComboBoxTemplate="{StaticResource SpecComboBoxTemplate}"/>
+                </TabControl.Resources>
+                <TabItem Header="Board Calibration">
+                    <ScrollViewer>
+                        <StackPanel Margin="16">
+                            <materialDesign:Card Margin="0,0,0,16" Padding="16">
+                                <StackPanel>
+                                    <TextBlock Text="Board Calibration"
+                                               Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                                               Margin="0,0,0,16"/>
+                                    <StackPanel Orientation="Horizontal">
+                                        <!-- Voltage card -->
+                                        <materialDesign:Card Padding="16" Width="300" Margin="0,0,16,0">
+                                            <StackPanel>
+                                                <TextBlock Text="Voltage"
+                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                                                           Margin="0,0,0,8"/>
+                                                <TextBlock Text="Low Side" FontWeight="Bold"/>
+                                                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             materialDesign:HintAssist.Hint="Reference [mV]"
+                                                             Text="{Binding VoltageLowReference}"
+                                                             Width="120" Margin="0,0,8,0"/>
+                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             materialDesign:HintAssist.Hint="Result"
+                                                             Text="{Binding VoltageLowResult}"
+                                                             Width="120"/>
+                                                </StackPanel>
+                                                <TextBlock Text="High Side" FontWeight="Bold" Margin="0,8,0,0"/>
+                                                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             materialDesign:HintAssist.Hint="Reference [mV]"
+                                                             Text="{Binding VoltageHighReference}"
+                                                             Width="120" Margin="0,0,8,0"/>
+                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             materialDesign:HintAssist.Hint="Result"
+                                                             Text="{Binding VoltageHighResult}"
+                                                             Width="120"/>
+                                                </StackPanel>
+                                            </StackPanel>
+                                        </materialDesign:Card>
+
+                                        <!-- Current card -->
+                                        <materialDesign:Card Padding="16" Width="260" Margin="0,0,16,0">
+                                            <StackPanel>
+                                                <TextBlock Text="Current"
+                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                                                           Margin="0,0,0,8"/>
+                                                <StackPanel Orientation="Horizontal">
+                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             materialDesign:HintAssist.Hint="Reference [mA]"
+                                                             Text="{Binding CurrentReference}"
+                                                             Width="120" Margin="0,0,8,0"/>
+                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             materialDesign:HintAssist.Hint="Result"
+                                                             Text="{Binding CurrentResult}"
+                                                             Width="120"/>
+                                                </StackPanel>
+                                                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                                    <Button Content="Calibrate"
+                                                            Width="80"
+                                                            Margin="0,0,8,0"
+                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                    <Button Content="Discharge"
+                                                            Width="80"
+                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                </StackPanel>
+                                            </StackPanel>
+                                        </materialDesign:Card>
+
+                                        <!-- Temperature card -->
+                                        <materialDesign:Card Padding="16" Width="260">
+                                            <StackPanel>
+                                                <TextBlock Text="Temperature"
+                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                                                           Margin="0,0,0,8"/>
+                                                <StackPanel Orientation="Horizontal">
+                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             materialDesign:HintAssist.Hint="Reference [°C]"
+                                                             Text="{Binding TemperatureReference}"
+                                                             Width="120" Margin="0,0,8,0"/>
+                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             materialDesign:HintAssist.Hint="Result"
+                                                             Text="{Binding TemperatureResult}"
+                                                             Width="120"/>
+                                                </StackPanel>
+                                                <Button Content="Set Temp"
+                                                        Width="80"
+                                                        Margin="0,8,0,0"
+                                                        Style="{StaticResource SecondaryActionButton}"/>
+                                            </StackPanel>
+                                        </materialDesign:Card>
                                     </StackPanel>
-                                </materialDesign:Card>
+                                </StackPanel>
+                            </materialDesign:Card>
+                        </StackPanel>
+                    </ScrollViewer>
+                </TabItem>
 
-                                <!-- Current card -->
-                                <materialDesign:Card Padding="16" Width="260" Margin="0,0,16,0">
-                                    <StackPanel>
-                                        <TextBlock Text="Current"
-                                                   Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                                                   Margin="0,0,0,8"/>
-                                        <StackPanel Orientation="Horizontal">
-                                            <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                     materialDesign:HintAssist.Hint="Reference [mA]"
-                                                     Text="{Binding CurrentReference}"
-                                                     Width="120" Margin="0,0,8,0"/>
-                                            <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                     materialDesign:HintAssist.Hint="Result"
-                                                     Text="{Binding CurrentResult}"
-                                                     Width="120"/>
-                                        </StackPanel>
-                                        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                                            <Button Content="Calibrate"
-                                                    Width="80"
-                                                    Margin="0,0,8,0"
-                                                    Style="{StaticResource SecondaryActionButton}"/>
-                                            <Button Content="Discharge"
-                                                    Width="80"
-                                                    Style="{StaticResource SecondaryActionButton}"/>
-                                        </StackPanel>
-                                    </StackPanel>
-                                </materialDesign:Card>
-
-                                <!-- Temperature card -->
-                                <materialDesign:Card Padding="16" Width="260">
-                                    <StackPanel>
-                                        <TextBlock Text="Temperature"
-                                                   Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                                                   Margin="0,0,0,8"/>
-                                        <StackPanel Orientation="Horizontal">
-                                            <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                     materialDesign:HintAssist.Hint="Reference [°C]"
-                                                     Text="{Binding TemperatureReference}"
-                                                     Width="120" Margin="0,0,8,0"/>
-                                            <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                     materialDesign:HintAssist.Hint="Result"
-                                                     Text="{Binding TemperatureResult}"
-                                                     Width="120"/>
-                                        </StackPanel>
-                                        <Button Content="Set Temp"
+                <TabItem Header="Board Data">
+                    <ScrollViewer>
+                        <StackPanel Margin="16">
+                            <materialDesign:Card Margin="0,0,0,16" Padding="16">
+                                <materialDesign:Card.Resources>
+                                    <CollectionViewSource x:Key="BoardDataSettingsGrouped" Source="{Binding BoardDataSettings}">
+                                        <CollectionViewSource.GroupDescriptions>
+                                            <PropertyGroupDescription PropertyName="Category" />
+                                        </CollectionViewSource.GroupDescriptions>
+                                    </CollectionViewSource>
+                                </materialDesign:Card.Resources>
+                                <StackPanel>
+                                    <TextBlock Text="Board Settings Data"
+                                               Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                                               Margin="0,0,0,16"/>
+                                    <DataGrid ItemsSource="{Binding Source={StaticResource BoardDataSettingsGrouped}}"
+                                              AutoGenerateColumns="False"
+                                              HeadersVisibility="Column"
+                                              CanUserAddRows="False"
+                                              Margin="0,0,0,16">
+                                        <DataGrid.Columns>
+                                            <DataGridTemplateColumn Header="Parameter Name" IsReadOnly="True">
+                                                <DataGridTemplateColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <TextBlock Text="{Binding Parameter}"/>
+                                                    </DataTemplate>
+                                                </DataGridTemplateColumn.CellTemplate>
+                                            </DataGridTemplateColumn>
+                                            <DataGridTemplateColumn Header="Spec" CellEditingTemplateSelector="{StaticResource SpecTemplateSelector}">
+                                                <DataGridTemplateColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <TextBlock Text="{Binding Spec}"/>
+                                                    </DataTemplate>
+                                                </DataGridTemplateColumn.CellTemplate>
+                                            </DataGridTemplateColumn>
+                                            <DataGridTemplateColumn Header="Unit">
+                                                <DataGridTemplateColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <TextBlock Text="{Binding Unit}"/>
+                                                    </DataTemplate>
+                                                </DataGridTemplateColumn.CellTemplate>
+                                                <DataGridTemplateColumn.CellEditingTemplate>
+                                                    <DataTemplate>
+                                                        <TextBox Text="{Binding Unit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                                    </DataTemplate>
+                                                </DataGridTemplateColumn.CellEditingTemplate>
+                                            </DataGridTemplateColumn>
+                                            <DataGridTemplateColumn Header="Description" IsReadOnly="True">
+                                                <DataGridTemplateColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <TextBlock Text="{Binding Description}"/>
+                                                    </DataTemplate>
+                                                </DataGridTemplateColumn.CellTemplate>
+                                            </DataGridTemplateColumn>
+                                        </DataGrid.Columns>
+                                        <DataGrid.GroupStyle>
+                                            <GroupStyle>
+                                                <GroupStyle.HeaderTemplate>
+                                                    <DataTemplate>
+                                                        <TextBlock Text="{Binding Name}" FontWeight="Bold" />
+                                                    </DataTemplate>
+                                                </GroupStyle.HeaderTemplate>
+                                            </GroupStyle>
+                                        </DataGrid.GroupStyle>
+                                    </DataGrid>
+                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                        <Button Content="Read"
+                                                Command="{Binding ReadBoardDataCommand}"
                                                 Width="80"
-                                                Margin="0,8,0,0"
+                                                Margin="0,0,8,0"
+                                                Style="{StaticResource SecondaryActionButton}"/>
+                                        <Button Content="Write"
+                                                Command="{Binding WriteBoardDataCommand}"
+                                                Width="80"
                                                 Style="{StaticResource SecondaryActionButton}"/>
                                     </StackPanel>
-                                </materialDesign:Card>
-                            </StackPanel>
+                                </StackPanel>
+                            </materialDesign:Card>
                         </StackPanel>
-                    </materialDesign:Card>
-                </StackPanel>
-            </ScrollViewer>
-        </TabItem>
+                    </ScrollViewer>
+                </TabItem>
 
-        <TabItem Header="Board Data">
-            <ScrollViewer>
-                <StackPanel Margin="16">
-                    <materialDesign:Card Margin="0,0,0,16" Padding="16">
-                        <materialDesign:Card.Resources>
-                            <CollectionViewSource x:Key="BoardDataSettingsGrouped" Source="{Binding BoardDataSettings}">
-                                <CollectionViewSource.GroupDescriptions>
-                                    <PropertyGroupDescription PropertyName="Category" />
-                                </CollectionViewSource.GroupDescriptions>
-                            </CollectionViewSource>
-                        </materialDesign:Card.Resources>
-                        <StackPanel>
-                            <TextBlock Text="Board Settings Data"
-                                       Style="{StaticResource MaterialDesignHeadline6TextBlock}"
-                                       Margin="0,0,0,16"/>
-                            <DataGrid ItemsSource="{Binding Source={StaticResource BoardDataSettingsGrouped}}"
-                                      AutoGenerateColumns="False"
-                                      HeadersVisibility="Column"
-                                      CanUserAddRows="False"
-                                      Margin="0,0,0,16">
-                                <DataGrid.Columns>
-                                    <DataGridTemplateColumn Header="Parameter Name" IsReadOnly="True">
-                                        <DataGridTemplateColumn.CellTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding Parameter}"/>
-                                            </DataTemplate>
-                                        </DataGridTemplateColumn.CellTemplate>
-                                    </DataGridTemplateColumn>
-                                    <DataGridTemplateColumn Header="Spec" CellEditingTemplateSelector="{StaticResource SpecTemplateSelector}">
-                                        <DataGridTemplateColumn.CellTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding Spec}"/>
-                                            </DataTemplate>
-                                        </DataGridTemplateColumn.CellTemplate>
-                                    </DataGridTemplateColumn>
-                                    <DataGridTemplateColumn Header="Unit">
-                                        <DataGridTemplateColumn.CellTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding Unit}"/>
-                                            </DataTemplate>
-                                        </DataGridTemplateColumn.CellTemplate>
-                                        <DataGridTemplateColumn.CellEditingTemplate>
-                                            <DataTemplate>
-                                                <TextBox Text="{Binding Unit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-                                            </DataTemplate>
-                                        </DataGridTemplateColumn.CellEditingTemplate>
-                                    </DataGridTemplateColumn>
-                                    <DataGridTemplateColumn Header="Description" IsReadOnly="True">
-                                        <DataGridTemplateColumn.CellTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding Description}"/>
-                                            </DataTemplate>
-                                        </DataGridTemplateColumn.CellTemplate>
-                                    </DataGridTemplateColumn>
-                                </DataGrid.Columns>
-                                <DataGrid.GroupStyle>
-                                    <GroupStyle>
-                                        <GroupStyle.HeaderTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding Name}" FontWeight="Bold" />
-                                            </DataTemplate>
-                                        </GroupStyle.HeaderTemplate>
-                                    </GroupStyle>
-                                </DataGrid.GroupStyle>
-                            </DataGrid>
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                <Button Content="Read"
-                                        Command="{Binding ReadBoardDataCommand}"
-                                        Width="80"
-                                        Margin="0,0,8,0"
-                                        Style="{StaticResource SecondaryActionButton}"/>
-                                <Button Content="Write"
-                                        Command="{Binding WriteBoardDataCommand}"
-                                        Width="80"
-                                        Style="{StaticResource SecondaryActionButton}"/>
-                            </StackPanel>
+                <TabItem Header="Protection">
+                    <ScrollViewer>
+                        <StackPanel Margin="16">
+                            <materialDesign:Card Margin="0,0,0,16" Padding="16">
+                                <materialDesign:Card.Resources>
+                                    <CollectionViewSource x:Key="ProtectionSettingsGrouped" Source="{Binding ProtectionSettings}">
+                                        <CollectionViewSource.GroupDescriptions>
+                                            <PropertyGroupDescription PropertyName="Category" />
+                                        </CollectionViewSource.GroupDescriptions>
+                                    </CollectionViewSource>
+                                </materialDesign:Card.Resources>
+                                <StackPanel>
+                                    <TextBlock Text="Protection Settings Data"
+                                               Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                                               Margin="0,0,0,16"/>
+                                    <DataGrid ItemsSource="{Binding Source={StaticResource ProtectionSettingsGrouped}}"
+                                              AutoGenerateColumns="False"
+                                              HeadersVisibility="Column"
+                                              CanUserAddRows="False"
+                                              Margin="0,0,0,16">
+                                        <DataGrid.Columns>
+                                            <DataGridTemplateColumn Header="Parameter Name" IsReadOnly="True">
+                                                <DataGridTemplateColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <TextBlock Text="{Binding Parameter}"/>
+                                                    </DataTemplate>
+                                                </DataGridTemplateColumn.CellTemplate>
+                                            </DataGridTemplateColumn>
+                                            <DataGridTemplateColumn Header="Spec"
+                                                                    CellEditingTemplateSelector="{StaticResource SpecTemplateSelector}">
+                                                <DataGridTemplateColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <TextBlock Text="{Binding Spec}"/>
+                                                    </DataTemplate>
+                                                </DataGridTemplateColumn.CellTemplate>
+                                            </DataGridTemplateColumn>
+                                            <DataGridTemplateColumn Header="Unit">
+                                                <DataGridTemplateColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <TextBlock Text="{Binding Unit}"/>
+                                                    </DataTemplate>
+                                                </DataGridTemplateColumn.CellTemplate>
+                                                <DataGridTemplateColumn.CellEditingTemplate>
+                                                    <DataTemplate>
+                                                        <TextBox Text="{Binding Unit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                                    </DataTemplate>
+                                                </DataGridTemplateColumn.CellEditingTemplate>
+                                            </DataGridTemplateColumn>
+                                            <DataGridTemplateColumn Header="Description" IsReadOnly="True">
+                                                <DataGridTemplateColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <TextBlock Text="{Binding Description}"/>
+                                                    </DataTemplate>
+                                                </DataGridTemplateColumn.CellTemplate>
+                                            </DataGridTemplateColumn>
+                                        </DataGrid.Columns>
+                                        <DataGrid.GroupStyle>
+                                            <GroupStyle>
+                                                <GroupStyle.HeaderTemplate>
+                                                    <DataTemplate>
+                                                        <TextBlock Text="{Binding Name}" FontWeight="Bold" />
+                                                    </DataTemplate>
+                                                </GroupStyle.HeaderTemplate>
+                                            </GroupStyle>
+                                        </DataGrid.GroupStyle>
+                                    </DataGrid>
+                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                        <Button Content="Read"
+                                                Command="{Binding ReadProtectionCommand}"
+                                                Width="80"
+                                                Margin="0,0,8,0"
+                                                Style="{StaticResource SecondaryActionButton}"/>
+                                        <Button Content="Write"
+                                                Command="{Binding WriteProtectionCommand}"
+                                                Width="80"
+                                                Style="{StaticResource SecondaryActionButton}"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </materialDesign:Card>
                         </StackPanel>
-                    </materialDesign:Card>
-                </StackPanel>
-            </ScrollViewer>
-        </TabItem>
+                    </ScrollViewer>
+                </TabItem>
 
-        <TabItem Header="Protection">
-            <ScrollViewer>
-                <StackPanel Margin="16">
-                    <materialDesign:Card Margin="0,0,0,16" Padding="16">
-                        <materialDesign:Card.Resources>
-                            <CollectionViewSource x:Key="ProtectionSettingsGrouped" Source="{Binding ProtectionSettings}">
-                                <CollectionViewSource.GroupDescriptions>
-                                    <PropertyGroupDescription PropertyName="Category" />
-                                </CollectionViewSource.GroupDescriptions>
-                            </CollectionViewSource>
-                        </materialDesign:Card.Resources>
-                        <StackPanel>
-                            <TextBlock Text="Protection Settings Data"
-                                       Style="{StaticResource MaterialDesignHeadline6TextBlock}"
-                                       Margin="0,0,0,16"/>
-                            <DataGrid ItemsSource="{Binding Source={StaticResource ProtectionSettingsGrouped}}"
-                                      AutoGenerateColumns="False"
-                                      HeadersVisibility="Column"
-                                      CanUserAddRows="False"
-                                      Margin="0,0,0,16">
-                                <DataGrid.Columns>
-                                    <DataGridTemplateColumn Header="Parameter Name" IsReadOnly="True">
-                                        <DataGridTemplateColumn.CellTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding Parameter}"/>
-                                            </DataTemplate>
-                                        </DataGridTemplateColumn.CellTemplate>
-                                    </DataGridTemplateColumn>
-                                    <DataGridTemplateColumn Header="Spec"
-                                                            CellEditingTemplateSelector="{StaticResource SpecTemplateSelector}">
-                                        <DataGridTemplateColumn.CellTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding Spec}"/>
-                                            </DataTemplate>
-                                        </DataGridTemplateColumn.CellTemplate>
-                                    </DataGridTemplateColumn>
-                                    <DataGridTemplateColumn Header="Unit">
-                                        <DataGridTemplateColumn.CellTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding Unit}"/>
-                                            </DataTemplate>
-                                        </DataGridTemplateColumn.CellTemplate>
-                                        <DataGridTemplateColumn.CellEditingTemplate>
-                                            <DataTemplate>
-                                                <TextBox Text="{Binding Unit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-                                            </DataTemplate>
-                                        </DataGridTemplateColumn.CellEditingTemplate>
-                                    </DataGridTemplateColumn>
-                                    <DataGridTemplateColumn Header="Description" IsReadOnly="True">
-                                        <DataGridTemplateColumn.CellTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding Description}"/>
-                                            </DataTemplate>
-                                        </DataGridTemplateColumn.CellTemplate>
-                                    </DataGridTemplateColumn>
-                                </DataGrid.Columns>
-                                <DataGrid.GroupStyle>
-                                    <GroupStyle>
-                                        <GroupStyle.HeaderTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding Name}" FontWeight="Bold" />
-                                            </DataTemplate>
-                                        </GroupStyle.HeaderTemplate>
-                                    </GroupStyle>
-                                </DataGrid.GroupStyle>
-                            </DataGrid>
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                <Button Content="Read"
-                                        Command="{Binding ReadProtectionCommand}"
-                                        Width="80"
-                                        Margin="0,0,8,0"
-                                        Style="{StaticResource SecondaryActionButton}"/>
-                                <Button Content="Write"
-                                        Command="{Binding WriteProtectionCommand}"
-                                        Width="80"
-                                        Style="{StaticResource SecondaryActionButton}"/>
-                            </StackPanel>
+                <TabItem Header="System">
+                    <ScrollViewer>
+                        <StackPanel Margin="16">
+                            <materialDesign:Card Margin="0,0,0,16" Padding="16">
+                                <StackPanel>
+                                    <TextBlock Text="System Settings"
+                                               Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                                               Margin="0,0,0,16"/>
+                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                             materialDesign:HintAssist.Hint="Board Port"
+                                             Text="{Binding BoardPort}"
+                                             Width="200"/>
+                                </StackPanel>
+                            </materialDesign:Card>
                         </StackPanel>
-                    </materialDesign:Card>
-                </StackPanel>
-            </ScrollViewer>
-        </TabItem>
+                    </ScrollViewer>
+                </TabItem>
 
-        <TabItem Header="System">
-            <ScrollViewer>
-                <StackPanel Margin="16">
-                    <materialDesign:Card Margin="0,0,0,16" Padding="16">
-                        <StackPanel>
-                            <TextBlock Text="System Settings"
-                                       Style="{StaticResource MaterialDesignHeadline6TextBlock}"
-                                       Margin="0,0,0,16"/>
-                            <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                     materialDesign:HintAssist.Hint="Board Port"
-                                     Text="{Binding BoardPort}"
-                                     Width="200"/>
+                <TabItem Header="Paths">
+                    <ScrollViewer>
+                        <StackPanel Margin="16">
+                            <materialDesign:Card Margin="0,0,0,16" Padding="16">
+                                <StackPanel>
+                                    <TextBlock Text="Paths"
+                                               Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                                               Margin="0,0,0,16"/>
+                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                             materialDesign:HintAssist.Hint="Data Export Path"
+                                             Text="{Binding DataExportPath}"
+                                             Margin="0,0,0,8"
+                                             HorizontalAlignment="Stretch"/>
+                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                             materialDesign:HintAssist.Hint="Profile Path"
+                                             Text="{Binding ProfilePath}"
+                                             HorizontalAlignment="Stretch"/>
+                                </StackPanel>
+                            </materialDesign:Card>
                         </StackPanel>
-                    </materialDesign:Card>
-                </StackPanel>
-            </ScrollViewer>
-        </TabItem>
+                    </ScrollViewer>
+                </TabItem>
 
-        <TabItem Header="Paths">
-            <ScrollViewer>
-                <StackPanel Margin="16">
-                    <materialDesign:Card Margin="0,0,0,16" Padding="16">
-                        <StackPanel>
-                            <TextBlock Text="Paths"
-                                       Style="{StaticResource MaterialDesignHeadline6TextBlock}"
-                                       Margin="0,0,0,16"/>
-                            <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                     materialDesign:HintAssist.Hint="Data Export Path"
-                                     Text="{Binding DataExportPath}"
-                                     Margin="0,0,0,8"
-                                     HorizontalAlignment="Stretch"/>
-                            <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                     materialDesign:HintAssist.Hint="Profile Path"
-                                     Text="{Binding ProfilePath}"
-                                     HorizontalAlignment="Stretch"/>
-                        </StackPanel>
-                    </materialDesign:Card>
-                </StackPanel>
-            </ScrollViewer>
-        </TabItem>
+                <TabItem Header="Features">
+                    <ScrollViewer>
+                        <StackPanel Margin="16">
+                            <materialDesign:Card Margin="0,0,0,16" Padding="16">
+                                <StackPanel>
+                                    <TextBlock Text="Features"
+                                               Style="{StaticResource MaterialDesignHeadline6TextBlock}"
+                                               Margin="0,0,0,16"/>
+                                    <Grid Margin="0,8,0,0">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
 
-        <TabItem Header="Features">
-            <ScrollViewer>
-                <StackPanel Margin="16">
-                    <materialDesign:Card Margin="0,0,0,16" Padding="16">
-                        <StackPanel>
-                            <TextBlock Text="Features"
-                                       Style="{StaticResource MaterialDesignHeadline6TextBlock}"
-                                       Margin="0,0,0,16"/>
-                            <Grid Margin="0,8,0,0">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Row="0"
+                                                   Text="Advanced Features"
+                                                   VerticalAlignment="Center"/>
+                                        <ToggleButton Grid.Row="0"
+                                                      Grid.Column="1"
+                                                      Style="{StaticResource MaterialDesignSwitchToggleButton}"
+                                                      IsChecked="{Binding EnableAdvancedFeatures}"
+                                                      Margin="16,0,0,0"/>
 
-                                <TextBlock Grid.Row="0"
-                                           Text="Advanced Features"
-                                           VerticalAlignment="Center"/>
-                                <ToggleButton Grid.Row="0"
-                                              Grid.Column="1"
-                                              Style="{StaticResource MaterialDesignSwitchToggleButton}"
-                                              IsChecked="{Binding EnableAdvancedFeatures}"
-                                              Margin="16,0,0,0"/>
+                                        <TextBlock Grid.Row="1"
+                                                   Text="Dark Theme"
+                                                   VerticalAlignment="Center"
+                                                   Margin="0,8,0,0"/>
+                                        <ToggleButton Grid.Row="1"
+                                                      Grid.Column="1"
+                                                      Style="{StaticResource MaterialDesignSwitchToggleButton}"
+                                                      IsChecked="{Binding EnableDarkTheme}"
+                                                      Margin="16,8,0,0"/>
 
-                                <TextBlock Grid.Row="1"
-                                           Text="Dark Theme"
-                                           VerticalAlignment="Center"
-                                           Margin="0,8,0,0"/>
-                                <ToggleButton Grid.Row="1"
-                                              Grid.Column="1"
-                                              Style="{StaticResource MaterialDesignSwitchToggleButton}"
-                                              IsChecked="{Binding EnableDarkTheme}"
-                                              Margin="16,8,0,0"/>
+                                        <TextBlock Grid.Row="2"
+                                                   Text="Notifications"
+                                                   VerticalAlignment="Center"
+                                                   Margin="0,8,0,0"/>
+                                        <ToggleButton Grid.Row="2"
+                                                      Grid.Column="1"
+                                                      Style="{StaticResource MaterialDesignSwitchToggleButton}"
+                                                      IsChecked="{Binding EnableNotifications}"
+                                                      Margin="16,8,0,0"/>
 
-                                <TextBlock Grid.Row="2"
-                                           Text="Notifications"
-                                           VerticalAlignment="Center"
-                                           Margin="0,8,0,0"/>
-                                <ToggleButton Grid.Row="2"
-                                              Grid.Column="1"
-                                              Style="{StaticResource MaterialDesignSwitchToggleButton}"
-                                              IsChecked="{Binding EnableNotifications}"
-                                              Margin="16,8,0,0"/>
-
-                                <TextBlock Grid.Row="3"
-                                           Text="Auto Updates"
-                                           VerticalAlignment="Center"
-                                           Margin="0,8,0,0"/>
-                                <ToggleButton Grid.Row="3"
-                                              Grid.Column="1"
-                                              Style="{StaticResource MaterialDesignSwitchToggleButton}"
-                                              IsChecked="{Binding EnableAutoUpdates}"
-                                              Margin="16,8,0,0"/>
+                                        <TextBlock Grid.Row="3"
+                                                   Text="Auto Updates"
+                                                   VerticalAlignment="Center"
+                                                   Margin="0,8,0,0"/>
+                                        <ToggleButton Grid.Row="3"
+                                                      Grid.Column="1"
+                                                      Style="{StaticResource MaterialDesignSwitchToggleButton}"
+                                                      IsChecked="{Binding EnableAutoUpdates}"
+                                                      Margin="16,8,0,0"/>
                             </Grid>
+                                </StackPanel>
+                            </materialDesign:Card>
                         </StackPanel>
-                    </materialDesign:Card>
-                </StackPanel>
-            </ScrollViewer>
-        </TabItem>
-    </TabControl>
+                    </ScrollViewer>
+                </TabItem>
+        </TabControl>
+    </Grid>
 </UserControl>

--- a/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
@@ -13,19 +13,25 @@
             <RowDefinition Height="15"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <GroupBox Grid.Row="0" Margin="0,0,0,8" Padding="12">
-            <GroupBox.Header>
+        <materialDesign:Card Grid.Row="0" Margin="0,0,0,8" Padding="12">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <materialDesign:PackIcon Kind="FileSign" Width="20" Height="20" Margin="0,0,6,0"/>
-                    <TextBlock Text="Test Setup" FontWeight="SemiBold" FontSize="16"/>
+                    <materialDesign:PackIcon Kind="FileSign" Width="26" Height="26" Margin="0,0,12,0"/>
+                    <StackPanel>
+                        <TextBlock Text="Test Setup" FontSize="20" FontWeight="Bold"/>
+                        <TextBlock Text="Review cell information before configuring profiles." Foreground="#6B7280"/>
+                    </StackPanel>
                 </StackPanel>
-            </GroupBox.Header>
 
-            <TextBlock FontSize="14"
-             TextWrapping="NoWrap"
-             TextTrimming="CharacterEllipsis"
-             VerticalAlignment="Center"
-             ToolTipService.ShowDuration="60000" Margin="0">
+                <TextBlock Grid.Column="1" FontSize="14"
+                           TextWrapping="NoWrap"
+                           TextTrimming="CharacterEllipsis"
+                           VerticalAlignment="Center"
+                           ToolTipService.ShowDuration="60000" Margin="24,0,0,0">
     <!-- 선택 셀: 타이틀(가장 강조) -->
     <Run Text="{Binding SelectedCell.DisplayNameAndId, Mode=OneWay}"
          FontWeight="SemiBold" Foreground="{StaticResource TitleBrush}"/>
@@ -50,21 +56,22 @@
     <Run Text="   •   " Foreground="{StaticResource SepBrush}"/>
 
     <Run Text="Updated " Foreground="{StaticResource MetaLabelBrush}"/>
-    <Run Text="{Binding SelectedCell.LastUpdated, StringFormat={}{0:yyyy-MM-dd HH:mm}}" 
+    <Run Text="{Binding SelectedCell.LastUpdated, StringFormat={}{0:yyyy-MM-dd HH:mm}}"
          Foreground="{StaticResource MetaValueBrush}"/>
 
     <!-- 전체 원문 툴팁(잘릴 때 대비) -->
-                <TextBlock.ToolTip>
-                    <TextBlock>
+                    <TextBlock.ToolTip>
+                        <TextBlock>
         <Run Text="{Binding SelectedCell.DisplayNameAndId, Mode=OneWay}"/>
         <Run Text="  |  SN: "/><Run Text="{Binding SelectedCell.SerialNumber}"/>
         <Run Text="  |  Type: "/><Run Text="{Binding SelectedCell.CellType}"/>
         <Run Text="  |  MFR: "/><Run Text="{Binding SelectedCell.Manufacturer}"/>
         <Run Text="  |  Updated: "/><Run Text="{Binding SelectedCell.LastUpdated, StringFormat={}{0:yyyy-MM-dd HH:mm:ss}}"/>
-                    </TextBlock>
-                </TextBlock.ToolTip>
+                        </TextBlock>
+                    </TextBlock.ToolTip>
   </TextBlock>
-        </GroupBox>
+            </Grid>
+        </materialDesign:Card>
         <DockPanel Grid.Row="2" >
             <UniformGrid x:Name="ProfilesGrid" Rows="1">
 

--- a/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
@@ -9,16 +9,23 @@
             mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.RowDefinitions>
-            <RowDefinition Height="30"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="15"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <GroupBox Grid.Row="0" Margin="0" Padding="0">
+        <GroupBox Grid.Row="0" Margin="0,0,0,8" Padding="12">
+            <GroupBox.Header>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <materialDesign:PackIcon Kind="FileSign" Width="20" Height="20" Margin="0,0,6,0"/>
+                    <TextBlock Text="Test Setup" FontWeight="SemiBold" FontSize="16"/>
+                </StackPanel>
+            </GroupBox.Header>
+
             <TextBlock FontSize="14"
              TextWrapping="NoWrap"
              TextTrimming="CharacterEllipsis"
              VerticalAlignment="Center"
-             ToolTipService.ShowDuration="60000" Margin="20,0,0,0">
+             ToolTipService.ShowDuration="60000" Margin="0">
     <!-- 선택 셀: 타이틀(가장 강조) -->
     <Run Text="{Binding SelectedCell.DisplayNameAndId, Mode=OneWay}"
          FontWeight="SemiBold" Foreground="{StaticResource TitleBrush}"/>


### PR DESCRIPTION
## Summary
- introduce group box headers with tab icons and descriptions for the Home, Cell Library, Run, Schedule, Test Setup, Settings, and Help views to match the Analyzer tab styling
- reorganize top-of-view controls (e.g., cell library search, run schedule picker) inside the new headers while preserving existing functionality

## Testing
- `dotnet build CellManager/CellManager.sln` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc2584d08832384e5167f24a4c95b