### PR TITLE
Add scrollbars to schedule views

### DIFF
--- a/CellManager/CellManager/Views/ScheduleView.xaml
+++ b/CellManager/CellManager/Views/ScheduleView.xaml
@@ -373,7 +373,10 @@
                                 <ListBox.Template>
                                     <ControlTemplate TargetType="ListBox">
                                         <Border BorderBrush="#E5E7EB" BorderThickness="1" SnapsToDevicePixels="True">
-                                            <ScrollViewer Focusable="False" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" CanContentScroll="True">
+                                            <ScrollViewer Focusable="False"
+                                                          HorizontalScrollBarVisibility="Auto"
+                                                          VerticalScrollBarVisibility="Auto"
+                                                          CanContentScroll="True">
                                                 <ItemsPresenter />
                                             </ScrollViewer>
                                         </Border>
@@ -552,7 +555,10 @@
 
                     <Grid Grid.Row="1">
                         <Border Background="#F9FAFB" CornerRadius="8">
-                            <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Padding="12">
+                            <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                                           VerticalScrollBarVisibility="Auto"
+                                           CanContentScroll="True"
+                                           Padding="12">
                                 <ItemsControl ItemsSource="{Binding CalendarDays}">
                                     <ItemsControl.ItemsPanel>
                                         <ItemsPanelTemplate>


### PR DESCRIPTION
## Summary
- enable both vertical and horizontal scrollbars on the sequence builder list to ensure long content stays accessible
- allow the schedule calendar preview to scroll in both directions when its content exceeds the available space

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f16216088323b3a4744a8e20059a