### PR TITLE
Rearrange schedule overview layout

### DIFF
--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -52,85 +52,52 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <Grid Grid.Row="0" Margin="0,0,0,12">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
+        <!-- Cell info status bar and compact overview -->
+        <materialDesign:Card Grid.Row="0" Margin="0,0,0,8" Padding="12">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
 
-            <!-- Cell info status bar -->
-            <materialDesign:Card Grid.Column="0" Padding="16" Margin="0,0,12,0">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
                     <materialDesign:PackIcon Kind="Calendar" Width="26" Height="26" Margin="0,0,12,0"/>
                     <StackPanel>
                         <TextBlock Text="Schedule" FontSize="20" FontWeight="Bold"/>
                         <TextBlock Text="Review the active cell details and assigned schedules." Foreground="#6B7280"/>
                     </StackPanel>
                 </StackPanel>
-            </materialDesign:Card>
 
-            <!-- Compact schedule overview -->
-            <materialDesign:Card Grid.Column="1" Padding="16" MinWidth="400" MaxWidth="520">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
+                <Grid Grid.Column="1" Margin="24,0" VerticalAlignment="Center">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
 
-                    <Grid Grid.Row="0">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0"
+                               Text="{Binding ScheduleSummaryText}"
+                               Foreground="#6B7280"
+                               TextWrapping="NoWrap"
+                               TextTrimming="CharacterEllipsis"
+                               MaxWidth="260"/>
 
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                            <materialDesign:PackIcon Kind="CalendarRange" Width="22" Height="22" Margin="0,0,8,0"/>
-                            <StackPanel>
-                                <TextBlock Text="Schedule Calendar" FontWeight="SemiBold" FontSize="15"/>
-                                <TextBlock Text="{Binding ScheduleSummaryText}" Foreground="#6B7280" TextWrapping="Wrap"/>
-                            </StackPanel>
-                        </StackPanel>
-
-                        <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="16,0,0,0">
-                            <StackPanel Width="140">
-                                <TextBlock Text="Start Date" Foreground="#6B7280" FontSize="11"/>
-                                <DatePicker SelectedDate="{Binding ScheduleStartDate, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-                            </StackPanel>
-                            <StackPanel Margin="12,0,0,0" Width="120">
-                                <TextBlock Text="Start Time" Foreground="#6B7280" FontSize="11"/>
-                                <xctk:TimePicker Value="{Binding ScheduleStartTimePickerValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                 Format="Custom"
-                                                 FormatString="HH:mm"
-                                                 AllowSpin="True"/>
-                            </StackPanel>
-                        </StackPanel>
-                    </Grid>
-
-                    <Grid Grid.Row="1" Margin="0,16,0,0">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
-
-                        <StackPanel Grid.Row="0" Grid.Column="0">
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="24,0,0,0" VerticalAlignment="Center">
+                        <StackPanel Margin="0,0,16,0">
                             <TextBlock Text="Start" Foreground="#6B7280" FontSize="11"/>
-                            <TextBlock Text="{Binding ScheduleStartDateTime, StringFormat={}{0:yyyy-MM-dd HH:mm}}" FontSize="16" FontWeight="SemiBold"/>
+                            <TextBlock Text="{Binding ScheduleStartDateTime, StringFormat={}{0:yyyy-MM-dd HH:mm}}" FontSize="14" FontWeight="SemiBold"/>
                         </StackPanel>
-                        <StackPanel Grid.Row="0" Grid.Column="1">
+                        <StackPanel Margin="0,0,16,0">
                             <TextBlock Text="End" Foreground="#6B7280" FontSize="11"/>
-                            <TextBlock Text="{Binding ScheduleEndDateTime, StringFormat={}{0:yyyy-MM-dd HH:mm}}" FontSize="16" FontWeight="SemiBold"/>
+                            <TextBlock Text="{Binding ScheduleEndDateTime, StringFormat={}{0:yyyy-MM-dd HH:mm}}" FontSize="14" FontWeight="SemiBold"/>
                         </StackPanel>
