### PR TITLE
Add schedule overview summaries and loop validation warning

### DIFF
--- a/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
+++ b/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
@@ -78,6 +78,16 @@ namespace CellManager.ViewModels
         [ObservableProperty] private TimeSpan _totalDuration;
         [ObservableProperty] private Cell? _selectedCell;
 
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(ScheduleStartDateTime))]
+        [NotifyPropertyChangedFor(nameof(ScheduleEndDateTime))]
+        private DateTime _scheduleStartDate = DateTime.Today;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(ScheduleStartDateTime))]
+        [NotifyPropertyChangedFor(nameof(ScheduleEndDateTime))]
+        private TimeSpan _scheduleStartTime = TimeSpan.FromHours(8);
+
         private string _scheduleSummaryText = string.Empty;
         public string ScheduleSummaryText
         {
@@ -98,6 +108,29 @@ namespace CellManager.ViewModels
             get => _isLoopValid;
             private set => SetProperty(ref _isLoopValid, value);
         }
+
+        public string LoopRangeDisplay
+        {
+            get
+            {
+                if (LoopStartIndex <= 0 || LoopEndIndex <= 0)
+                    return "Not set";
+                var range = $"{LoopStartIndex} → {LoopEndIndex}";
+                return IsLoopValid ? range : $"{range} (invalid)";
+            }
+        }
+
+        public DateTime ScheduleStartDateTime => ScheduleStartDate.Date + ScheduleStartTime;
+
+        public DateTime ScheduleEndDateTime => ScheduleStartDateTime + TotalDuration;
+
+        public DateTime? ScheduleStartTimePickerValue
+        {
+            get => DateTime.Today.Add(ScheduleStartTime);
+            set => ScheduleStartTime = (value ?? DateTime.Today).TimeOfDay;
+        }
+
+        public ObservableCollection<ScheduleCalendarDay> CalendarDays { get; } = new();
 
         public RelayCommand<StepTemplate> RemoveStepCommand { get; }
         public RelayCommand SaveScheduleCommand { get; }
@@ -450,6 +483,7 @@ namespace CellManager.ViewModels
             UpdateLoopIndices();
             UpdateScheduleSummaryText();
             RefreshLoopSummary();
+            RefreshCalendarSchedule();
             OnPropertyChanged(nameof(CanSaveSchedule));
         }
 
@@ -675,6 +709,7 @@ namespace CellManager.ViewModels
             SaveScheduleCommand?.NotifyCanExecuteChanged();
             RefreshLoopSummary();
             OnPropertyChanged(nameof(CanSaveSchedule));
+            OnPropertyChanged(nameof(LoopRangeDisplay));
         }
 
         partial void OnLoopEndIndexChanged(int value)
@@ -682,11 +717,35 @@ namespace CellManager.ViewModels
             SaveScheduleCommand?.NotifyCanExecuteChanged();
             RefreshLoopSummary();
             OnPropertyChanged(nameof(CanSaveSchedule));
+            OnPropertyChanged(nameof(LoopRangeDisplay));
         }
 
         partial void OnRepeatCountChanged(int value)
         {
             UpdateTotalDuration();
+        }
+
+        partial void OnScheduleStartDateChanged(DateTime value)
+        {
+            _scheduleStartDate = value.Date;
+            UpdateScheduleSummaryText();
+            RefreshCalendarSchedule();
+            OnPropertyChanged(nameof(ScheduleStartDateTime));
+            OnPropertyChanged(nameof(ScheduleEndDateTime));
+        }
+
+        partial void OnScheduleStartTimeChanged(TimeSpan value)
+        {
+            UpdateScheduleSummaryText();
+            RefreshCalendarSchedule();
+            OnPropertyChanged(nameof(ScheduleStartDateTime));
+            OnPropertyChanged(nameof(ScheduleEndDateTime));
+            OnPropertyChanged(nameof(ScheduleStartTimePickerValue));
+        }
+
+        partial void OnTotalDurationChanged(TimeSpan value)
+        {
+            OnPropertyChanged(nameof(ScheduleEndDateTime));
         }
 
         private void UpdateScheduleSummaryText()
@@ -697,6 +756,9 @@ namespace CellManager.ViewModels
                 ? "00:00:00"
                 : TotalDuration.ToString("hh\\:mm\\:ss");
 
