### PR TITLE
Adjust schedule header and step library layout

### DIFF
--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -49,7 +49,6 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="15"/>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <!-- Cell info status bar and compact overview -->
@@ -69,18 +68,7 @@
                 </StackPanel>
 
                 <Grid Grid.Column="1" Margin="24,0" VerticalAlignment="Center" HorizontalAlignment="Right">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock Grid.Column="0"
-                               Text="{Binding ScheduleSummaryText}"
-                               Foreground="#6B7280"
-                               TextWrapping="NoWrap"
-                               TextTrimming="CharacterEllipsis"/>
-
-                    <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="24,0,0,0" VerticalAlignment="Center">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <StackPanel Margin="0,0,16,0">
                             <TextBlock Text="Start" Foreground="#6B7280" FontSize="11"/>
                             <TextBlock Text="{Binding ScheduleStartDateTime, StringFormat={}{0:yyyy-MM-dd HH:mm}}" FontSize="14" FontWeight="SemiBold"/>
@@ -118,6 +106,10 @@
 
         <!-- Main content -->
         <Grid Grid.Row="2">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="700"/>
@@ -125,7 +117,7 @@
             </Grid.ColumnDefinitions>
 
             <!-- Schedule list -->
-            <GroupBox Grid.Column="0" Margin="0" MinWidth="300">
+            <GroupBox Grid.Row="0" Grid.Column="0" Margin="0" MinWidth="300">
                 <DockPanel>
                     <Grid DockPanel.Dock="Top">
                         <Grid.ColumnDefinitions>
@@ -261,7 +253,7 @@
             </GroupBox>
 
             <!-- Sequence builder -->
-            <GroupBox Grid.Column="1" Margin="10,0,10,0">
+            <GroupBox Grid.Row="0" Grid.Column="1" Margin="10,0,10,0">
                 <Grid >
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -531,7 +523,7 @@
 
 
             <!-- Step library -->
-            <GroupBox Grid.Column="2" Margin="0" Style="{x:Null}" BorderThickness="0"
+            <GroupBox Grid.Row="0" Grid.Column="2" Grid.RowSpan="2" Margin="0" Style="{x:Null}" BorderThickness="0"
                       VerticalAlignment="Stretch" VerticalContentAlignment="Stretch">
                 <ScrollViewer VerticalScrollBarVisibility="Auto"
                               HorizontalScrollBarVisibility="Disabled"
@@ -588,17 +580,9 @@
                     </ItemsControl>
                 </ScrollViewer>
             </GroupBox>
-        </Grid>
 
-        <!-- Schedule calendar card -->
-        <Grid Grid.Row="3" Margin="0,16,0,0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="700"/>
-                <ColumnDefinition Width="350"/>
-            </Grid.ColumnDefinitions>
-
-            <materialDesign:Card Grid.Column="0" Grid.ColumnSpan="2" Padding="16" Margin="0,0,10,0">
+            <!-- Schedule calendar card -->
+            <materialDesign:Card Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Padding="16" Margin="0,16,10,0">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="*"/>


### PR DESCRIPTION
## Summary
- remove the duplicated schedule summary text in the schedule tab header
- allow the step library to span the available vertical space by restructuring the layout
- move the schedule calendar card inside the main content grid so the right column can use the extra space

## Testing
- `dotnet build CellManager/CellManager.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d7ea12f48323924b458b91af3ece