### PR TITLE
Add duplicate cell command and menu option

### DIFF
--- a/CellManager/CellManager/ViewModels/CellLibraryViewModel.cs
+++ b/CellManager/CellManager/ViewModels/CellLibraryViewModel.cs
@@ -64,6 +64,7 @@ namespace CellManager.ViewModels
         public RelayCommand SaveCellCommand { get; }
         public RelayCommand CancelEditCommand { get; }
         public RelayCommand<Cell> DeleteCellCommand { get; }
+        public RelayCommand<Cell> DuplicateCellCommand { get; }
         public RelayCommand<Cell> SelectCellCommand { get; }
         public RelayCommand<Cell> OpenDetailsCommand { get; }
 
@@ -76,6 +77,7 @@ namespace CellManager.ViewModels
             SaveCellCommand = new RelayCommand(SaveCurrent, () => EditingCell != null || SelectedCell != null);
             CancelEditCommand = new RelayCommand(CancelNew, () => EditingCell != null);
             DeleteCellCommand = new RelayCommand<Cell>(DeleteCell, c => EditingCell == null && c != null && c.Id > 0);
+            DuplicateCellCommand = new RelayCommand<Cell>(DuplicateCell, c => EditingCell == null && c != null && c.Id > 0);
 
             SelectCellCommand = new RelayCommand<Cell>(ExecuteSelectCell);
             OpenDetailsCommand = new RelayCommand<Cell>(ExecuteOpenDetails, c => c != null);
@@ -234,6 +236,35 @@ namespace CellManager.ViewModels
             UpdateCanExecutes();
         }
 
+        /// <summary>
+        ///     Creates a copy of the provided cell, resets identifying fields, and persists it as a new entry.
+        /// </summary>
+        private void DuplicateCell(Cell cell)
+        {
+            if (cell == null || cell.Id <= 0) return;
+
+            var duplicate = new Cell(cell)
+            {
+                Id = 0,
+                SerialNumber = string.Empty,
+                PartNumber = string.Empty,
+                IsActive = false
+            };
+
+            _cellRepository.SaveCell(duplicate);
+            var newId = duplicate.Id;
+
+            ExecuteLoadData();
+
+            if (newId > 0)
+            {
+                SelectedCell = CellModels.FirstOrDefault(x => x.Id == newId);
+                WeakReferenceMessenger.Default.Send(new CellSelectedMessage(SelectedCell));
+            }
+
+            UpdateCanExecutes();
+        }
+
         // -------- 기타 --------
         /// <summary>
         ///     Handles selection toggles from the list view and synchronizes the active indicator flag.
@@ -290,6 +321,7 @@ namespace CellManager.ViewModels
             SaveCellCommand?.NotifyCanExecuteChanged();
             CancelEditCommand?.NotifyCanExecuteChanged();
             DeleteCellCommand?.NotifyCanExecuteChanged();
+            DuplicateCellCommand?.NotifyCanExecuteChanged();
         }
     }
 }

--- a/CellManager/CellManager/Views/CellLibary/CellLibraryView.xaml
+++ b/CellManager/CellManager/Views/CellLibary/CellLibraryView.xaml
@@ -182,6 +182,13 @@
                                         <materialDesign:PackIcon Kind="Pencil" Width="16" Height="16"/>
                                     </MenuItem.Icon>
                                 </MenuItem>
+                                <MenuItem Header="Duplicate"
+                                          Command="{Binding PlacementTarget.Tag.DuplicateCellCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                          CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
+                                    <MenuItem.Icon>
+                                        <materialDesign:PackIcon Kind="ContentCopy" Width="16" Height="16"/>
+                                    </MenuItem.Icon>
+                                </MenuItem>
                                 <MenuItem Header="Delete"
                                           Command="{Binding PlacementTarget.Tag.DeleteCellCommand, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                                           CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}">


### PR DESCRIPTION
## Summary
- add a duplicate-cell relay command that copies the selected cell, clears identifiers, saves it, and refreshes the selection
- broadcast the cell-selected message after creating the duplicate and keep command states in sync
- expose the duplicate action through the cell list context menu

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9ff3e4ac8323938865d32fe80a52