+            var startLabel = ScheduleStartDateTime.ToString("yyyy-MM-dd HH:mm");
+            var endLabel = ScheduleEndDateTime.ToString("yyyy-MM-dd HH:mm");
+
             var stepSummary = profileCount switch
             {
                 0 => "No profile steps configured",
@@ -704,7 +766,7 @@ namespace CellManager.ViewModels
                 _ => $"{profileCount} profile steps configured"
             };
 
-            ScheduleSummaryText = $"{stepSummary} • Total duration: {durationText} • Repeat count: {repeatCount}";
+            ScheduleSummaryText = $"{stepSummary} • Total duration: {durationText} • Repeat count: {repeatCount} • {startLabel} → {endLabel}";
         }
 
         private void UpdateLoopSummary(int displayStartIndex, int displayEndIndex, bool isValid)
@@ -731,11 +793,202 @@ namespace CellManager.ViewModels
 
             IsLoopValid = isValid;
             LoopSummaryText = summary;
+            OnPropertyChanged(nameof(LoopRangeDisplay));
         }
 
         private void RefreshLoopSummary()
         {
             TryGetNormalizedLoopBounds(out _, out _);
         }
+
+        private void RefreshCalendarSchedule()
+        {
+            CalendarDays.Clear();
+
+            var steps = BuildExecutionPlan().ToList();
+            if (!steps.Any())
+                return;
+
+            var current = ScheduleStartDateTime;
+            var dayMap = new Dictionary<DateTime, ScheduleCalendarDay>();
+
+            foreach (var step in steps)
+            {
+                var start = current;
+                var end = current + step.Duration;
+                var entry = new ScheduleCalendarEntry(
+                    step.Order,
+                    step.Name,
+                    start,
+                    end,
+                    step.Duration,
+                    step.IsLoopSegment,
+                    step.LoopIteration);
+
+                var key = start.Date;
+                if (!dayMap.TryGetValue(key, out var day))
+                {
+                    day = new ScheduleCalendarDay(key);
+                    dayMap.Add(key, day);
+                }
+
+                day.Entries.Add(entry);
+                current = end;
+            }
+
+            foreach (var day in dayMap.Values.OrderBy(d => d.Date))
+                CalendarDays.Add(day);
+        }
+
+        private IEnumerable<ExecutionStep> BuildExecutionPlan()
+        {
+            var results = new List<ExecutionStep>();
+            if (!Sequence.Any())
+                return results;
+
+            var loopStartIndex = Sequence.ToList().FindIndex(s => s.Kind == StepKind.LoopStart);
+            var loopEndIndex = Sequence.ToList().FindIndex(s => s.Kind == StepKind.LoopEnd);
+            var hasValidLoop = loopStartIndex >= 0 && loopEndIndex > loopStartIndex;
+
+            var beforeLoop = new List<StepTemplate>();
+            var loopSteps = new List<StepTemplate>();
+            var afterLoop = new List<StepTemplate>();
+
+            var encounteredLoopStart = false;
+            var encounteredLoopEnd = false;
+            var insideLoop = false;
+
+            foreach (var step in Sequence)
+            {
+                if (step.Kind == StepKind.LoopStart)
+                {
+                    encounteredLoopStart = true;
+                    insideLoop = true;
+                    continue;
+                }
+
+                if (step.Kind == StepKind.LoopEnd)
+                {
+                    encounteredLoopEnd = true;
+                    insideLoop = false;
+                    continue;
+                }
+
+                if (step.Kind != StepKind.Profile)
+                    continue;
+
+                if (!encounteredLoopStart)
+                {
+                    beforeLoop.Add(step);
+                }
+                else if (insideLoop || !encounteredLoopEnd)
+                {
+                    loopSteps.Add(step);
+                }
+                else
+                {
+                    afterLoop.Add(step);
+                }
+            }
+
+            var order = 1;
+
+            foreach (var step in beforeLoop)
+                results.Add(new ExecutionStep(order++, step.Name, step.Duration, false, 0));
+
+            if (loopSteps.Any())
+            {
+                var iterations = hasValidLoop ? Math.Max(1, RepeatCount) : 1;
+                for (var iteration = 1; iteration <= iterations; iteration++)
+                {
+                    foreach (var step in loopSteps)
+                        results.Add(new ExecutionStep(order++, step.Name, step.Duration, hasValidLoop, hasValidLoop ? iteration : 0));
+                }
+            }
+
+            foreach (var step in afterLoop)
+                results.Add(new ExecutionStep(order++, step.Name, step.Duration, false, 0));
+
+            return results;
+        }
+
+        private sealed class ExecutionStep
+        {
+            public ExecutionStep(int order, string name, TimeSpan duration, bool isLoopSegment, int loopIteration)
+            {
+                Order = order;
+                Name = name;
+                Duration = duration;
+                IsLoopSegment = isLoopSegment;
+                LoopIteration = loopIteration;
+            }
+
+            public int Order { get; }
+            public string Name { get; }
+            public TimeSpan Duration { get; }
+            public bool IsLoopSegment { get; }
+            public int LoopIteration { get; }
+        }
+    }
+
+    /// <summary>Represents a single day within the schedule calendar preview.</summary>
+    public class ScheduleCalendarDay
+    {
+        public ScheduleCalendarDay(DateTime date)
+        {
+            Date = date.Date;
+        }
+
+        public DateTime Date { get; }
+
+        public string Header => Date.ToString("yyyy-MM-dd (ddd)");
+
+        public ObservableCollection<ScheduleCalendarEntry> Entries { get; } = new();
+
+        public string TotalDurationText
+        {
+            get
+            {
+                if (!Entries.Any())
+                    return "Total for day: 00:00:00";
+                var ticks = Entries.Sum(e => e.Duration.Ticks);
+                return $"Total for day: {new TimeSpan(ticks):hh\\:mm\\:ss}";
+            }
+        }
+    }
+
+    /// <summary>Describes a scheduled step with concrete start and end timestamps.</summary>
+    public class ScheduleCalendarEntry
+    {
+        public ScheduleCalendarEntry(int order, string stepName, DateTime start, DateTime end, TimeSpan duration, bool isLoopSegment, int loopIteration)
+        {
+            Order = order;
+            StepName = stepName;
+            Start = start;
+            End = end;
+            Duration = duration;
+            IsLoopSegment = isLoopSegment;
+            LoopIteration = loopIteration;
+        }
+
+        public int Order { get; }
+        public string StepName { get; }
+        public DateTime Start { get; }
+        public DateTime End { get; }
+        public TimeSpan Duration { get; }
+        public bool IsLoopSegment { get; }
+        public int LoopIteration { get; }
+
+        public bool HasLoopIteration => IsLoopSegment && LoopIteration > 0;
+
+        public string StepLabel => $"#{Order} {StepName}";
+
+        public string StartDisplay => $"Start: {Start:yyyy-MM-dd HH:mm}";
+
+        public string EndDisplay => $"End: {End:yyyy-MM-dd HH:mm}";
+
+        public string DurationDisplay => $"Duration: {Duration:hh\\:mm\\:ss}";
+
+        public string LoopIterationDisplay => HasLoopIteration ? $"Loop iteration {LoopIteration}" : string.Empty;
     }
 }

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -153,46 +153,23 @@
                     </StackPanel>
                 </Grid>
 
