### PR TITLE
Align Analyzer and Run tab layout margins

### DIFF
--- a/CellManager/CellManager/Views/AnalysisView.xaml
+++ b/CellManager/CellManager/Views/AnalysisView.xaml
@@ -147,7 +147,7 @@
         </DataTemplate>
     </UserControl.Resources>
 
-    <Grid>
+    <Grid Margin="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
@@ -155,7 +155,7 @@
         </Grid.RowDefinitions>
 
         <!-- Header ribbon -->
-        <materialDesign:Card Grid.Row="0" Margin="8">
+        <materialDesign:Card Grid.Row="0" Margin="0,0,0,12">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
@@ -195,7 +195,7 @@
         </materialDesign:Card>
 
         <!-- Body -->
-        <Grid Grid.Row="1" Margin="0,0,0,8">
+        <Grid Grid.Row="1" Margin="0,0,0,12">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="340"/>
                 <ColumnDefinition Width="*"/>
@@ -204,7 +204,7 @@
 
             <!-- Left column: data management -->
             <StackPanel Grid.Column="0">
-                <materialDesign:Card>
+                <materialDesign:Card Margin="0,0,0,12">
                     <StackPanel>
                         <DockPanel Margin="0,0,0,8">
                             <TextBlock DockPanel.Dock="Left" Text="Datasets" FontSize="16" FontWeight="SemiBold"/>
@@ -238,7 +238,7 @@
                     </StackPanel>
                 </materialDesign:Card>
 
-                <materialDesign:Card Visibility="{Binding IsCompareMode, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <materialDesign:Card Margin="0,0,0,12" Visibility="{Binding IsCompareMode, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <StackPanel>
                         <TextBlock Text="Comparison options" FontSize="16" FontWeight="SemiBold" Margin="0,0,0,8"/>
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
@@ -302,7 +302,7 @@
 
             <!-- Center column: charts -->
             <StackPanel Grid.Column="1">
-                <materialDesign:Card>
+                <materialDesign:Card Margin="0,0,0,12">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
@@ -370,14 +370,14 @@
 
             <!-- Right column: insights -->
             <StackPanel Grid.Column="2">
-                <materialDesign:Card Visibility="{Binding HasWarnings, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <materialDesign:Card Margin="0,0,0,12" Visibility="{Binding HasWarnings, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <StackPanel>
                         <TextBlock Text="Data quality checks" FontSize="16" FontWeight="SemiBold"/>
                         <ItemsControl ItemsSource="{Binding Warnings}" ItemTemplate="{StaticResource WarningTemplate}"/>
                     </StackPanel>
                 </materialDesign:Card>
 
-                <materialDesign:Card>
+                <materialDesign:Card Margin="0,0,0,12">
                     <StackPanel>
                         <TextBlock Text="Summary" FontSize="16" FontWeight="SemiBold"/>
                         <Grid Margin="0,8,0,0">
@@ -407,7 +407,7 @@
                     </StackPanel>
                 </materialDesign:Card>
 
-                <materialDesign:Card>
+                <materialDesign:Card Margin="0,0,0,12">
                     <StackPanel>
                         <DockPanel>
                             <TextBlock Text="Automatic analysis" DockPanel.Dock="Left" FontSize="16" FontWeight="SemiBold"/>

--- a/CellManager/CellManager/Views/RunView.xaml
+++ b/CellManager/CellManager/Views/RunView.xaml
@@ -13,7 +13,7 @@
     <UserControl.Resources>
         <converters:NullOrEmptyToPlaceholderConverter x:Key="NullOrEmptyToPlaceholderConverter"/>
     </UserControl.Resources>
-    <Grid>
+    <Grid Margin="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
@@ -26,7 +26,7 @@
         </Grid.ColumnDefinitions>
 
         <!-- Header and schedule selection -->
-        <materialDesign:Card Grid.Row="0" Grid.ColumnSpan="2" Margin="8,8,8,0" Padding="12">
+        <materialDesign:Card Grid.Row="0" Grid.ColumnSpan="2" Margin="0,0,0,12" Padding="12">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
@@ -54,13 +54,13 @@
         </materialDesign:Card>
 
         <!-- Timeline preview and board status -->
-        <Grid Grid.Row="1" Grid.ColumnSpan="2" Margin="8">
+        <Grid Grid.Row="1" Grid.ColumnSpan="2" Margin="0,0,0,12">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="300"/>
             </Grid.ColumnDefinitions>
 
-            <GroupBox Grid.Column="0" Margin="0,0,8,0">
+            <GroupBox Grid.Column="0" Margin="0,0,12,0">
                 <StackPanel>
                     <TextBlock Text="Timeline Preview" FontWeight="Bold" FontSize="15"/>
                     <local:TimelinePreviewControl Steps="{Binding TimelineSteps}"/>
@@ -79,13 +79,13 @@
         </Grid>
 
         <!-- Controls and current step details -->
-        <Grid Grid.Row="2" Grid.ColumnSpan="2" Margin="8">
+        <Grid Grid.Row="2" Grid.ColumnSpan="2" Margin="0,0,0,12">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="340"/>
             </Grid.ColumnDefinitions>
 
-            <GroupBox Grid.Column="0" Margin="0,0,8,0">
+            <GroupBox Grid.Column="0" Margin="0,0,12,0">
                 <StackPanel>
                     <TextBlock Text="Controls" FontWeight="Bold" FontSize="15"/>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,4">
@@ -105,7 +105,7 @@
                 </StackPanel>
             </GroupBox>
 
-            <GroupBox Grid.Column="1" Margin="8,0,0,0">
+            <GroupBox Grid.Column="1" Margin="12,0,0,0">
                 <StackPanel>
                     <TextBlock Text="Current Step" FontWeight="Bold" FontSize="15"/>
                     <StackPanel Margin="0,8,0,0">
@@ -130,7 +130,7 @@
         </Grid>
 
         <!-- Run logs -->
-        <GroupBox Grid.Row="3" Grid.ColumnSpan="2" Margin="8">
+        <GroupBox Grid.Row="3" Grid.ColumnSpan="2">
             <StackPanel>
                 <TextBlock Text="Run Logs" FontWeight="Bold" FontSize="15"/>
                 <ListBox ItemsSource="{Binding RunLogs}" Height="120"


### PR DESCRIPTION
## Summary
- add outer 12px margin to the Analyzer and Run user controls so they match the other tabs
- normalize spacing between major sections within each view for consistent gutters between cards and group boxes

## Testing
- `dotnet build CellManager.sln` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcbe02b9c8323b267dc71af7f99d7