-                        <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,12,0,0">
+                        <StackPanel Margin="0,0,16,0">
                             <TextBlock Text="Total Duration" Foreground="#6B7280" FontSize="11"/>
-                            <TextBlock Text="{Binding TotalDuration, StringFormat={}{0:hh\\:mm\\:ss}}" FontSize="16" FontWeight="SemiBold"/>
+                            <TextBlock Text="{Binding TotalDuration, StringFormat={}{0:hh\\:mm\\:ss}}" FontSize="14" FontWeight="SemiBold"/>
                         </StackPanel>
-                        <StackPanel Grid.Row="1" Grid.Column="1" Margin="0,12,0,0">
+                        <StackPanel>
                             <TextBlock Text="Save Status" Foreground="#6B7280" FontSize="11"/>
-                            <TextBlock FontSize="16" FontWeight="SemiBold">
+                            <TextBlock FontSize="14" FontWeight="SemiBold">
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock">
                                         <Setter Property="Text" Value="Ready"/>
@@ -145,10 +112,24 @@
                                 </TextBlock.Style>
                             </TextBlock>
                         </StackPanel>
-                    </Grid>
+                    </StackPanel>
                 </Grid>
-            </materialDesign:Card>
-        </Grid>
+
+                <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
+                    <StackPanel Width="140">
+                        <TextBlock Text="Start Date" Foreground="#6B7280" FontSize="11"/>
+                        <DatePicker SelectedDate="{Binding ScheduleStartDate, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                    </StackPanel>
+                    <StackPanel Margin="12,0,0,0" Width="120">
+                        <TextBlock Text="Start Time" Foreground="#6B7280" FontSize="11"/>
+                        <xctk:TimePicker Value="{Binding ScheduleStartTimePickerValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         Format="Custom"
+                                         FormatString="HH:mm"
+                                         AllowSpin="True"/>
+                    </StackPanel>
+                </StackPanel>
+            </Grid>
+        </materialDesign:Card>
 
         <!-- Schedule calendar card -->
         <materialDesign:Card Grid.Row="1" Padding="16" Margin="0,0,0,8">

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -48,18 +48,18 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="15"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <!-- Cell info status bar -->
-        <materialDesign:Card Grid.Row="0" Margin="0,0,0,8" Padding="12">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
+        <Grid Grid.Row="0" Margin="0,0,0,12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Cell info status bar -->
+            <materialDesign:Card Grid.Column="0" Padding="16" Margin="0,0,12,0">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <materialDesign:PackIcon Kind="Calendar" Width="26" Height="26" Margin="0,0,12,0"/>
                     <StackPanel>
@@ -67,69 +67,70 @@
                         <TextBlock Text="Review the active cell details and assigned schedules." Foreground="#6B7280"/>
                     </StackPanel>
                 </StackPanel>
-            </Grid>
-        </materialDesign:Card>
+            </materialDesign:Card>
 
-        <!-- Schedule overview card -->
-        <materialDesign:Card Grid.Row="1" Padding="16" Margin="0,0,0,8">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
+            <!-- Compact schedule overview -->
+            <materialDesign:Card Grid.Column="1" Padding="16" MinWidth="400" MaxWidth="520">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
 
-                <Grid Grid.Row="0" Margin="0,0,0,12">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
+                    <Grid Grid.Row="0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
 
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <materialDesign:PackIcon Kind="CalendarRange" Width="22" Height="22" Margin="0,0,8,0"/>
-                        <StackPanel>
-                            <TextBlock Text="Schedule Calendar" FontWeight="SemiBold" FontSize="15"/>
-                            <TextBlock Text="{Binding ScheduleSummaryText}" Foreground="#6B7280" TextWrapping="Wrap"/>
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <materialDesign:PackIcon Kind="CalendarRange" Width="22" Height="22" Margin="0,0,8,0"/>
+                            <StackPanel>
+                                <TextBlock Text="Schedule Calendar" FontWeight="SemiBold" FontSize="15"/>
+                                <TextBlock Text="{Binding ScheduleSummaryText}" Foreground="#6B7280" TextWrapping="Wrap"/>
+                            </StackPanel>
                         </StackPanel>