-                <UniformGrid Grid.Row="1" Rows="2" Columns="3" Margin="0,20,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                <UniformGrid Grid.Row="1" Rows="2" Columns="2" Margin="0,20,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6" Margin="0,0,16,16">
                         <StackPanel>
                             <TextBlock Text="Start" Foreground="#6B7280" FontSize="11"/>
                             <TextBlock Text="{Binding ScheduleStartDateTime, StringFormat={}{0:yyyy-MM-dd HH:mm}}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Border>
-                    <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6" Margin="0,0,16,16">
+                    <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6" Margin="0,0,0,16">
                         <StackPanel>
                             <TextBlock Text="End" Foreground="#6B7280" FontSize="11"/>
                             <TextBlock Text="{Binding ScheduleEndDateTime, StringFormat={}{0:yyyy-MM-dd HH:mm}}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center"/>
                         </StackPanel>
                     </Border>
-                    <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6" Margin="0,0,0,16">
+                    <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6" Margin="0,0,16,0">
                         <StackPanel>
                             <TextBlock Text="Total Duration" Foreground="#6B7280" FontSize="11"/>
                             <TextBlock Text="{Binding TotalDuration, StringFormat={}{0:hh\\:mm\\:ss}}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center"/>
-                        </StackPanel>
-                    </Border>
-                    <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6" Margin="0,0,16,0">
-                        <StackPanel>
-                            <TextBlock Text="Repeat Count" Foreground="#6B7280" FontSize="11"/>
-                            <TextBlock Text="{Binding RepeatCount}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center"/>
-                        </StackPanel>
-                    </Border>
-                    <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6" Margin="0,0,16,0">
-                        <StackPanel>
-                            <TextBlock Text="Loop Range" Foreground="#6B7280" FontSize="11"/>
-                            <TextBlock Text="{Binding LoopRangeDisplay}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center">
-                                <TextBlock.Style>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="Foreground" Value="#111827"/>
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding IsLoopValid}" Value="False">
-                                                <Setter Property="Foreground" Value="{DynamicResource MaterialDesignValidationErrorColor}"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </TextBlock.Style>
-                            </TextBlock>
                         </StackPanel>
                     </Border>
                     <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6">

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -113,28 +113,123 @@
             </Grid>
         </materialDesign:Card>
 
