### PR TITLE
Fix selection toggle mismatch after cell deletion

### DIFF
--- a/CellManager/CellManager/ViewModels/CellLibraryViewModel.cs
+++ b/CellManager/CellManager/ViewModels/CellLibraryViewModel.cs
@@ -225,11 +225,36 @@ namespace CellManager.ViewModels
 
             if (result == true)
             {
+                var wasSelected = SelectedCell?.Id == cell.Id;
+                var filteredBefore = FilteredCells.Cast<Cell>().ToList();
+                var filteredIndex = filteredBefore.IndexOf(cell);
+
                 _cellRepository.DeleteCell(cell);
                 ExecuteLoadData();
 
-                SelectedCell = (CellModels.Count > 0) ? CellModels[0] : null;
                 WeakReferenceMessenger.Default.Send(new CellDeletedMessage(cell));
+
+                if (wasSelected)
+                {
+                    var filteredAfter = FilteredCells.Cast<Cell>().ToList();
+
+                    if (filteredAfter.Count == 0)
+                    {
+                        SelectedCell = null;
+                        WeakReferenceMessenger.Default.Send(new CellSelectedMessage(null));
+                    }
+                    else
+                    {
+                        var targetIndex = filteredIndex >= 0
+                            ? Math.Clamp(filteredIndex, 0, filteredAfter.Count - 1)
+                            : 0;
+
+                        var nextSelection = filteredAfter[targetIndex];
+                        SelectedCell = nextSelection;
+                        WeakReferenceMessenger.Default.Send(new CellSelectedMessage(nextSelection));
+                    }
+                }
+
                 FilteredCells.Refresh();
             }
 


### PR DESCRIPTION
## Summary
- keep the list-view selection in sync after removing a cell by restoring the next available entry in the filtered view
- notify listeners of the new selection when the deleted cell was active so toggle state stays aligned

## Testing
- `dotnet test` *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cca8f036688323bec113378868c245