-                    </StackPanel>
 
-                    <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
-                        <StackPanel Width="150">
-                            <TextBlock Text="Start Date" Foreground="#6B7280" FontSize="11"/>
-                            <DatePicker SelectedDate="{Binding ScheduleStartDate, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                        <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="16,0,0,0">
+                            <StackPanel Width="140">
+                                <TextBlock Text="Start Date" Foreground="#6B7280" FontSize="11"/>
+                                <DatePicker SelectedDate="{Binding ScheduleStartDate, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                            </StackPanel>
+                            <StackPanel Margin="12,0,0,0" Width="120">
+                                <TextBlock Text="Start Time" Foreground="#6B7280" FontSize="11"/>
+                                <xctk:TimePicker Value="{Binding ScheduleStartTimePickerValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                 Format="Custom"
+                                                 FormatString="HH:mm"
+                                                 AllowSpin="True"/>
+                            </StackPanel>
                         </StackPanel>
-                        <StackPanel Margin="12,0,0,0" Width="130">
-                            <TextBlock Text="Start Time" Foreground="#6B7280" FontSize="11"/>
-                            <xctk:TimePicker Value="{Binding ScheduleStartTimePickerValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                             Format="Custom"
-                                             FormatString="HH:mm"
-                                             AllowSpin="True"/>
-                        </StackPanel>
-                    </StackPanel>
-                </Grid>
+                    </Grid>
 
-                <UniformGrid Grid.Row="1" Rows="2" Columns="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                    <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6" Margin="0,0,16,16">
-                        <StackPanel>
+                    <Grid Grid.Row="1" Margin="0,16,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <StackPanel Grid.Row="0" Grid.Column="0">
                             <TextBlock Text="Start" Foreground="#6B7280" FontSize="11"/>
-                            <TextBlock Text="{Binding ScheduleStartDateTime, StringFormat={}{0:yyyy-MM-dd HH:mm}}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{Binding ScheduleStartDateTime, StringFormat={}{0:yyyy-MM-dd HH:mm}}" FontSize="16" FontWeight="SemiBold"/>
                         </StackPanel>
-                    </Border>
-                    <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6" Margin="0,0,0,16">
-                        <StackPanel>
+                        <StackPanel Grid.Row="0" Grid.Column="1">
                             <TextBlock Text="End" Foreground="#6B7280" FontSize="11"/>
-                            <TextBlock Text="{Binding ScheduleEndDateTime, StringFormat={}{0:yyyy-MM-dd HH:mm}}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{Binding ScheduleEndDateTime, StringFormat={}{0:yyyy-MM-dd HH:mm}}" FontSize="16" FontWeight="SemiBold"/>
                         </StackPanel>
-                    </Border>
-                    <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6" Margin="0,0,16,0">
-                        <StackPanel>
+                        <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,12,0,0">
                             <TextBlock Text="Total Duration" Foreground="#6B7280" FontSize="11"/>
-                            <TextBlock Text="{Binding TotalDuration, StringFormat={}{0:hh\\:mm\\:ss}}" FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center"/>
+                            <TextBlock Text="{Binding TotalDuration, StringFormat={}{0:hh\\:mm\\:ss}}" FontSize="16" FontWeight="SemiBold"/>
                         </StackPanel>
-                    </Border>
-                    <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6">
-                        <StackPanel>
+                        <StackPanel Grid.Row="1" Grid.Column="1" Margin="0,12,0,0">
                             <TextBlock Text="Save Status" Foreground="#6B7280" FontSize="11"/>
-                            <TextBlock FontSize="18" FontWeight="SemiBold" HorizontalAlignment="Center">
+                            <TextBlock FontSize="16" FontWeight="SemiBold">
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock">
                                         <Setter Property="Text" Value="Ready"/>
@@ -144,13 +145,13 @@
                                 </TextBlock.Style>
                             </TextBlock>
                         </StackPanel>
-                    </Border>
-                </UniformGrid>
-            </Grid>
-        </materialDesign:Card>
+                    </Grid>
+                </Grid>
+            </materialDesign:Card>
+        </Grid>
 
         <!-- Schedule calendar card -->