-        <!-- Schedule summary card -->
+        <!-- Schedule calendar card -->
         <materialDesign:Card Grid.Row="1" Padding="16" Margin="0,0,0,8">
             <Grid>
                 <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <!-- Header -->
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <materialDesign:PackIcon Kind="CalendarClock" Width="22" Height="22" Margin="0,0,8,0"/>
-                    <StackPanel>
-                        <TextBlock Text="Schedule Overview" FontWeight="SemiBold" FontSize="15"/>
-                        <TextBlock Text="{Binding ScheduleSummaryText}" Foreground="#6B7280" TextWrapping="Wrap"/>
-                    </StackPanel>
-                </StackPanel>
+                <Grid Grid.Row="0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
 
-                <!-- Loop summary -->
-                <Border Grid.Row="1" Margin="0,12,0,0" Padding="12,8" CornerRadius="6" Background="#F9FAFB" BorderBrush="#E5E7EB" BorderThickness="1">
-                    <TextBlock Text="{Binding LoopSummaryText}" TextWrapping="Wrap" TextAlignment="Center">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <materialDesign:PackIcon Kind="CalendarRange" Width="22" Height="22" Margin="0,0,8,0"/>
+                        <StackPanel>
+                            <TextBlock Text="Schedule Calendar" FontWeight="SemiBold" FontSize="15"/>
+                            <TextBlock Text="{Binding ScheduleSummaryText}" Foreground="#6B7280" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
+                        <StackPanel Width="150">
+                            <TextBlock Text="Start Date" Foreground="#6B7280" FontSize="11"/>
+                            <DatePicker SelectedDate="{Binding ScheduleStartDate, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                        </StackPanel>
+                        <StackPanel Margin="12,0,0,0" Width="130">
+                            <TextBlock Text="Start Time" Foreground="#6B7280" FontSize="11"/>
+                            <xctk:TimePicker Value="{Binding ScheduleStartTimePickerValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             Format="Custom"
+                                             FormatString="HH:mm"
+                                             AllowSpin="True"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Grid>
+
+                <UniformGrid Grid.Row="1" Rows="2" Columns="3" Margin="0,20,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                    <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6" Margin="0,0,16,16">
+                        <StackPanel>
+                            <TextBlock Text="Start" Foreground="#6B7280" FontSize="11"/>
+                            <TextBlock Text="{Binding ScheduleStartDateTime, StringFormat={}{0:yyyy-MM-dd HH:mm}}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6" Margin="0,0,16,16">
+                        <StackPanel>
+                            <TextBlock Text="End" Foreground="#6B7280" FontSize="11"/>
+                            <TextBlock Text="{Binding ScheduleEndDateTime, StringFormat={}{0:yyyy-MM-dd HH:mm}}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6" Margin="0,0,0,16">
+                        <StackPanel>
+                            <TextBlock Text="Total Duration" Foreground="#6B7280" FontSize="11"/>
+                            <TextBlock Text="{Binding TotalDuration, StringFormat={}{0:hh\\:mm\\:ss}}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6" Margin="0,0,16,0">
+                        <StackPanel>
+                            <TextBlock Text="Repeat Count" Foreground="#6B7280" FontSize="11"/>
+                            <TextBlock Text="{Binding RepeatCount}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center"/>
+                        </StackPanel>
+                    </Border>
+                    <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6" Margin="0,0,16,0">
+                        <StackPanel>
+                            <TextBlock Text="Loop Range" Foreground="#6B7280" FontSize="11"/>
+                            <TextBlock Text="{Binding LoopRangeDisplay}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Foreground" Value="#111827"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsLoopValid}" Value="False">
+                                                <Setter Property="Foreground" Value="{DynamicResource MaterialDesignValidationErrorColor}"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </StackPanel>
+                    </Border>
+                    <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6">
+                        <StackPanel>
+                            <TextBlock Text="Save Status" Foreground="#6B7280" FontSize="11"/>
+                            <TextBlock FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Text" Value="Ready"/>
+                                        <Setter Property="Foreground" Value="#059669"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding CanSaveSchedule}" Value="False">
+                                                <Setter Property="Text" Value="Blocked"/>
+                                                <Setter Property="Foreground" Value="{DynamicResource MaterialDesignValidationErrorColor}"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </StackPanel>
+                    </Border>
+                </UniformGrid>
+
+                <Border Grid.Row="2" Margin="0,20,0,0" Padding="12" CornerRadius="6" BorderThickness="1">
+                    <Border.Style>
+                        <Style TargetType="Border">
+                            <Setter Property="Background" Value="#F9FAFB"/>
+                            <Setter Property="BorderBrush" Value="#E5E7EB"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsLoopValid}" Value="False">
+                                    <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignValidationErrorColor}"/>
+                                    <Setter Property="Background" Value="#FFF5F5"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Border.Style>
+                    <TextBlock Text="{Binding LoopSummaryText}" TextWrapping="Wrap">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock">
                                 <Setter Property="Foreground" Value="#1F2937"/>
