### PR TITLE
Adjust form field alignment and width

### DIFF
--- a/CellManager/CellManager/Views/Shared/FormStyles.xaml
+++ b/CellManager/CellManager/Views/Shared/FormStyles.xaml
@@ -49,7 +49,8 @@
 
     <Style x:Key="FormFieldStackStyle" TargetType="StackPanel">
         <Setter Property="Margin" Value="0,5,0,5"/>
-        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="MaxWidth" Value="320"/>
     </Style>
 
     <Thickness x:Key="FormControlMargin">0,5,0,5</Thickness>


### PR DESCRIPTION
## Summary
- align form field stack panels to the left so form inputs no longer stretch edge-to-edge
- cap form field stack width to 320px to keep text inputs at the intended size

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcda8f0088323bbe90ccf98a93701