-        <materialDesign:Card Grid.Row="2" Padding="16" Margin="0,0,0,8">
+        <materialDesign:Card Grid.Row="1" Padding="16" Margin="0,0,0,8">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*"/>
@@ -254,7 +255,7 @@
         </materialDesign:Card>
 
         <!-- Main content -->
-        <Grid Grid.Row="4">
+        <Grid Grid.Row="3">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="700"/>

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -48,6 +48,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="15"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
@@ -69,18 +70,15 @@
             </Grid>
         </materialDesign:Card>
 
-        <!-- Schedule calendar card -->
+        <!-- Schedule overview card -->
         <materialDesign:Card Grid.Row="1" Padding="16" Margin="0,0,0,8">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <Grid Grid.Row="0">
+                <Grid Grid.Row="0" Margin="0,0,0,12">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
@@ -109,7 +107,7 @@
                     </StackPanel>
                 </Grid>
 
-                <UniformGrid Grid.Row="1" Rows="2" Columns="2" Margin="0,20,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                <UniformGrid Grid.Row="1" Rows="2" Columns="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                     <Border Background="#FFFFFF" BorderBrush="#E5E7EB" BorderThickness="1" Padding="12" CornerRadius="6" Margin="0,0,16,16">
                         <StackPanel>
                             <TextBlock Text="Start" Foreground="#6B7280" FontSize="11"/>
@@ -148,35 +146,17 @@
                         </StackPanel>
                     </Border>
                 </UniformGrid>
+            </Grid>
+        </materialDesign:Card>
 
-                <Border Grid.Row="2" Margin="0,20,0,0" Padding="12" CornerRadius="6" BorderThickness="1">
-                    <Border.Style>
-                        <Style TargetType="Border">
-                            <Setter Property="Background" Value="#F9FAFB"/>
-                            <Setter Property="BorderBrush" Value="#E5E7EB"/>
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding IsLoopValid}" Value="False">
-                                    <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignValidationErrorColor}"/>
-                                    <Setter Property="Background" Value="#FFF5F5"/>
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </Border.Style>
-                    <TextBlock Text="{Binding LoopSummaryText}" TextWrapping="Wrap">
-                        <TextBlock.Style>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="Foreground" Value="#1F2937"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding IsLoopValid}" Value="False">
-                                        <Setter Property="Foreground" Value="{DynamicResource MaterialDesignValidationErrorColor}"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </TextBlock.Style>
-                    </TextBlock>
-                </Border>
-
-                <Grid Grid.Row="3" Margin="0,20,0,0">
+        <!-- Schedule calendar card -->
+        <materialDesign:Card Grid.Row="2" Padding="16" Margin="0,0,0,8">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <Grid Grid.Row="0">
                     <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
                         <ItemsControl ItemsSource="{Binding CalendarDays}">
                             <ItemsControl.ItemsPanel>
@@ -249,7 +229,7 @@
                     </TextBlock>
                 </Grid>
 
-                <TextBlock Grid.Row="4" Margin="0,18,0,0" FontWeight="SemiBold" TextWrapping="Wrap"
+                <TextBlock Grid.Row="1" Margin="0,18,0,0" FontWeight="SemiBold" TextWrapping="Wrap"
                            Foreground="{DynamicResource MaterialDesignValidationErrorColor}" TextAlignment="Center">
                     <TextBlock.Style>
                         <Style TargetType="TextBlock">
@@ -274,7 +254,7 @@
         </materialDesign:Card>
 
         <!-- Main content -->
-        <Grid Grid.Row="3">
+        <Grid Grid.Row="4">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="700"/>


### PR DESCRIPTION
## Summary
- move the schedule calendar title, summary text, and start controls into a dedicated overview card at the top of the tab
- present schedule timing metrics (start, end, duration, save status) alongside the controls for a clearer snapshot
- simplify the calendar card so it focuses on the day entries and remove the extra loop summary section

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb6fc534083239a843064cb2c1cd8