@@ -148,65 +243,80 @@
                     </TextBlock>
                 </Border>
 
-                <!-- Calendar style quick facts -->
-                <Border Grid.Row="2" Margin="0,16,0,0" Padding="12" CornerRadius="8" BorderBrush="#E5E7EB" BorderThickness="1">
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="*"/>
-                        </Grid.RowDefinitions>
-                        <TextBlock Text="Schedule Snapshot" FontWeight="SemiBold" Foreground="#4B5563"/>
-                        <UniformGrid Grid.Row="1" Rows="2" Columns="2" Margin="0,12,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                            <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6">
-                                <StackPanel>
-                                    <TextBlock Text="Total Duration" Foreground="#6B7280" FontSize="11"/>
-                                    <TextBlock Text="{Binding TotalDuration, StringFormat={}{0:hh\\:mm\\:ss}}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center"/>
-                                </StackPanel>
-                            </Border>
-                            <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6">
-                                <StackPanel>
-                                    <TextBlock Text="Repeat Count" Foreground="#6B7280" FontSize="11"/>
-                                    <TextBlock Text="{Binding RepeatCount}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center"/>
-                                </StackPanel>
-                            </Border>
-                            <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6">
-                                <StackPanel>
-                                    <TextBlock Text="Loop Range" Foreground="#6B7280" FontSize="11"/>
-                                    <TextBlock FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center">
-                                        <TextBlock.Text>
-                                            <MultiBinding StringFormat="{}{0} → {1}">
-                                                <Binding Path="LoopStartIndex"/>
-                                                <Binding Path="LoopEndIndex"/>
-                                            </MultiBinding>
-                                        </TextBlock.Text>
-                                    </TextBlock>
-                                </StackPanel>
-                            </Border>
-                            <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6">
-                                <StackPanel>
-                                    <TextBlock Text="Save Status" Foreground="#6B7280" FontSize="11"/>
-                                    <TextBlock FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center">
-                                        <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
-                                                <Setter Property="Text" Value="Ready"/>
-                                                <Setter Property="Foreground" Value="#059669"/>
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding CanSaveSchedule}" Value="False">
-                                                        <Setter Property="Text" Value="Blocked"/>
-                                                        <Setter Property="Foreground" Value="{DynamicResource MaterialDesignValidationErrorColor}"/>
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                    </TextBlock>
-                                </StackPanel>
-                            </Border>
-                        </UniformGrid>
-                    </Grid>
-                </Border>
+                <Grid Grid.Row="3" Margin="0,20,0,0">
+                    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
+                        <ItemsControl ItemsSource="{Binding CalendarDays}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <StackPanel Orientation="Horizontal"/>
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type vm:ScheduleCalendarDay}">
+                                    <materialDesign:Card Width="260" Margin="0,0,16,0" Padding="12">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding Header}" FontWeight="SemiBold" FontSize="14"/>
+                                            <TextBlock Text="{Binding TotalDurationText}" Foreground="#6B7280" FontSize="11" Margin="0,2,0,0"/>
+                                            <ItemsControl ItemsSource="{Binding Entries}" Margin="0,12,0,0">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate DataType="{x:Type vm:ScheduleCalendarEntry}">
+                                                        <Border Margin="0,0,0,12" Padding="10" CornerRadius="6" BorderThickness="1">
+                                                            <Border.Style>
+                                                                <Style TargetType="Border">
+                                                                    <Setter Property="Background" Value="#FFFFFF"/>
+                                                                    <Setter Property="BorderBrush" Value="#E5E7EB"/>
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding IsLoopSegment}" Value="True">
+                                                                            <Setter Property="BorderBrush" Value="#93C5FD"/>
+                                                                            <Setter Property="Background" Value="#F5FAFF"/>
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </Border.Style>
+                                                            <StackPanel>
+                                                                <TextBlock Text="{Binding StepLabel}" FontWeight="SemiBold" FontSize="13"/>
+                                                                <TextBlock Text="{Binding StartDisplay}" Foreground="#1F2937" Margin="0,6,0,0"/>
+                                                                <TextBlock Text="{Binding EndDisplay}" Foreground="#1F2937"/>
+                                                                <TextBlock Text="{Binding DurationDisplay}" Foreground="#6B7280" Margin="0,6,0,0"/>
+                                                                <TextBlock Text="{Binding LoopIterationDisplay}" Foreground="#2563EB" FontSize="11" Margin="0,4,0,0">
+                                                                    <TextBlock.Style>
+                                                                        <Style TargetType="TextBlock">
+                                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                                            <Style.Triggers>
+                                                                                <DataTrigger Binding="{Binding HasLoopIteration}" Value="True">
+                                                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                                                </DataTrigger>
+                                                                            </Style.Triggers>
+                                                                        </Style>
+                                                                    </TextBlock.Style>
+                                                                </TextBlock>
+                                                            </StackPanel>
+                                                        </Border>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                    </materialDesign:Card>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                    <TextBlock Text="Add profile steps to preview calendar timing." Foreground="#9CA3AF" FontStyle="Italic"
+                               HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding CalendarDays.Count}" Value="0">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Grid>
 
