### PR TITLE
Adjust preview text for test setup profiles

### DIFF
--- a/CellManager/CellManager/Models/TestProfile/ChargeProfile.cs
+++ b/CellManager/CellManager/Models/TestProfile/ChargeProfile.cs
@@ -18,26 +18,32 @@ namespace CellManager.Models.TestProfile
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(PreviewText))]
+        [NotifyPropertyChangedFor(nameof(TestSetupPreviewText))]
         private double _chargeCurrent;
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(PreviewText))]
+        [NotifyPropertyChangedFor(nameof(TestSetupPreviewText))]
         private double _chargeCutoffVoltage;
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(PreviewText))]
+        [NotifyPropertyChangedFor(nameof(TestSetupPreviewText))]
         private double _cutoffCurrent;
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(PreviewText))]
+        [NotifyPropertyChangedFor(nameof(TestSetupPreviewText))]
         private ChargeMode _chargeMode;
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(PreviewText))]
+        [NotifyPropertyChangedFor(nameof(TestSetupPreviewText))]
         private double? _chargeCapacityMah;
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(PreviewText))]
+        [NotifyPropertyChangedFor(nameof(TestSetupPreviewText))]
         private TimeSpan _chargeTime;
 
         [ObservableProperty]
@@ -79,18 +85,25 @@ namespace CellManager.Models.TestProfile
         /// <summary>
         ///     Text displayed in the UI profile tree summarizing the key charge settings.
         /// </summary>
-        public string PreviewText
+        public string PreviewText => BuildPreviewText(includeChargeMode: true);
+
+        /// <summary>
+        ///     Alternate preview used in the test setup view that hides the charge mode portion.
+        /// </summary>
+        public string TestSetupPreviewText => BuildPreviewText(includeChargeMode: false);
+
+        private string BuildPreviewText(bool includeChargeMode)
         {
-            get
+            var baseText = includeChargeMode
+                ? $"{ChargeMode} , {ChargeCutoffVoltage} mV, {ChargeCurrent} mA, {CutoffCurrent} mA"
+                : $"{ChargeCutoffVoltage} mV, {ChargeCurrent} mA, {CutoffCurrent} mA";
+
+            return ChargeMode switch
             {
-                var baseText = $"{ChargeMode} , {ChargeCutoffVoltage} mV, {ChargeCurrent} mA, {CutoffCurrent} mA";
-                return ChargeMode switch
-                {
-                    ChargeMode.ChargeByCapacity => $"{baseText}, {ChargeCapacityMah} mAh",
-                    ChargeMode.ChargeByTime => $"{baseText}, {ChargeTime}",
-                    _ => baseText
-                };
-            }
+                ChargeMode.ChargeByCapacity => $"{baseText}, {ChargeCapacityMah} mAh",
+                ChargeMode.ChargeByTime => $"{baseText}, {ChargeTime}",
+                _ => baseText
+            };
         }
     }
 

--- a/CellManager/CellManager/Models/TestProfile/DischargeProfile.cs
+++ b/CellManager/CellManager/Models/TestProfile/DischargeProfile.cs
@@ -29,18 +29,22 @@ namespace CellManager.Models.TestProfile
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(PreviewText))]
+        [NotifyPropertyChangedFor(nameof(TestSetupPreviewText))]
         private DischargeMode _dischargeMode;
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(PreviewText))]
+        [NotifyPropertyChangedFor(nameof(TestSetupPreviewText))]
         private double _dischargeCurrent;
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(PreviewText))]
+        [NotifyPropertyChangedFor(nameof(TestSetupPreviewText))]
         private double _dischargeCutoffVoltage;
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(PreviewText))]
+        [NotifyPropertyChangedFor(nameof(TestSetupPreviewText))]
         private TimeSpan _dischargeTime;
 
         [ObservableProperty]
@@ -54,23 +58,31 @@ namespace CellManager.Models.TestProfile
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(PreviewText))]
+        [NotifyPropertyChangedFor(nameof(TestSetupPreviewText))]
         private double? _dischargeCapacityMah;
 
         /// <summary>
         ///     User-facing summary of the discharge configuration shown in the profile tree.
         /// </summary>
-        public string PreviewText
+        public string PreviewText => BuildPreviewText(includeDischargeMode: true);
+
+        /// <summary>
+        ///     Alternate preview used in the test setup view that hides the discharge mode portion.
+        /// </summary>
+        public string TestSetupPreviewText => BuildPreviewText(includeDischargeMode: false);
+
+        private string BuildPreviewText(bool includeDischargeMode)
         {
-            get
+            var baseText = includeDischargeMode
+                ? $"{DischargeMode} , {DischargeCutoffVoltage} mV, {DischargeCurrent} mA"
+                : $"{DischargeCutoffVoltage} mV, {DischargeCurrent} mA";
+
+            return DischargeMode switch
             {
-                var baseText = $"{DischargeMode} , {DischargeCutoffVoltage} mV, {DischargeCurrent} mA";
-                return DischargeMode switch
-                {
-                    DischargeMode.DischargeByCapacity => $"{baseText}, {DischargeCapacityMah} mAh",
-                    DischargeMode.DischargeByTime => $"{baseText}, {DischargeTime}",
-                    _ => baseText
-                };
-            }
+                DischargeMode.DischargeByCapacity => $"{baseText}, {DischargeCapacityMah} mAh",
+                DischargeMode.DischargeByTime => $"{baseText}, {DischargeTime}",
+                _ => baseText
+            };
         }
 
         partial void OnDischargeHoursChanged(int value) => UpdateDischargeTime();

--- a/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
+++ b/CellManager/CellManager/Views/TestSetup/TestSetupView.xaml
@@ -99,8 +99,8 @@
                                                 </materialDesign:PackIcon.Style>
                                             </materialDesign:PackIcon>
                                         </StackPanel>
-                                            <TextBlock Text="{Binding PreviewText}" FontSize="11" Margin="0,2,0,0"
-                                                       TextTrimming="CharacterEllipsis" ToolTip="{Binding PreviewText}"/>
+                                            <TextBlock Text="{Binding TestSetupPreviewText}" FontSize="11" Margin="0,2,0,0"
+                                                       TextTrimming="CharacterEllipsis" ToolTip="{Binding TestSetupPreviewText}"/>
                                         </StackPanel>
                                     </DataTemplate>
                                 </ListBox.ItemTemplate>
@@ -213,8 +213,8 @@
                                                 </materialDesign:PackIcon.Style>
                                             </materialDesign:PackIcon>
                                         </StackPanel>
-                                            <TextBlock Text="{Binding PreviewText}" FontSize="11" Margin="0,2,0,0"
-                                                       TextTrimming="CharacterEllipsis" ToolTip="{Binding PreviewText}"/>
+                                            <TextBlock Text="{Binding TestSetupPreviewText}" FontSize="11" Margin="0,2,0,0"
+                                                       TextTrimming="CharacterEllipsis" ToolTip="{Binding TestSetupPreviewText}"/>
                                         </StackPanel>
                                     </DataTemplate>
                                 </ListBox.ItemTemplate>


### PR DESCRIPTION
## Summary
- add dedicated test setup preview strings to charge and discharge profiles that omit the mode label
- update the test setup view to bind to the new preview text while leaving the schedule view unchanged

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d10afb5f7483238b009ca82da832e8