### PR TITLE
Set schedule start time automatically and stretch profile list

### DIFF
--- a/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
+++ b/CellManager/CellManager/ViewModels/ScheduleViewModel.cs
@@ -81,12 +81,12 @@ namespace CellManager.ViewModels
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(ScheduleStartDateTime))]
         [NotifyPropertyChangedFor(nameof(ScheduleEndDateTime))]
-        private DateTime _scheduleStartDate = DateTime.Today;
+        private DateTime _scheduleStartDate = DateTime.Now.Date;
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(ScheduleStartDateTime))]
         [NotifyPropertyChangedFor(nameof(ScheduleEndDateTime))]
-        private TimeSpan _scheduleStartTime = TimeSpan.FromHours(8);
+        private TimeSpan _scheduleStartTime = DateTime.Now.TimeOfDay;
 
         private string _scheduleSummaryText = string.Empty;
         public string ScheduleSummaryText
@@ -191,6 +191,7 @@ namespace CellManager.ViewModels
             });
 
             UpdateTotalDuration();
+            ResetScheduleStartToNow();
         }
 
         /// <summary>Reloads the schedule and library data when the active cell changes.</summary>
@@ -487,6 +488,13 @@ namespace CellManager.ViewModels
             OnPropertyChanged(nameof(CanSaveSchedule));
         }
 
+        private void ResetScheduleStartToNow()
+        {
+            var now = DateTime.Now;
+            ScheduleStartDate = now.Date;
+            ScheduleStartTime = now.TimeOfDay;
+        }
+
         /// <summary>Determines the total duration encompassed by the current loop markers.</summary>
         private long CalculateLoopSegmentTicksFromSequence()
         {
@@ -609,6 +617,7 @@ namespace CellManager.ViewModels
             DeleteScheduleCommand.NotifyCanExecuteChanged();
             SaveScheduleCommand?.NotifyCanExecuteChanged();
             OnPropertyChanged(nameof(CanSaveSchedule));
+            ResetScheduleStartToNow();
         }
 
         /// <summary>Creates a new blank schedule and selects it for editing.</summary>

--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -58,7 +58,6 @@
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
 
                 <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
@@ -115,19 +114,6 @@
                     </StackPanel>
                 </Grid>
 
-                <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
-                    <StackPanel Width="140">
-                        <TextBlock Text="Start Date" Foreground="#6B7280" FontSize="11"/>
-                        <DatePicker SelectedDate="{Binding ScheduleStartDate, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-                    </StackPanel>
-                    <StackPanel Margin="12,0,0,0" Width="120">
-                        <TextBlock Text="Start Time" Foreground="#6B7280" FontSize="11"/>
-                        <xctk:TimePicker Value="{Binding ScheduleStartTimePickerValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                         Format="Custom"
-                                         FormatString="HH:mm"
-                                         AllowSpin="True"/>
-                    </StackPanel>
-                </StackPanel>
             </Grid>
         </materialDesign:Card>
 
@@ -548,8 +534,12 @@
 
 
             <!-- Step library -->
-            <GroupBox Grid.Column="2" Grid.RowSpan="2" Margin="0" Style="{x:Null}" BorderThickness="0">
-                <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <GroupBox Grid.Column="2" Margin="0" Style="{x:Null}" BorderThickness="0"
+                      VerticalAlignment="Stretch" VerticalContentAlignment="Stretch">
+                <ScrollViewer VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Disabled"
+                              CanContentScroll="True"
+                              Padding="0,0,4,0">
                     <ItemsControl ItemsSource="{Binding StepLibrary}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>


### PR DESCRIPTION
## Summary
- default each schedule's start timestamp to the current time and remove manual date/time pickers from the schedule tab header
- ensure the schedule profile library column stretches and scrolls to the bottom of the available space

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ae9404d48323bacb94ad4a98d8f9