-                <!-- Warning message -->
-                <TextBlock Grid.Row="3" Margin="0,14,0,0" FontWeight="SemiBold" TextWrapping="Wrap"
+                <TextBlock Grid.Row="4" Margin="0,18,0,0" FontWeight="SemiBold" TextWrapping="Wrap"
                            Foreground="{DynamicResource MaterialDesignValidationErrorColor}" TextAlignment="Center">
                     <TextBlock.Style>
                         <Style TargetType="TextBlock">

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -114,80 +114,100 @@
         </materialDesign:Card>
 
         <!-- Schedule summary card -->
-        <materialDesign:Card Grid.Row="1" Padding="12" Margin="0,0,0,8">
-            <StackPanel>
+        <materialDesign:Card Grid.Row="1" Padding="16" Margin="0,0,0,8">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <!-- Header -->
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <materialDesign:PackIcon Kind="TimelineClock" Width="22" Height="22" Margin="0,0,8,0"/>
+                    <materialDesign:PackIcon Kind="CalendarClock" Width="22" Height="22" Margin="0,0,8,0"/>
                     <StackPanel>
                         <TextBlock Text="Schedule Overview" FontWeight="SemiBold" FontSize="15"/>
                         <TextBlock Text="{Binding ScheduleSummaryText}" Foreground="#6B7280" TextWrapping="Wrap"/>
                     </StackPanel>
                 </StackPanel>
 
-                <TextBlock Margin="30,8,0,0" Text="{Binding LoopSummaryText}" TextWrapping="Wrap">
-                    <TextBlock.Style>
-                        <Style TargetType="TextBlock">
-                            <Setter Property="Foreground" Value="#374151"/>
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding IsLoopValid}" Value="False">
-                                    <Setter Property="Foreground" Value="{DynamicResource MaterialDesignValidationErrorColor}"/>
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </TextBlock.Style>
-                </TextBlock>
+                <!-- Loop summary -->
+                <Border Grid.Row="1" Margin="0,12,0,0" Padding="12,8" CornerRadius="6" Background="#F9FAFB" BorderBrush="#E5E7EB" BorderThickness="1">
+                    <TextBlock Text="{Binding LoopSummaryText}" TextWrapping="Wrap" TextAlignment="Center">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="#1F2937"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsLoopValid}" Value="False">
+                                        <Setter Property="Foreground" Value="{DynamicResource MaterialDesignValidationErrorColor}"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Border>
 
-                <Grid Margin="0,12,0,0">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
+                <!-- Calendar style quick facts -->
+                <Border Grid.Row="2" Margin="0,16,0,0" Padding="12" CornerRadius="8" BorderBrush="#E5E7EB" BorderThickness="1">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <TextBlock Text="Schedule Snapshot" FontWeight="SemiBold" Foreground="#4B5563"/>
+                        <UniformGrid Grid.Row="1" Rows="2" Columns="2" Margin="0,12,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                            <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6">
+                                <StackPanel>
+                                    <TextBlock Text="Total Duration" Foreground="#6B7280" FontSize="11"/>
+                                    <TextBlock Text="{Binding TotalDuration, StringFormat={}{0:hh\\:mm\\:ss}}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </Border>
+                            <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6">
+                                <StackPanel>
+                                    <TextBlock Text="Repeat Count" Foreground="#6B7280" FontSize="11"/>
+                                    <TextBlock Text="{Binding RepeatCount}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </Border>
+                            <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6">
+                                <StackPanel>
+                                    <TextBlock Text="Loop Range" Foreground="#6B7280" FontSize="11"/>
+                                    <TextBlock FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center">
+                                        <TextBlock.Text>
+                                            <MultiBinding StringFormat="{}{0} → {1}">
+                                                <Binding Path="LoopStartIndex"/>
+                                                <Binding Path="LoopEndIndex"/>
+                                            </MultiBinding>
+                                        </TextBlock.Text>
+                                    </TextBlock>
+                                </StackPanel>
+                            </Border>
+                            <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6">
+                                <StackPanel>
+                                    <TextBlock Text="Save Status" Foreground="#6B7280" FontSize="11"/>
+                                    <TextBlock FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Text" Value="Ready"/>
+                                                <Setter Property="Foreground" Value="#059669"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding CanSaveSchedule}" Value="False">
+                                                        <Setter Property="Text" Value="Blocked"/>
+                                                        <Setter Property="Foreground" Value="{DynamicResource MaterialDesignValidationErrorColor}"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </StackPanel>
+                            </Border>
+                        </UniformGrid>
+                    </Grid>
+                </Border>
 
-                    <StackPanel Grid.Column="0">
-                        <TextBlock Text="Total Duration" Foreground="#6B7280" FontSize="12"/>
-                        <TextBlock Text="{Binding TotalDuration, StringFormat={}{0:hh\\:mm\\:ss}}" FontWeight="SemiBold"/>
-                    </StackPanel>
-
-                    <StackPanel Grid.Column="1">
-                        <TextBlock Text="Repeat Count" Foreground="#6B7280" FontSize="12"/>
-                        <TextBlock Text="{Binding RepeatCount}" FontWeight="SemiBold"/>
-                    </StackPanel>
-
-                    <StackPanel Grid.Column="2">
-                        <TextBlock Text="Loop Range" Foreground="#6B7280" FontSize="12"/>
-                        <TextBlock FontWeight="SemiBold">
-                            <TextBlock.Text>
-                                <MultiBinding StringFormat="{}{0} → {1}">
-                                    <Binding Path="LoopStartIndex"/>
-                                    <Binding Path="LoopEndIndex"/>
-                                </MultiBinding>
-                            </TextBlock.Text>
-                        </TextBlock>
-                    </StackPanel>
-
-                    <StackPanel Grid.Column="3">
-                        <TextBlock Text="Save Status" Foreground="#6B7280" FontSize="12"/>
-                        <TextBlock FontWeight="SemiBold">
-                            <TextBlock.Style>
-                                <Style TargetType="TextBlock">
-                                    <Setter Property="Text" Value="Ready"/>
-                                    <Setter Property="Foreground" Value="#059669"/>
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding CanSaveSchedule}" Value="False">
-                                            <Setter Property="Text" Value="Blocked"/>
-                                            <Setter Property="Foreground" Value="{DynamicResource MaterialDesignValidationErrorColor}"/>
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </TextBlock.Style>
-                        </TextBlock>
-                    </StackPanel>
-                </Grid>
-
-                <TextBlock Margin="0,10,0,0" FontWeight="SemiBold" TextWrapping="Wrap"
-                           Foreground="{DynamicResource MaterialDesignValidationErrorColor}">
+                <!-- Warning message -->
+                <TextBlock Grid.Row="3" Margin="0,14,0,0" FontWeight="SemiBold" TextWrapping="Wrap"
+                           Foreground="{DynamicResource MaterialDesignValidationErrorColor}" TextAlignment="Center">
                     <TextBlock.Style>
                         <Style TargetType="TextBlock">
                             <Setter Property="Visibility" Value="Collapsed"/>
@@ -207,7 +227,7 @@
                         </Style>
                     </TextBlock.Style>
                 </TextBlock>
-            </StackPanel>
+            </Grid>
         </materialDesign:Card>
 
         <!-- Main content -->

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -47,6 +47,7 @@
     <Grid Margin="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="15"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
@@ -112,8 +113,105 @@
             </Grid>
         </materialDesign:Card>
 
+        <!-- Schedule summary card -->
+        <materialDesign:Card Grid.Row="1" Padding="12" Margin="0,0,0,8">
+            <StackPanel>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <materialDesign:PackIcon Kind="TimelineClock" Width="22" Height="22" Margin="0,0,8,0"/>
+                    <StackPanel>
+                        <TextBlock Text="Schedule Overview" FontWeight="SemiBold" FontSize="15"/>
+                        <TextBlock Text="{Binding ScheduleSummaryText}" Foreground="#6B7280" TextWrapping="Wrap"/>
+                    </StackPanel>
+                </StackPanel>
+
+                <TextBlock Margin="30,8,0,0" Text="{Binding LoopSummaryText}" TextWrapping="Wrap">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Foreground" Value="#374151"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsLoopValid}" Value="False">
+                                    <Setter Property="Foreground" Value="{DynamicResource MaterialDesignValidationErrorColor}"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+
+                <Grid Margin="0,12,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0">
+                        <TextBlock Text="Total Duration" Foreground="#6B7280" FontSize="12"/>
+                        <TextBlock Text="{Binding TotalDuration, StringFormat={}{0:hh\\:mm\\:ss}}" FontWeight="SemiBold"/>
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="1">
+                        <TextBlock Text="Repeat Count" Foreground="#6B7280" FontSize="12"/>
+                        <TextBlock Text="{Binding RepeatCount}" FontWeight="SemiBold"/>
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="2">
+                        <TextBlock Text="Loop Range" Foreground="#6B7280" FontSize="12"/>
+                        <TextBlock FontWeight="SemiBold">
+                            <TextBlock.Text>
+                                <MultiBinding StringFormat="{}{0} → {1}">
+                                    <Binding Path="LoopStartIndex"/>
+                                    <Binding Path="LoopEndIndex"/>
+                                </MultiBinding>
+                            </TextBlock.Text>
+                        </TextBlock>
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="3">
+                        <TextBlock Text="Save Status" Foreground="#6B7280" FontSize="12"/>
+                        <TextBlock FontWeight="SemiBold">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Text" Value="Ready"/>
+                                    <Setter Property="Foreground" Value="#059669"/>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding CanSaveSchedule}" Value="False">
+                                            <Setter Property="Text" Value="Blocked"/>
+                                            <Setter Property="Foreground" Value="{DynamicResource MaterialDesignValidationErrorColor}"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </StackPanel>
+                </Grid>
+
+                <TextBlock Margin="0,10,0,0" FontWeight="SemiBold" TextWrapping="Wrap"
+                           Foreground="{DynamicResource MaterialDesignValidationErrorColor}">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Setter Property="Text" Value="Loop start index must come before the loop end index to save this schedule."/>
+                            <Style.Triggers>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding CanSaveSchedule}" Value="False"/>
+                                        <Condition Binding="{Binding IsLoopValid}" Value="False"/>
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </MultiDataTrigger>
+                                <DataTrigger Binding="{Binding SelectedSchedule}" Value="{x:Null}">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+            </StackPanel>
+        </materialDesign:Card>
+
         <!-- Main content -->
-        <Grid Grid.Row="2">
+        <Grid Grid.Row="3">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="700"/>


### PR DESCRIPTION
## Summary
- add derived summary properties to `ScheduleViewModel` for formatted schedule and loop information and keep them refreshed with total duration updates
- surface the summary data in a new schedule overview card that displays duration, repeat count, loop range, and save readiness
- present a clear warning whenever loop validation fails and prevents saving the schedule

## Testing
- `dotnet build CellManager/CellManager.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cca00266b08323ae94595d7e4c3a7b