### PR TITLE
Update calibration tab layout and add ADC displays

### DIFF
--- a/CellManager/CellManager/ViewModels/SettingsViewModel.cs
+++ b/CellManager/CellManager/ViewModels/SettingsViewModel.cs
@@ -56,6 +56,12 @@ namespace CellManager.ViewModels
         private string _packVoltageAdcValue = "0";
 
         [ObservableProperty]
+        private string _voltageMeasurement = "0";
+
+        [ObservableProperty]
+        private string _packVoltageMeasurement = "0";
+
+        [ObservableProperty]
         private string _currentReference = "500";
 
         [ObservableProperty]
@@ -65,6 +71,9 @@ namespace CellManager.ViewModels
         private string _currentAdcValue = "0";
 
         [ObservableProperty]
+        private string _currentMeasurement = "0";
+
+        [ObservableProperty]
         private string _temperatureReference = "25";
 
         [ObservableProperty]
@@ -72,6 +81,9 @@ namespace CellManager.ViewModels
 
         [ObservableProperty]
         private string _temperatureAdcValue = "0";
+
+        [ObservableProperty]
+        private string _temperatureMeasurement = "0";
 
         // Default paths
         [ObservableProperty]

--- a/CellManager/CellManager/ViewModels/SettingsViewModel.cs
+++ b/CellManager/CellManager/ViewModels/SettingsViewModel.cs
@@ -38,7 +38,22 @@ namespace CellManager.ViewModels
         private string _voltageHighResult = "0";
 
         [ObservableProperty]
+        private string _packVoltageLowReference = "1000";
+
+        [ObservableProperty]
+        private string _packVoltageLowResult = "0";
+
+        [ObservableProperty]
+        private string _packVoltageHighReference = "4000";
+
+        [ObservableProperty]
+        private string _packVoltageHighResult = "0";
+
+        [ObservableProperty]
         private string _voltageAdcValue = "0";
+
+        [ObservableProperty]
+        private string _packVoltageAdcValue = "0";
 
         [ObservableProperty]
         private string _currentReference = "500";

--- a/CellManager/CellManager/ViewModels/SettingsViewModel.cs
+++ b/CellManager/CellManager/ViewModels/SettingsViewModel.cs
@@ -38,16 +38,25 @@ namespace CellManager.ViewModels
         private string _voltageHighResult = "0";
 
         [ObservableProperty]
+        private string _voltageAdcValue = "0";
+
+        [ObservableProperty]
         private string _currentReference = "500";
 
         [ObservableProperty]
         private string _currentResult = "0";
 
         [ObservableProperty]
+        private string _currentAdcValue = "0";
+
+        [ObservableProperty]
         private string _temperatureReference = "25";
 
         [ObservableProperty]
         private string _temperatureResult = "0";
+
+        [ObservableProperty]
+        private string _temperatureAdcValue = "0";
 
         // Default paths
         [ObservableProperty]

--- a/CellManager/CellManager/ViewModels/SettingsViewModel.cs
+++ b/CellManager/CellManager/ViewModels/SettingsViewModel.cs
@@ -90,6 +90,7 @@ namespace CellManager.ViewModels
         public RelayCommand WriteProtectionCommand { get; }
         public RelayCommand ReadBoardDataCommand { get; }
         public RelayCommand WriteBoardDataCommand { get; }
+        public RelayCommand ReadAdcValuesCommand { get; }
 
         private readonly Dictionary<string, List<ProtectionSetting>> _profiles = new();
         private readonly string _boardDataFilePath = Path.Combine(AppContext.BaseDirectory, "BoardDataProfiles", "1.0.json");
@@ -101,6 +102,7 @@ namespace CellManager.ViewModels
             WriteProtectionCommand = new RelayCommand(WriteProtectionSettings, CanReadWriteProtection);
             ReadBoardDataCommand = new RelayCommand(ReadBoardDataSettings);
             WriteBoardDataCommand = new RelayCommand(WriteBoardDataSettings);
+            ReadAdcValuesCommand = new RelayCommand(ReadAdcValues);
             ReadProtectionSettings();
             ReadBoardDataSettings();
         }
@@ -135,6 +137,11 @@ namespace CellManager.ViewModels
             }
 
             // Placeholder for writing logic
+        }
+
+        private void ReadAdcValues()
+        {
+            // Placeholder for reading ADC values from hardware
         }
 
         partial void OnFirmwareVersionChanged(string value)

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -105,6 +105,7 @@
                                                         <Grid.ColumnDefinitions>
                                                             <ColumnDefinition Width="Auto"/>
                                                             <ColumnDefinition Width="160"/>
+                                                            <ColumnDefinition Width="160"/>
                                                         </Grid.ColumnDefinitions>
                                                         <Grid.RowDefinitions>
                                                             <RowDefinition Height="Auto"/>
@@ -124,6 +125,13 @@
                                                                  Text="{Binding VoltageAdcValue}"
                                                                  IsReadOnly="True"
                                                                  Margin="12,0,0,8"/>
+                                                        <TextBox Grid.Row="0"
+                                                                 Grid.Column="2"
+                                                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                 materialDesign:HintAssist.Hint="Result [mV]"
+                                                                 Text="{Binding VoltageMeasurement}"
+                                                                 IsReadOnly="True"
+                                                                 Margin="12,0,0,8"/>
                                                         <TextBlock Grid.Row="1"
                                                                    Text="Pack Voltage"
                                                                    FontWeight="SemiBold"
@@ -134,6 +142,13 @@
                                                                  Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                                  materialDesign:HintAssist.Hint="ADC"
                                                                  Text="{Binding PackVoltageAdcValue}"
+                                                                 IsReadOnly="True"
+                                                                 Margin="12,0,0,8"/>
+                                                        <TextBox Grid.Row="1"
+                                                                 Grid.Column="2"
+                                                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                 materialDesign:HintAssist.Hint="Result [mV]"
+                                                                 Text="{Binding PackVoltageMeasurement}"
                                                                  IsReadOnly="True"
                                                                  Margin="12,0,0,8"/>
                                                         <TextBlock Grid.Row="2"
@@ -148,6 +163,13 @@
                                                                  Text="{Binding CurrentAdcValue}"
                                                                  IsReadOnly="True"
                                                                  Margin="12,0,0,8"/>
+                                                        <TextBox Grid.Row="2"
+                                                                 Grid.Column="2"
+                                                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                 materialDesign:HintAssist.Hint="Result [mA]"
+                                                                 Text="{Binding CurrentMeasurement}"
+                                                                 IsReadOnly="True"
+                                                                 Margin="12,0,0,8"/>
                                                         <TextBlock Grid.Row="3"
                                                                    Text="Temperature"
                                                                    FontWeight="SemiBold"
@@ -158,6 +180,13 @@
                                                                  Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                                  materialDesign:HintAssist.Hint="ADC"
                                                                  Text="{Binding TemperatureAdcValue}"
+                                                                 IsReadOnly="True"
+                                                                 Margin="12,0,0,0"/>
+                                                        <TextBox Grid.Row="3"
+                                                                 Grid.Column="2"
+                                                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                 materialDesign:HintAssist.Hint="Result [°C]"
+                                                                 Text="{Binding TemperatureMeasurement}"
                                                                  IsReadOnly="True"
                                                                  Margin="12,0,0,0"/>
                                                     </Grid>

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -102,9 +102,10 @@
                                                             <RowDefinition Height="Auto"/>
                                                             <RowDefinition Height="Auto"/>
                                                             <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="Auto"/>
                                                         </Grid.RowDefinitions>
                                                         <TextBlock Grid.Row="0"
-                                                                   Text="Voltage"
+                                                                   Text="Cell Voltage"
                                                                    FontWeight="SemiBold"
                                                                    VerticalAlignment="Center"
                                                                    Margin="0,0,12,0"/>
@@ -116,7 +117,7 @@
                                                                  Width="160"
                                                                  IsReadOnly="True"/>
                                                         <TextBlock Grid.Row="1"
-                                                                   Text="Current"
+                                                                   Text="Pack Voltage"
                                                                    FontWeight="SemiBold"
                                                                    VerticalAlignment="Center"
                                                                    Margin="0,12,12,0"/>
@@ -125,15 +126,28 @@
                                                                  Margin="0,12,0,0"
                                                                  Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                                  materialDesign:HintAssist.Hint="ADC"
-                                                                 Text="{Binding CurrentAdcValue}"
+                                                                 Text="{Binding PackVoltageAdcValue}"
                                                                  Width="160"
                                                                  IsReadOnly="True"/>
                                                         <TextBlock Grid.Row="2"
-                                                                   Text="Temperature"
+                                                                   Text="Current"
                                                                    FontWeight="SemiBold"
                                                                    VerticalAlignment="Center"
                                                                    Margin="0,12,12,0"/>
                                                         <TextBox Grid.Row="2"
+                                                                 Grid.Column="1"
+                                                                 Margin="0,12,0,0"
+                                                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                 materialDesign:HintAssist.Hint="ADC"
+                                                                 Text="{Binding CurrentAdcValue}"
+                                                                 Width="160"
+                                                                 IsReadOnly="True"/>
+                                                        <TextBlock Grid.Row="3"
+                                                                   Text="Temperature"
+                                                                   FontWeight="SemiBold"
+                                                                   VerticalAlignment="Center"
+                                                                   Margin="0,12,12,0"/>
+                                                        <TextBox Grid.Row="3"
                                                                  Grid.Column="1"
                                                                  Margin="0,12,0,0"
                                                                  Style="{StaticResource MaterialDesignOutlinedTextBox}"
@@ -158,7 +172,7 @@
                                                 <TextBlock Text="Voltage"
                                                            Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
                                                            Margin="0,0,0,8"/>
-                                                <TextBlock Text="Low Side" FontWeight="Bold" Margin="0,16,0,0"/>
+                                                <TextBlock Text="Cell Voltage Low Side" FontWeight="Bold" Margin="0,16,0,0"/>
                                                 <Grid Margin="0,4,0,0">
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="Auto"/>
@@ -179,7 +193,7 @@
                                                             Width="100"
                                                             Style="{StaticResource SecondaryActionButton}"/>
                                                 </Grid>
-                                                <TextBlock Text="High Side" FontWeight="Bold" Margin="0,16,0,0"/>
+                                                <TextBlock Text="Cell Voltage High Side" FontWeight="Bold" Margin="0,16,0,0"/>
                                                 <Grid Margin="0,4,0,0">
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="Auto"/>
@@ -194,6 +208,48 @@
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
                                                              Text="{Binding VoltageHighResult}"
+                                                             Width="140" Margin="0,0,8,0"/>
+                                                    <Button Grid.Column="2"
+                                                            Content="Calibrate High"
+                                                            Width="100"
+                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                </Grid>
+                                                <TextBlock Text="Pack Voltage Low Side" FontWeight="Bold" Margin="0,16,0,0"/>
+                                                <Grid Margin="0,4,0,0">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             materialDesign:HintAssist.Hint="Reference [mV]"
+                                                             Text="{Binding PackVoltageLowReference}"
+                                                             Width="140" Margin="0,0,8,0"/>
+                                                    <TextBox Grid.Column="1"
+                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             materialDesign:HintAssist.Hint="Result"
+                                                             Text="{Binding PackVoltageLowResult}"
+                                                             Width="140" Margin="0,0,8,0"/>
+                                                    <Button Grid.Column="2"
+                                                            Content="Calibrate Low"
+                                                            Width="100"
+                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                </Grid>
+                                                <TextBlock Text="Pack Voltage High Side" FontWeight="Bold" Margin="0,16,0,0"/>
+                                                <Grid Margin="0,4,0,0">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             materialDesign:HintAssist.Hint="Reference [mV]"
+                                                             Text="{Binding PackVoltageHighReference}"
+                                                             Width="140" Margin="0,0,8,0"/>
+                                                    <TextBox Grid.Column="1"
+                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             materialDesign:HintAssist.Hint="Result"
+                                                             Text="{Binding PackVoltageHighResult}"
                                                              Width="140" Margin="0,0,8,0"/>
                                                     <Button Grid.Column="2"
                                                             Content="Calibrate High"

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -84,24 +84,24 @@
                                     <StackPanel>
                                         <!-- ADC readings -->
                                         <materialDesign:Card Padding="16" Margin="0,0,0,16">
-                                            <Grid materialDesign:GridAssist.RowSpacing="16">
+                                            <Grid>
                                                 <Grid.RowDefinitions>
                                                     <RowDefinition Height="Auto"/>
                                                     <RowDefinition Height="Auto"/>
                                                 </Grid.RowDefinitions>
                                                 <TextBlock Grid.Row="0"
                                                            Text="ADC Readings"
-                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"/>
+                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                                                           Margin="0,0,0,12"/>
                                                 <Grid Grid.Row="1"
-                                                      materialDesign:GridAssist.ColumnSpacing="16"
+                                                      Margin="0,0,0,0"
                                                       VerticalAlignment="Center">
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="*"/>
                                                         <ColumnDefinition Width="Auto"/>
                                                     </Grid.ColumnDefinitions>
                                                     <Grid Grid.Column="0"
-                                                          materialDesign:GridAssist.ColumnSpacing="12"
-                                                          materialDesign:GridAssist.RowSpacing="12">
+                                                          Margin="0,0,16,0">
                                                         <Grid.ColumnDefinitions>
                                                             <ColumnDefinition Width="Auto"/>
                                                             <ColumnDefinition Width="160"/>
@@ -115,65 +115,74 @@
                                                         <TextBlock Grid.Row="0"
                                                                    Text="Cell Voltage"
                                                                    FontWeight="SemiBold"
-                                                                   VerticalAlignment="Center"/>
+                                                                   VerticalAlignment="Center"
+                                                                   Margin="0,0,0,8"/>
                                                         <TextBox Grid.Row="0"
                                                                  Grid.Column="1"
                                                                  Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                                  materialDesign:HintAssist.Hint="ADC"
                                                                  Text="{Binding VoltageAdcValue}"
-                                                                 IsReadOnly="True"/>
+                                                                 IsReadOnly="True"
+                                                                 Margin="12,0,0,8"/>
                                                         <TextBlock Grid.Row="1"
                                                                    Text="Pack Voltage"
                                                                    FontWeight="SemiBold"
-                                                                   VerticalAlignment="Center"/>
+                                                                   VerticalAlignment="Center"
+                                                                   Margin="0,0,0,8"/>
                                                         <TextBox Grid.Row="1"
                                                                  Grid.Column="1"
                                                                  Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                                  materialDesign:HintAssist.Hint="ADC"
                                                                  Text="{Binding PackVoltageAdcValue}"
-                                                                 IsReadOnly="True"/>
+                                                                 IsReadOnly="True"
+                                                                 Margin="12,0,0,8"/>
                                                         <TextBlock Grid.Row="2"
                                                                    Text="Current"
                                                                    FontWeight="SemiBold"
-                                                                   VerticalAlignment="Center"/>
+                                                                   VerticalAlignment="Center"
+                                                                   Margin="0,0,0,8"/>
                                                         <TextBox Grid.Row="2"
                                                                  Grid.Column="1"
                                                                  Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                                  materialDesign:HintAssist.Hint="ADC"
                                                                  Text="{Binding CurrentAdcValue}"
-                                                                 IsReadOnly="True"/>
+                                                                 IsReadOnly="True"
+                                                                 Margin="12,0,0,8"/>
                                                         <TextBlock Grid.Row="3"
                                                                    Text="Temperature"
                                                                    FontWeight="SemiBold"
-                                                                   VerticalAlignment="Center"/>
+                                                                   VerticalAlignment="Center"
+                                                                   Margin="0,0,0,0"/>
                                                         <TextBox Grid.Row="3"
                                                                  Grid.Column="1"
                                                                  Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                                  materialDesign:HintAssist.Hint="ADC"
                                                                  Text="{Binding TemperatureAdcValue}"
-                                                                 IsReadOnly="True"/>
+                                                                 IsReadOnly="True"
+                                                                 Margin="12,0,0,0"/>
                                                     </Grid>
                                                     <Button Grid.Column="1"
                                                             Content="Read"
                                                             Width="110"
                                                             Command="{Binding ReadAdcValuesCommand}"
-                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                            Style="{StaticResource SecondaryActionButton}"
+                                                            Margin="16,0,0,0"/>
                                                 </Grid>
                                             </Grid>
                                         </materialDesign:Card>
 
                                         <!-- Voltage card -->
                                         <materialDesign:Card Padding="16" Margin="0,0,0,16">
-                                            <Grid materialDesign:GridAssist.RowSpacing="16">
+                                            <Grid>
                                                 <Grid.RowDefinitions>
                                                     <RowDefinition Height="Auto"/>
                                                     <RowDefinition Height="Auto"/>
                                                 </Grid.RowDefinitions>
                                                 <TextBlock Text="Voltage"
-                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"/>
+                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                                                           Margin="0,0,0,12"/>
                                                 <Grid Grid.Row="1"
-                                                      materialDesign:GridAssist.RowSpacing="12"
-                                                      materialDesign:GridAssist.ColumnSpacing="12">
+                                                      Margin="0,0,0,0">
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="Auto"/>
                                                         <ColumnDefinition Width="160"/>
@@ -189,98 +198,114 @@
                                                     <TextBlock Grid.Row="0"
                                                                Text="Cell Voltage Low Side"
                                                                FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"/>
+                                                               VerticalAlignment="Center"
+                                                               Margin="0,0,0,12"/>
                                                     <TextBox Grid.Row="0"
                                                              Grid.Column="1"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Reference [mV]"
-                                                             Text="{Binding VoltageLowReference}"/>
+                                                             Text="{Binding VoltageLowReference}"
+                                                             Margin="12,0,0,12"/>
                                                     <TextBox Grid.Row="0"
                                                              Grid.Column="2"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding VoltageLowResult}"/>
+                                                             Text="{Binding VoltageLowResult}"
+                                                             Margin="12,0,0,12"/>
                                                     <Button Grid.Row="0"
                                                             Grid.Column="3"
                                                             Content="Calibrate Low"
                                                             Width="120"
-                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                            Style="{StaticResource SecondaryActionButton}"
+                                                            Margin="12,0,0,12"/>
 
                                                     <TextBlock Grid.Row="1"
                                                                Text="Cell Voltage High Side"
                                                                FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"/>
+                                                               VerticalAlignment="Center"
+                                                               Margin="0,0,0,12"/>
                                                     <TextBox Grid.Row="1"
                                                              Grid.Column="1"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Reference [mV]"
-                                                             Text="{Binding VoltageHighReference}"/>
+                                                             Text="{Binding VoltageHighReference}"
+                                                             Margin="12,0,0,12"/>
                                                     <TextBox Grid.Row="1"
                                                              Grid.Column="2"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding VoltageHighResult}"/>
+                                                             Text="{Binding VoltageHighResult}"
+                                                             Margin="12,0,0,12"/>
                                                     <Button Grid.Row="1"
                                                             Grid.Column="3"
                                                             Content="Calibrate High"
                                                             Width="120"
-                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                            Style="{StaticResource SecondaryActionButton}"
+                                                            Margin="12,0,0,12"/>
 
                                                     <TextBlock Grid.Row="2"
                                                                Text="Pack Voltage Low Side"
                                                                FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"/>
+                                                               VerticalAlignment="Center"
+                                                               Margin="0,0,0,12"/>
                                                     <TextBox Grid.Row="2"
                                                              Grid.Column="1"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Reference [mV]"
-                                                             Text="{Binding PackVoltageLowReference}"/>
+                                                             Text="{Binding PackVoltageLowReference}"
+                                                             Margin="12,0,0,12"/>
                                                     <TextBox Grid.Row="2"
                                                              Grid.Column="2"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding PackVoltageLowResult}"/>
+                                                             Text="{Binding PackVoltageLowResult}"
+                                                             Margin="12,0,0,12"/>
                                                     <Button Grid.Row="2"
                                                             Grid.Column="3"
                                                             Content="Calibrate Low"
                                                             Width="120"
-                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                            Style="{StaticResource SecondaryActionButton}"
+                                                            Margin="12,0,0,12"/>
 
                                                     <TextBlock Grid.Row="3"
                                                                Text="Pack Voltage High Side"
                                                                FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"/>
+                                                               VerticalAlignment="Center"
+                                                               Margin="0,0,0,0"/>
                                                     <TextBox Grid.Row="3"
                                                              Grid.Column="1"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Reference [mV]"
-                                                             Text="{Binding PackVoltageHighReference}"/>
+                                                             Text="{Binding PackVoltageHighReference}"
+                                                             Margin="12,0,0,0"/>
                                                     <TextBox Grid.Row="3"
                                                              Grid.Column="2"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding PackVoltageHighResult}"/>
+                                                             Text="{Binding PackVoltageHighResult}"
+                                                             Margin="12,0,0,0"/>
                                                     <Button Grid.Row="3"
                                                             Grid.Column="3"
                                                             Content="Calibrate High"
                                                             Width="120"
-                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                            Style="{StaticResource SecondaryActionButton}"
+                                                            Margin="12,0,0,0"/>
                                                 </Grid>
                                             </Grid>
                                         </materialDesign:Card>
 
                                         <!-- Current card -->
                                         <materialDesign:Card Padding="16" Margin="0,0,0,16">
-                                            <Grid materialDesign:GridAssist.RowSpacing="16">
+                                            <Grid>
                                                 <Grid.RowDefinitions>
                                                     <RowDefinition Height="Auto"/>
                                                     <RowDefinition Height="Auto"/>
                                                 </Grid.RowDefinitions>
                                                 <TextBlock Text="Current"
-                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"/>
+                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                                                           Margin="0,0,0,12"/>
                                                 <Grid Grid.Row="1"
-                                                      materialDesign:GridAssist.ColumnSpacing="12"
-                                                      materialDesign:GridAssist.RowSpacing="12">
+                                                      Margin="0,0,0,0">
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="Auto"/>
                                                         <ColumnDefinition Width="160"/>
@@ -294,46 +319,53 @@
                                                     <TextBlock Grid.Row="0"
                                                                Text="Calibration"
                                                                FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"/>
+                                                               VerticalAlignment="Center"
+                                                               Margin="0,0,0,12"/>
                                                     <TextBox Grid.Row="0"
                                                              Grid.Column="1"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Reference [mA]"
-                                                             Text="{Binding CurrentReference}"/>
+                                                             Text="{Binding CurrentReference}"
+                                                             Margin="12,0,0,12"/>
                                                     <TextBox Grid.Row="0"
                                                              Grid.Column="2"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding CurrentResult}"/>
+                                                             Text="{Binding CurrentResult}"
+                                                             Margin="12,0,0,12"/>
                                                     <Button Grid.Row="0"
                                                             Grid.Column="3"
                                                             Content="Calibrate"
                                                             Width="120"
-                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                            Style="{StaticResource SecondaryActionButton}"
+                                                            Margin="12,0,0,12"/>
                                                     <TextBlock Grid.Row="1"
                                                                Text="Discharge"
                                                                FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"/>
+                                                               VerticalAlignment="Center"
+                                                               Margin="0,0,0,0"/>
                                                     <Button Grid.Row="1"
                                                             Grid.Column="3"
                                                             Content="Discharge"
                                                             Width="120"
-                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                            Style="{StaticResource SecondaryActionButton}"
+                                                            Margin="12,0,0,0"/>
                                                 </Grid>
                                             </Grid>
                                         </materialDesign:Card>
 
                                         <!-- Temperature card -->
                                         <materialDesign:Card Padding="16">
-                                            <Grid materialDesign:GridAssist.RowSpacing="16">
+                                            <Grid>
                                                 <Grid.RowDefinitions>
                                                     <RowDefinition Height="Auto"/>
                                                     <RowDefinition Height="Auto"/>
                                                 </Grid.RowDefinitions>
                                                 <TextBlock Text="Temperature"
-                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"/>
+                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                                                           Margin="0,0,0,12"/>
                                                 <Grid Grid.Row="1"
-                                                      materialDesign:GridAssist.ColumnSpacing="12">
+                                                      Margin="0,0,0,0">
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="Auto"/>
                                                         <ColumnDefinition Width="160"/>
@@ -343,19 +375,23 @@
                                                     <TextBlock Grid.Column="0"
                                                                Text="Calibration"
                                                                FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"/>
+                                                               VerticalAlignment="Center"
+                                                               Margin="0,0,0,0"/>
                                                     <TextBox Grid.Column="1"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Reference [°C]"
-                                                             Text="{Binding TemperatureReference}"/>
+                                                             Text="{Binding TemperatureReference}"
+                                                             Margin="12,0,0,0"/>
                                                     <TextBox Grid.Column="2"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding TemperatureResult}"/>
+                                                             Text="{Binding TemperatureResult}"
+                                                             Margin="12,0,0,0"/>
                                                     <Button Grid.Column="3"
                                                             Content="Set Temp"
                                                             Width="120"
-                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                            Style="{StaticResource SecondaryActionButton}"
+                                                            Margin="12,0,0,0"/>
                                                 </Grid>
                                             </Grid>
                                         </materialDesign:Card>

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -81,350 +81,352 @@
                                     <TextBlock Text="Board Calibration"
                                                Style="{StaticResource MaterialDesignHeadline6TextBlock}"
                                                Margin="0,0,0,16"/>
-                                    <StackPanel>
-                                        <!-- ADC readings -->
-                                        <materialDesign:Card Padding="16" Margin="0,0,0,16">
-                                            <Grid>
-                                                <Grid.RowDefinitions>
-                                                    <RowDefinition Height="Auto"/>
-                                                    <RowDefinition Height="Auto"/>
-                                                </Grid.RowDefinitions>
-                                                <TextBlock Grid.Row="0"
-                                                           Text="ADC Readings"
-                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                                                           Margin="0,0,0,12"/>
-                                                <Grid Grid.Row="1"
-                                                      Margin="0,0,0,0"
-                                                      VerticalAlignment="Center">
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="*"/>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                    </Grid.ColumnDefinitions>
-                                                    <Grid Grid.Column="0"
-                                                          Margin="0,0,16,0">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+
+                                        <StackPanel Grid.Column="0">
+                                            <!-- ADC readings -->
+                                            <materialDesign:Card Padding="16" Margin="0,0,16,16">
+                                                <Grid>
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                    </Grid.RowDefinitions>
+                                                    <TextBlock Grid.Row="0"
+                                                               Text="ADC Readings"
+                                                               Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                                                               Margin="0,0,0,12"/>
+                                                    <Grid Grid.Row="1"
+                                                          VerticalAlignment="Center">
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="*"/>
+                                                            <ColumnDefinition Width="Auto"/>
+                                                        </Grid.ColumnDefinitions>
+                                                        <Grid Grid.Column="0"
+                                                              Margin="0,0,16,0">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="160"/>
+                                                                <ColumnDefinition Width="160"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <Grid.RowDefinitions>
+                                                                <RowDefinition Height="Auto"/>
+                                                                <RowDefinition Height="Auto"/>
+                                                                <RowDefinition Height="Auto"/>
+                                                                <RowDefinition Height="Auto"/>
+                                                            </Grid.RowDefinitions>
+                                                            <TextBlock Grid.Row="0"
+                                                                       Text="Cell Voltage"
+                                                                       FontWeight="SemiBold"
+                                                                       VerticalAlignment="Center"
+                                                                       Margin="0,0,0,8"/>
+                                                            <TextBox Grid.Row="0"
+                                                                     Grid.Column="1"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="ADC"
+                                                                     Text="{Binding VoltageAdcValue}"
+                                                                     IsReadOnly="True"
+                                                                     Margin="12,0,0,8"/>
+                                                            <TextBox Grid.Row="0"
+                                                                     Grid.Column="2"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="Result [mV]"
+                                                                     Text="{Binding VoltageMeasurement}"
+                                                                     IsReadOnly="True"
+                                                                     Margin="12,0,0,8"/>
+                                                            <TextBlock Grid.Row="1"
+                                                                       Text="Pack Voltage"
+                                                                       FontWeight="SemiBold"
+                                                                       VerticalAlignment="Center"
+                                                                       Margin="0,0,0,8"/>
+                                                            <TextBox Grid.Row="1"
+                                                                     Grid.Column="1"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="ADC"
+                                                                     Text="{Binding PackVoltageAdcValue}"
+                                                                     IsReadOnly="True"
+                                                                     Margin="12,0,0,8"/>
+                                                            <TextBox Grid.Row="1"
+                                                                     Grid.Column="2"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="Result [mV]"
+                                                                     Text="{Binding PackVoltageMeasurement}"
+                                                                     IsReadOnly="True"
+                                                                     Margin="12,0,0,8"/>
+                                                            <TextBlock Grid.Row="2"
+                                                                       Text="Current"
+                                                                       FontWeight="SemiBold"
+                                                                       VerticalAlignment="Center"
+                                                                       Margin="0,0,0,8"/>
+                                                            <TextBox Grid.Row="2"
+                                                                     Grid.Column="1"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="ADC"
+                                                                     Text="{Binding CurrentAdcValue}"
+                                                                     IsReadOnly="True"
+                                                                     Margin="12,0,0,8"/>
+                                                            <TextBox Grid.Row="2"
+                                                                     Grid.Column="2"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="Result [mA]"
+                                                                     Text="{Binding CurrentMeasurement}"
+                                                                     IsReadOnly="True"
+                                                                     Margin="12,0,0,8"/>
+                                                            <TextBlock Grid.Row="3"
+                                                                       Text="Temperature"
+                                                                       FontWeight="SemiBold"
+                                                                       VerticalAlignment="Center"
+                                                                       Margin="0,0,0,0"/>
+                                                            <TextBox Grid.Row="3"
+                                                                     Grid.Column="1"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="ADC"
+                                                                     Text="{Binding TemperatureAdcValue}"
+                                                                     IsReadOnly="True"
+                                                                     Margin="12,0,0,0"/>
+                                                            <TextBox Grid.Row="3"
+                                                                     Grid.Column="2"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="Result [°C]"
+                                                                     Text="{Binding TemperatureMeasurement}"
+                                                                     IsReadOnly="True"
+                                                                     Margin="12,0,0,0"/>
+                                                        </Grid>
+                                                        <Button Grid.Column="1"
+                                                                Content="Read"
+                                                                MinWidth="120"
+                                                                Command="{Binding ReadAdcValuesCommand}"
+                                                                Style="{StaticResource SecondaryActionButton}"
+                                                                Margin="0"
+                                                                HorizontalAlignment="Stretch"/>
+                                                    </Grid>
+                                                </Grid>
+                                            </materialDesign:Card>
+
+                                            <!-- Voltage card -->
+                                            <materialDesign:Card Padding="16" Margin="0,0,16,0">
+                                                <Grid>
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                    </Grid.RowDefinitions>
+                                                    <TextBlock Text="Voltage"
+                                                               Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                                                               Margin="0,0,0,12"/>
+                                                    <UniformGrid Grid.Row="1" Columns="1" Rows="4">
+                                                        <Grid Margin="0,0,0,12">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="160"/>
+                                                                <ColumnDefinition Width="160"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock Text="Cell Voltage Low Side"
+                                                                       FontWeight="SemiBold"
+                                                                       VerticalAlignment="Center"/>
+                                                            <TextBox Grid.Column="1"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="Reference [mV]"
+                                                                     Text="{Binding VoltageLowReference}"
+                                                                     Margin="12,0,0,0"/>
+                                                            <TextBox Grid.Column="2"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="Result"
+                                                                     Text="{Binding VoltageLowResult}"
+                                                                     Margin="12,0,0,0"/>
+                                                            <Button Grid.Column="3"
+                                                                    Content="Calibrate Low"
+                                                                    MinWidth="120"
+                                                                    Style="{StaticResource SecondaryActionButton}"
+                                                                    Margin="12,0,0,0"/>
+                                                        </Grid>
+                                                        <Grid Margin="0,0,0,12">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="160"/>
+                                                                <ColumnDefinition Width="160"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock Text="Cell Voltage High Side"
+                                                                       FontWeight="SemiBold"
+                                                                       VerticalAlignment="Center"/>
+                                                            <TextBox Grid.Column="1"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="Reference [mV]"
+                                                                     Text="{Binding VoltageHighReference}"
+                                                                     Margin="12,0,0,0"/>
+                                                            <TextBox Grid.Column="2"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="Result"
+                                                                     Text="{Binding VoltageHighResult}"
+                                                                     Margin="12,0,0,0"/>
+                                                            <Button Grid.Column="3"
+                                                                    Content="Calibrate High"
+                                                                    MinWidth="120"
+                                                                    Style="{StaticResource SecondaryActionButton}"
+                                                                    Margin="12,0,0,0"/>
+                                                        </Grid>
+                                                        <Grid Margin="0,0,0,12">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="160"/>
+                                                                <ColumnDefinition Width="160"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock Text="Pack Voltage Low Side"
+                                                                       FontWeight="SemiBold"
+                                                                       VerticalAlignment="Center"/>
+                                                            <TextBox Grid.Column="1"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="Reference [mV]"
+                                                                     Text="{Binding PackVoltageLowReference}"
+                                                                     Margin="12,0,0,0"/>
+                                                            <TextBox Grid.Column="2"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="Result"
+                                                                     Text="{Binding PackVoltageLowResult}"
+                                                                     Margin="12,0,0,0"/>
+                                                            <Button Grid.Column="3"
+                                                                    Content="Calibrate Low"
+                                                                    MinWidth="120"
+                                                                    Style="{StaticResource SecondaryActionButton}"
+                                                                    Margin="12,0,0,0"/>
+                                                        </Grid>
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="160"/>
+                                                                <ColumnDefinition Width="160"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock Text="Pack Voltage High Side"
+                                                                       FontWeight="SemiBold"
+                                                                       VerticalAlignment="Center"/>
+                                                            <TextBox Grid.Column="1"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="Reference [mV]"
+                                                                     Text="{Binding PackVoltageHighReference}"
+                                                                     Margin="12,0,0,0"/>
+                                                            <TextBox Grid.Column="2"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="Result"
+                                                                     Text="{Binding PackVoltageHighResult}"
+                                                                     Margin="12,0,0,0"/>
+                                                            <Button Grid.Column="3"
+                                                                    Content="Calibrate High"
+                                                                    MinWidth="120"
+                                                                    Style="{StaticResource SecondaryActionButton}"
+                                                                    Margin="12,0,0,0"/>
+                                                        </Grid>
+                                                    </UniformGrid>
+                                                </Grid>
+                                            </materialDesign:Card>
+                                        </StackPanel>
+
+                                        <StackPanel Grid.Column="1">
+                                            <!-- Current card -->
+                                            <materialDesign:Card Padding="16" Margin="16,0,0,16">
+                                                <Grid>
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                    </Grid.RowDefinitions>
+                                                    <TextBlock Text="Current"
+                                                               Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                                                               Margin="0,0,0,12"/>
+                                                    <UniformGrid Grid.Row="1" Columns="1" Rows="2">
+                                                        <Grid Margin="0,0,0,12">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="160"/>
+                                                                <ColumnDefinition Width="160"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock Text="Calibration"
+                                                                       FontWeight="SemiBold"
+                                                                       VerticalAlignment="Center"/>
+                                                            <TextBox Grid.Column="1"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="Reference [mA]"
+                                                                     Text="{Binding CurrentReference}"
+                                                                     Margin="12,0,0,0"/>
+                                                            <TextBox Grid.Column="2"
+                                                                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                     materialDesign:HintAssist.Hint="Result"
+                                                                     Text="{Binding CurrentResult}"
+                                                                     Margin="12,0,0,0"/>
+                                                            <Button Grid.Column="3"
+                                                                    Content="Calibrate"
+                                                                    MinWidth="120"
+                                                                    Style="{StaticResource SecondaryActionButton}"
+                                                                    Margin="12,0,0,0"/>
+                                                        </Grid>
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="160"/>
+                                                                <ColumnDefinition Width="160"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock Text="Discharge"
+                                                                       FontWeight="SemiBold"
+                                                                       VerticalAlignment="Center"/>
+                                                            <Button Grid.Column="3"
+                                                                    Content="Discharge"
+                                                                    MinWidth="120"
+                                                                    Style="{StaticResource SecondaryActionButton}"
+                                                                    Margin="12,0,0,0"/>
+                                                        </Grid>
+                                                    </UniformGrid>
+                                                </Grid>
+                                            </materialDesign:Card>
+
+                                            <!-- Temperature card -->
+                                            <materialDesign:Card Padding="16" Margin="16,0,0,0">
+                                                <Grid>
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                    </Grid.RowDefinitions>
+                                                    <TextBlock Text="Temperature"
+                                                               Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                                                               Margin="0,0,0,12"/>
+                                                    <Grid Grid.Row="1">
                                                         <Grid.ColumnDefinitions>
                                                             <ColumnDefinition Width="Auto"/>
                                                             <ColumnDefinition Width="160"/>
                                                             <ColumnDefinition Width="160"/>
+                                                            <ColumnDefinition Width="Auto"/>
                                                         </Grid.ColumnDefinitions>
-                                                        <Grid.RowDefinitions>
-                                                            <RowDefinition Height="Auto"/>
-                                                            <RowDefinition Height="Auto"/>
-                                                            <RowDefinition Height="Auto"/>
-                                                            <RowDefinition Height="Auto"/>
-                                                        </Grid.RowDefinitions>
-                                                        <TextBlock Grid.Row="0"
-                                                                   Text="Cell Voltage"
+                                                        <TextBlock Text="Calibration"
                                                                    FontWeight="SemiBold"
-                                                                   VerticalAlignment="Center"
-                                                                   Margin="0,0,0,8"/>
-                                                        <TextBox Grid.Row="0"
-                                                                 Grid.Column="1"
+                                                                   VerticalAlignment="Center"/>
+                                                        <TextBox Grid.Column="1"
                                                                  Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                                 materialDesign:HintAssist.Hint="ADC"
-                                                                 Text="{Binding VoltageAdcValue}"
-                                                                 IsReadOnly="True"
-                                                                 Margin="12,0,0,8"/>
-                                                        <TextBox Grid.Row="0"
-                                                                 Grid.Column="2"
-                                                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                                 materialDesign:HintAssist.Hint="Result [mV]"
-                                                                 Text="{Binding VoltageMeasurement}"
-                                                                 IsReadOnly="True"
-                                                                 Margin="12,0,0,8"/>
-                                                        <TextBlock Grid.Row="1"
-                                                                   Text="Pack Voltage"
-                                                                   FontWeight="SemiBold"
-                                                                   VerticalAlignment="Center"
-                                                                   Margin="0,0,0,8"/>
-                                                        <TextBox Grid.Row="1"
-                                                                 Grid.Column="1"
-                                                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                                 materialDesign:HintAssist.Hint="ADC"
-                                                                 Text="{Binding PackVoltageAdcValue}"
-                                                                 IsReadOnly="True"
-                                                                 Margin="12,0,0,8"/>
-                                                        <TextBox Grid.Row="1"
-                                                                 Grid.Column="2"
-                                                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                                 materialDesign:HintAssist.Hint="Result [mV]"
-                                                                 Text="{Binding PackVoltageMeasurement}"
-                                                                 IsReadOnly="True"
-                                                                 Margin="12,0,0,8"/>
-                                                        <TextBlock Grid.Row="2"
-                                                                   Text="Current"
-                                                                   FontWeight="SemiBold"
-                                                                   VerticalAlignment="Center"
-                                                                   Margin="0,0,0,8"/>
-                                                        <TextBox Grid.Row="2"
-                                                                 Grid.Column="1"
-                                                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                                 materialDesign:HintAssist.Hint="ADC"
-                                                                 Text="{Binding CurrentAdcValue}"
-                                                                 IsReadOnly="True"
-                                                                 Margin="12,0,0,8"/>
-                                                        <TextBox Grid.Row="2"
-                                                                 Grid.Column="2"
-                                                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                                 materialDesign:HintAssist.Hint="Result [mA]"
-                                                                 Text="{Binding CurrentMeasurement}"
-                                                                 IsReadOnly="True"
-                                                                 Margin="12,0,0,8"/>
-                                                        <TextBlock Grid.Row="3"
-                                                                   Text="Temperature"
-                                                                   FontWeight="SemiBold"
-                                                                   VerticalAlignment="Center"
-                                                                   Margin="0,0,0,0"/>
-                                                        <TextBox Grid.Row="3"
-                                                                 Grid.Column="1"
-                                                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                                 materialDesign:HintAssist.Hint="ADC"
-                                                                 Text="{Binding TemperatureAdcValue}"
-                                                                 IsReadOnly="True"
+                                                                 materialDesign:HintAssist.Hint="Reference [°C]"
+                                                                 Text="{Binding TemperatureReference}"
                                                                  Margin="12,0,0,0"/>
-                                                        <TextBox Grid.Row="3"
-                                                                 Grid.Column="2"
+                                                        <TextBox Grid.Column="2"
                                                                  Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                                 materialDesign:HintAssist.Hint="Result [°C]"
-                                                                 Text="{Binding TemperatureMeasurement}"
-                                                                 IsReadOnly="True"
+                                                                 materialDesign:HintAssist.Hint="Result"
+                                                                 Text="{Binding TemperatureResult}"
                                                                  Margin="12,0,0,0"/>
+                                                        <Button Grid.Column="3"
+                                                                Content="Set Temp"
+                                                                MinWidth="120"
+                                                                Style="{StaticResource SecondaryActionButton}"
+                                                                Margin="12,0,0,0"/>
                                                     </Grid>
-                                                    <Button Grid.Column="1"
-                                                            Content="Read"
-                                                            Width="110"
-                                                            Command="{Binding ReadAdcValuesCommand}"
-                                                            Style="{StaticResource SecondaryActionButton}"
-                                                            Margin="16,0,0,0"/>
                                                 </Grid>
-                                            </Grid>
-                                        </materialDesign:Card>
-
-                                        <!-- Voltage card -->
-                                        <materialDesign:Card Padding="16" Margin="0,0,0,16">
-                                            <Grid>
-                                                <Grid.RowDefinitions>
-                                                    <RowDefinition Height="Auto"/>
-                                                    <RowDefinition Height="Auto"/>
-                                                </Grid.RowDefinitions>
-                                                <TextBlock Text="Voltage"
-                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                                                           Margin="0,0,0,12"/>
-                                                <Grid Grid.Row="1"
-                                                      Margin="0,0,0,0">
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="160"/>
-                                                        <ColumnDefinition Width="160"/>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                    </Grid.ColumnDefinitions>
-                                                    <Grid.RowDefinitions>
-                                                        <RowDefinition Height="Auto"/>
-                                                        <RowDefinition Height="Auto"/>
-                                                        <RowDefinition Height="Auto"/>
-                                                        <RowDefinition Height="Auto"/>
-                                                    </Grid.RowDefinitions>
-                                                    <TextBlock Grid.Row="0"
-                                                               Text="Cell Voltage Low Side"
-                                                               FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"
-                                                               Margin="0,0,0,12"/>
-                                                    <TextBox Grid.Row="0"
-                                                             Grid.Column="1"
-                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                             materialDesign:HintAssist.Hint="Reference [mV]"
-                                                             Text="{Binding VoltageLowReference}"
-                                                             Margin="12,0,0,12"/>
-                                                    <TextBox Grid.Row="0"
-                                                             Grid.Column="2"
-                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                             materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding VoltageLowResult}"
-                                                             Margin="12,0,0,12"/>
-                                                    <Button Grid.Row="0"
-                                                            Grid.Column="3"
-                                                            Content="Calibrate Low"
-                                                            Width="120"
-                                                            Style="{StaticResource SecondaryActionButton}"
-                                                            Margin="12,0,0,12"/>
-
-                                                    <TextBlock Grid.Row="1"
-                                                               Text="Cell Voltage High Side"
-                                                               FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"
-                                                               Margin="0,0,0,12"/>
-                                                    <TextBox Grid.Row="1"
-                                                             Grid.Column="1"
-                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                             materialDesign:HintAssist.Hint="Reference [mV]"
-                                                             Text="{Binding VoltageHighReference}"
-                                                             Margin="12,0,0,12"/>
-                                                    <TextBox Grid.Row="1"
-                                                             Grid.Column="2"
-                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                             materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding VoltageHighResult}"
-                                                             Margin="12,0,0,12"/>
-                                                    <Button Grid.Row="1"
-                                                            Grid.Column="3"
-                                                            Content="Calibrate High"
-                                                            Width="120"
-                                                            Style="{StaticResource SecondaryActionButton}"
-                                                            Margin="12,0,0,12"/>
-
-                                                    <TextBlock Grid.Row="2"
-                                                               Text="Pack Voltage Low Side"
-                                                               FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"
-                                                               Margin="0,0,0,12"/>
-                                                    <TextBox Grid.Row="2"
-                                                             Grid.Column="1"
-                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                             materialDesign:HintAssist.Hint="Reference [mV]"
-                                                             Text="{Binding PackVoltageLowReference}"
-                                                             Margin="12,0,0,12"/>
-                                                    <TextBox Grid.Row="2"
-                                                             Grid.Column="2"
-                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                             materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding PackVoltageLowResult}"
-                                                             Margin="12,0,0,12"/>
-                                                    <Button Grid.Row="2"
-                                                            Grid.Column="3"
-                                                            Content="Calibrate Low"
-                                                            Width="120"
-                                                            Style="{StaticResource SecondaryActionButton}"
-                                                            Margin="12,0,0,12"/>
-
-                                                    <TextBlock Grid.Row="3"
-                                                               Text="Pack Voltage High Side"
-                                                               FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"
-                                                               Margin="0,0,0,0"/>
-                                                    <TextBox Grid.Row="3"
-                                                             Grid.Column="1"
-                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                             materialDesign:HintAssist.Hint="Reference [mV]"
-                                                             Text="{Binding PackVoltageHighReference}"
-                                                             Margin="12,0,0,0"/>
-                                                    <TextBox Grid.Row="3"
-                                                             Grid.Column="2"
-                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                             materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding PackVoltageHighResult}"
-                                                             Margin="12,0,0,0"/>
-                                                    <Button Grid.Row="3"
-                                                            Grid.Column="3"
-                                                            Content="Calibrate High"
-                                                            Width="120"
-                                                            Style="{StaticResource SecondaryActionButton}"
-                                                            Margin="12,0,0,0"/>
-                                                </Grid>
-                                            </Grid>
-                                        </materialDesign:Card>
-
-                                        <!-- Current card -->
-                                        <materialDesign:Card Padding="16" Margin="0,0,0,16">
-                                            <Grid>
-                                                <Grid.RowDefinitions>
-                                                    <RowDefinition Height="Auto"/>
-                                                    <RowDefinition Height="Auto"/>
-                                                </Grid.RowDefinitions>
-                                                <TextBlock Text="Current"
-                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                                                           Margin="0,0,0,12"/>
-                                                <Grid Grid.Row="1"
-                                                      Margin="0,0,0,0">
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="160"/>
-                                                        <ColumnDefinition Width="160"/>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                    </Grid.ColumnDefinitions>
-                                                    <Grid.RowDefinitions>
-                                                        <RowDefinition Height="Auto"/>
-                                                        <RowDefinition Height="Auto"/>
-                                                    </Grid.RowDefinitions>
-                                                    <TextBlock Grid.Row="0"
-                                                               Text="Calibration"
-                                                               FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"
-                                                               Margin="0,0,0,12"/>
-                                                    <TextBox Grid.Row="0"
-                                                             Grid.Column="1"
-                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                             materialDesign:HintAssist.Hint="Reference [mA]"
-                                                             Text="{Binding CurrentReference}"
-                                                             Margin="12,0,0,12"/>
-                                                    <TextBox Grid.Row="0"
-                                                             Grid.Column="2"
-                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                             materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding CurrentResult}"
-                                                             Margin="12,0,0,12"/>
-                                                    <Button Grid.Row="0"
-                                                            Grid.Column="3"
-                                                            Content="Calibrate"
-                                                            Width="120"
-                                                            Style="{StaticResource SecondaryActionButton}"
-                                                            Margin="12,0,0,12"/>
-                                                    <TextBlock Grid.Row="1"
-                                                               Text="Discharge"
-                                                               FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"
-                                                               Margin="0,0,0,0"/>
-                                                    <Button Grid.Row="1"
-                                                            Grid.Column="3"
-                                                            Content="Discharge"
-                                                            Width="120"
-                                                            Style="{StaticResource SecondaryActionButton}"
-                                                            Margin="12,0,0,0"/>
-                                                </Grid>
-                                            </Grid>
-                                        </materialDesign:Card>
-
-                                        <!-- Temperature card -->
-                                        <materialDesign:Card Padding="16">
-                                            <Grid>
-                                                <Grid.RowDefinitions>
-                                                    <RowDefinition Height="Auto"/>
-                                                    <RowDefinition Height="Auto"/>
-                                                </Grid.RowDefinitions>
-                                                <TextBlock Text="Temperature"
-                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                                                           Margin="0,0,0,12"/>
-                                                <Grid Grid.Row="1"
-                                                      Margin="0,0,0,0">
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="160"/>
-                                                        <ColumnDefinition Width="160"/>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                    </Grid.ColumnDefinitions>
-                                                    <TextBlock Grid.Column="0"
-                                                               Text="Calibration"
-                                                               FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"
-                                                               Margin="0,0,0,0"/>
-                                                    <TextBox Grid.Column="1"
-                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                             materialDesign:HintAssist.Hint="Reference [°C]"
-                                                             Text="{Binding TemperatureReference}"
-                                                             Margin="12,0,0,0"/>
-                                                    <TextBox Grid.Column="2"
-                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                             materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding TemperatureResult}"
-                                                             Margin="12,0,0,0"/>
-                                                    <Button Grid.Column="3"
-                                                            Content="Set Temp"
-                                                            Width="120"
-                                                            Style="{StaticResource SecondaryActionButton}"
-                                                            Margin="12,0,0,0"/>
-                                                </Grid>
-                                            </Grid>
-                                        </materialDesign:Card>
-                                    </StackPanel>
+                                            </materialDesign:Card>
+                                        </StackPanel>
+                                    </Grid>
                                 </StackPanel>
                             </materialDesign:Card>
                         </StackPanel>

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -81,86 +81,151 @@
                                     <TextBlock Text="Board Calibration"
                                                Style="{StaticResource MaterialDesignHeadline6TextBlock}"
                                                Margin="0,0,0,16"/>
-                                    <StackPanel Orientation="Horizontal">
+                                    <StackPanel>
                                         <!-- Voltage card -->
-                                        <materialDesign:Card Padding="16" Width="300" Margin="0,0,16,0">
+                                        <materialDesign:Card Padding="16" Margin="0,0,0,16">
                                             <StackPanel>
                                                 <TextBlock Text="Voltage"
                                                            Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
                                                            Margin="0,0,0,8"/>
-                                                <TextBlock Text="Low Side" FontWeight="Bold"/>
-                                                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                                                <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
+                                                    <TextBlock Text="ADC"
+                                                               FontWeight="SemiBold"
+                                                               VerticalAlignment="Center"
+                                                               Width="80"/>
+                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             materialDesign:HintAssist.Hint="Value"
+                                                             Text="{Binding VoltageAdcValue}"
+                                                             Width="160"
+                                                             IsReadOnly="True"/>
+                                                </StackPanel>
+                                                <TextBlock Text="Low Side" FontWeight="Bold" Margin="0,16,0,0"/>
+                                                <Grid Margin="0,4,0,0">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
                                                     <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Reference [mV]"
                                                              Text="{Binding VoltageLowReference}"
-                                                             Width="120" Margin="0,0,8,0"/>
-                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             Width="140" Margin="0,0,8,0"/>
+                                                    <TextBox Grid.Column="1"
+                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
                                                              Text="{Binding VoltageLowResult}"
-                                                             Width="120"/>
-                                                </StackPanel>
-                                                <TextBlock Text="High Side" FontWeight="Bold" Margin="0,8,0,0"/>
-                                                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                                                             Width="140" Margin="0,0,8,0"/>
+                                                    <Button Grid.Column="2"
+                                                            Content="Calibrate Low"
+                                                            Width="100"
+                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                </Grid>
+                                                <TextBlock Text="High Side" FontWeight="Bold" Margin="0,16,0,0"/>
+                                                <Grid Margin="0,4,0,0">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
                                                     <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Reference [mV]"
                                                              Text="{Binding VoltageHighReference}"
-                                                             Width="120" Margin="0,0,8,0"/>
-                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             Width="140" Margin="0,0,8,0"/>
+                                                    <TextBox Grid.Column="1"
+                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
                                                              Text="{Binding VoltageHighResult}"
-                                                             Width="120"/>
-                                                </StackPanel>
+                                                             Width="140" Margin="0,0,8,0"/>
+                                                    <Button Grid.Column="2"
+                                                            Content="Calibrate High"
+                                                            Width="100"
+                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                </Grid>
                                             </StackPanel>
                                         </materialDesign:Card>
 
                                         <!-- Current card -->
-                                        <materialDesign:Card Padding="16" Width="260" Margin="0,0,16,0">
+                                        <materialDesign:Card Padding="16" Margin="0,0,0,16">
                                             <StackPanel>
-                                                <TextBlock Text="Current"
-                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                                                           Margin="0,0,0,8"/>
-                                                <StackPanel Orientation="Horizontal">
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBlock Text="Current"
+                                                               Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                                                               Margin="0,0,8,0"/>
+                                                    <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="16,0,0,0">
+                                                        <Button Content="Calibrate"
+                                                                Width="100"
+                                                                Margin="0,0,8,0"
+                                                                Style="{StaticResource SecondaryActionButton}"/>
+                                                        <Button Content="Discharge"
+                                                                Width="100"
+                                                                Style="{StaticResource SecondaryActionButton}"/>
+                                                    </StackPanel>
+                                                </Grid>
+                                                <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
+                                                    <TextBlock Text="ADC"
+                                                               FontWeight="SemiBold"
+                                                               VerticalAlignment="Center"
+                                                               Width="80"/>
+                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             materialDesign:HintAssist.Hint="Value"
+                                                             Text="{Binding CurrentAdcValue}"
+                                                             Width="160"
+                                                             IsReadOnly="True"/>
+                                                </StackPanel>
+                                                <StackPanel Orientation="Horizontal" Margin="0,16,0,0">
                                                     <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Reference [mA]"
                                                              Text="{Binding CurrentReference}"
-                                                             Width="120" Margin="0,0,8,0"/>
+                                                             Width="140" Margin="0,0,8,0"/>
                                                     <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
                                                              Text="{Binding CurrentResult}"
-                                                             Width="120"/>
-                                                </StackPanel>
-                                                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                                                    <Button Content="Calibrate"
-                                                            Width="80"
-                                                            Margin="0,0,8,0"
-                                                            Style="{StaticResource SecondaryActionButton}"/>
-                                                    <Button Content="Discharge"
-                                                            Width="80"
-                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                             Width="140"/>
                                                 </StackPanel>
                                             </StackPanel>
                                         </materialDesign:Card>
 
                                         <!-- Temperature card -->
-                                        <materialDesign:Card Padding="16" Width="260">
+                                        <materialDesign:Card Padding="16">
                                             <StackPanel>
-                                                <TextBlock Text="Temperature"
-                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                                                           Margin="0,0,0,8"/>
-                                                <StackPanel Orientation="Horizontal">
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBlock Text="Temperature"
+                                                               Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                                                               Margin="0,0,8,0"/>
+                                                    <Button Grid.Column="1"
+                                                            Content="Set Temp"
+                                                            Width="100"
+                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                </Grid>
+                                                <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
+                                                    <TextBlock Text="ADC"
+                                                               FontWeight="SemiBold"
+                                                               VerticalAlignment="Center"
+                                                               Width="80"/>
+                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             materialDesign:HintAssist.Hint="Value"
+                                                             Text="{Binding TemperatureAdcValue}"
+                                                             Width="160"
+                                                             IsReadOnly="True"/>
+                                                </StackPanel>
+                                                <StackPanel Orientation="Horizontal" Margin="0,16,0,0">
                                                     <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Reference [°C]"
                                                              Text="{Binding TemperatureReference}"
-                                                             Width="120" Margin="0,0,8,0"/>
+                                                             Width="140" Margin="0,0,8,0"/>
                                                     <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
                                                              Text="{Binding TemperatureResult}"
-                                                             Width="120"/>
+                                                             Width="140"/>
                                                 </StackPanel>
-                                                <Button Content="Set Temp"
-                                                        Width="80"
-                                                        Margin="0,8,0,0"
-                                                        Style="{StaticResource SecondaryActionButton}"/>
                                             </StackPanel>
                                         </materialDesign:Card>
                                     </StackPanel>

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -84,19 +84,27 @@
                                     <StackPanel>
                                         <!-- ADC readings -->
                                         <materialDesign:Card Padding="16" Margin="0,0,0,16">
-                                            <StackPanel>
-                                                <TextBlock Text="ADC Readings"
-                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                                                           Margin="0,0,0,8"/>
-                                                <Grid>
+                                            <Grid materialDesign:GridAssist.RowSpacing="16">
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="Auto"/>
+                                                    <RowDefinition Height="Auto"/>
+                                                </Grid.RowDefinitions>
+                                                <TextBlock Grid.Row="0"
+                                                           Text="ADC Readings"
+                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"/>
+                                                <Grid Grid.Row="1"
+                                                      materialDesign:GridAssist.ColumnSpacing="16"
+                                                      VerticalAlignment="Center">
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="*"/>
                                                         <ColumnDefinition Width="Auto"/>
                                                     </Grid.ColumnDefinitions>
-                                                    <Grid Grid.Column="0">
+                                                    <Grid Grid.Column="0"
+                                                          materialDesign:GridAssist.ColumnSpacing="12"
+                                                          materialDesign:GridAssist.RowSpacing="12">
                                                         <Grid.ColumnDefinitions>
                                                             <ColumnDefinition Width="Auto"/>
-                                                            <ColumnDefinition Width="*"/>
+                                                            <ColumnDefinition Width="160"/>
                                                         </Grid.ColumnDefinitions>
                                                         <Grid.RowDefinitions>
                                                             <RowDefinition Height="Auto"/>
@@ -107,224 +115,249 @@
                                                         <TextBlock Grid.Row="0"
                                                                    Text="Cell Voltage"
                                                                    FontWeight="SemiBold"
-                                                                   VerticalAlignment="Center"
-                                                                   Margin="0,0,12,0"/>
+                                                                   VerticalAlignment="Center"/>
                                                         <TextBox Grid.Row="0"
                                                                  Grid.Column="1"
                                                                  Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                                  materialDesign:HintAssist.Hint="ADC"
                                                                  Text="{Binding VoltageAdcValue}"
-                                                                 Width="160"
                                                                  IsReadOnly="True"/>
                                                         <TextBlock Grid.Row="1"
                                                                    Text="Pack Voltage"
                                                                    FontWeight="SemiBold"
-                                                                   VerticalAlignment="Center"
-                                                                   Margin="0,12,12,0"/>
+                                                                   VerticalAlignment="Center"/>
                                                         <TextBox Grid.Row="1"
                                                                  Grid.Column="1"
-                                                                 Margin="0,12,0,0"
                                                                  Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                                  materialDesign:HintAssist.Hint="ADC"
                                                                  Text="{Binding PackVoltageAdcValue}"
-                                                                 Width="160"
                                                                  IsReadOnly="True"/>
                                                         <TextBlock Grid.Row="2"
                                                                    Text="Current"
                                                                    FontWeight="SemiBold"
-                                                                   VerticalAlignment="Center"
-                                                                   Margin="0,12,12,0"/>
+                                                                   VerticalAlignment="Center"/>
                                                         <TextBox Grid.Row="2"
                                                                  Grid.Column="1"
-                                                                 Margin="0,12,0,0"
                                                                  Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                                  materialDesign:HintAssist.Hint="ADC"
                                                                  Text="{Binding CurrentAdcValue}"
-                                                                 Width="160"
                                                                  IsReadOnly="True"/>
                                                         <TextBlock Grid.Row="3"
                                                                    Text="Temperature"
                                                                    FontWeight="SemiBold"
-                                                                   VerticalAlignment="Center"
-                                                                   Margin="0,12,12,0"/>
+                                                                   VerticalAlignment="Center"/>
                                                         <TextBox Grid.Row="3"
                                                                  Grid.Column="1"
-                                                                 Margin="0,12,0,0"
                                                                  Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                                  materialDesign:HintAssist.Hint="ADC"
                                                                  Text="{Binding TemperatureAdcValue}"
-                                                                 Width="160"
                                                                  IsReadOnly="True"/>
                                                     </Grid>
                                                     <Button Grid.Column="1"
                                                             Content="Read"
-                                                            Width="100"
-                                                            Margin="16,0,0,0"
+                                                            Width="110"
                                                             Command="{Binding ReadAdcValuesCommand}"
                                                             Style="{StaticResource SecondaryActionButton}"/>
                                                 </Grid>
-                                            </StackPanel>
+                                            </Grid>
                                         </materialDesign:Card>
 
                                         <!-- Voltage card -->
                                         <materialDesign:Card Padding="16" Margin="0,0,0,16">
-                                            <StackPanel>
+                                            <Grid materialDesign:GridAssist.RowSpacing="16">
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="Auto"/>
+                                                    <RowDefinition Height="Auto"/>
+                                                </Grid.RowDefinitions>
                                                 <TextBlock Text="Voltage"
-                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                                                           Margin="0,0,0,8"/>
-                                                <TextBlock Text="Cell Voltage Low Side" FontWeight="Bold" Margin="0,16,0,0"/>
-                                                <Grid Margin="0,4,0,0">
+                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"/>
+                                                <Grid Grid.Row="1"
+                                                      materialDesign:GridAssist.RowSpacing="12"
+                                                      materialDesign:GridAssist.ColumnSpacing="12">
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="160"/>
+                                                        <ColumnDefinition Width="160"/>
                                                         <ColumnDefinition Width="Auto"/>
                                                     </Grid.ColumnDefinitions>
-                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                    </Grid.RowDefinitions>
+                                                    <TextBlock Grid.Row="0"
+                                                               Text="Cell Voltage Low Side"
+                                                               FontWeight="SemiBold"
+                                                               VerticalAlignment="Center"/>
+                                                    <TextBox Grid.Row="0"
+                                                             Grid.Column="1"
+                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Reference [mV]"
-                                                             Text="{Binding VoltageLowReference}"
-                                                             Width="140" Margin="0,0,8,0"/>
-                                                    <TextBox Grid.Column="1"
+                                                             Text="{Binding VoltageLowReference}"/>
+                                                    <TextBox Grid.Row="0"
+                                                             Grid.Column="2"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding VoltageLowResult}"
-                                                             Width="140" Margin="0,0,8,0"/>
-                                                    <Button Grid.Column="2"
+                                                             Text="{Binding VoltageLowResult}"/>
+                                                    <Button Grid.Row="0"
+                                                            Grid.Column="3"
                                                             Content="Calibrate Low"
-                                                            Width="100"
+                                                            Width="120"
                                                             Style="{StaticResource SecondaryActionButton}"/>
-                                                </Grid>
-                                                <TextBlock Text="Cell Voltage High Side" FontWeight="Bold" Margin="0,16,0,0"/>
-                                                <Grid Margin="0,4,0,0">
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                    </Grid.ColumnDefinitions>
-                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+
+                                                    <TextBlock Grid.Row="1"
+                                                               Text="Cell Voltage High Side"
+                                                               FontWeight="SemiBold"
+                                                               VerticalAlignment="Center"/>
+                                                    <TextBox Grid.Row="1"
+                                                             Grid.Column="1"
+                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Reference [mV]"
-                                                             Text="{Binding VoltageHighReference}"
-                                                             Width="140" Margin="0,0,8,0"/>
-                                                    <TextBox Grid.Column="1"
+                                                             Text="{Binding VoltageHighReference}"/>
+                                                    <TextBox Grid.Row="1"
+                                                             Grid.Column="2"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding VoltageHighResult}"
-                                                             Width="140" Margin="0,0,8,0"/>
-                                                    <Button Grid.Column="2"
+                                                             Text="{Binding VoltageHighResult}"/>
+                                                    <Button Grid.Row="1"
+                                                            Grid.Column="3"
                                                             Content="Calibrate High"
-                                                            Width="100"
+                                                            Width="120"
                                                             Style="{StaticResource SecondaryActionButton}"/>
-                                                </Grid>
-                                                <TextBlock Text="Pack Voltage Low Side" FontWeight="Bold" Margin="0,16,0,0"/>
-                                                <Grid Margin="0,4,0,0">
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                    </Grid.ColumnDefinitions>
-                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+
+                                                    <TextBlock Grid.Row="2"
+                                                               Text="Pack Voltage Low Side"
+                                                               FontWeight="SemiBold"
+                                                               VerticalAlignment="Center"/>
+                                                    <TextBox Grid.Row="2"
+                                                             Grid.Column="1"
+                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Reference [mV]"
-                                                             Text="{Binding PackVoltageLowReference}"
-                                                             Width="140" Margin="0,0,8,0"/>
-                                                    <TextBox Grid.Column="1"
+                                                             Text="{Binding PackVoltageLowReference}"/>
+                                                    <TextBox Grid.Row="2"
+                                                             Grid.Column="2"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding PackVoltageLowResult}"
-                                                             Width="140" Margin="0,0,8,0"/>
-                                                    <Button Grid.Column="2"
+                                                             Text="{Binding PackVoltageLowResult}"/>
+                                                    <Button Grid.Row="2"
+                                                            Grid.Column="3"
                                                             Content="Calibrate Low"
-                                                            Width="100"
+                                                            Width="120"
                                                             Style="{StaticResource SecondaryActionButton}"/>
-                                                </Grid>
-                                                <TextBlock Text="Pack Voltage High Side" FontWeight="Bold" Margin="0,16,0,0"/>
-                                                <Grid Margin="0,4,0,0">
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                    </Grid.ColumnDefinitions>
-                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+
+                                                    <TextBlock Grid.Row="3"
+                                                               Text="Pack Voltage High Side"
+                                                               FontWeight="SemiBold"
+                                                               VerticalAlignment="Center"/>
+                                                    <TextBox Grid.Row="3"
+                                                             Grid.Column="1"
+                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Reference [mV]"
-                                                             Text="{Binding PackVoltageHighReference}"
-                                                             Width="140" Margin="0,0,8,0"/>
-                                                    <TextBox Grid.Column="1"
+                                                             Text="{Binding PackVoltageHighReference}"/>
+                                                    <TextBox Grid.Row="3"
+                                                             Grid.Column="2"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding PackVoltageHighResult}"
-                                                             Width="140" Margin="0,0,8,0"/>
-                                                    <Button Grid.Column="2"
+                                                             Text="{Binding PackVoltageHighResult}"/>
+                                                    <Button Grid.Row="3"
+                                                            Grid.Column="3"
                                                             Content="Calibrate High"
-                                                            Width="100"
+                                                            Width="120"
                                                             Style="{StaticResource SecondaryActionButton}"/>
                                                 </Grid>
-                                            </StackPanel>
+                                            </Grid>
                                         </materialDesign:Card>
 
                                         <!-- Current card -->
                                         <materialDesign:Card Padding="16" Margin="0,0,0,16">
-                                            <StackPanel>
+                                            <Grid materialDesign:GridAssist.RowSpacing="16">
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="Auto"/>
+                                                    <RowDefinition Height="Auto"/>
+                                                </Grid.RowDefinitions>
                                                 <TextBlock Text="Current"
-                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                                                           Margin="0,0,0,8"/>
-                                                <Grid Margin="0,16,0,0">
+                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"/>
+                                                <Grid Grid.Row="1"
+                                                      materialDesign:GridAssist.ColumnSpacing="12"
+                                                      materialDesign:GridAssist.RowSpacing="12">
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="160"/>
+                                                        <ColumnDefinition Width="160"/>
                                                         <ColumnDefinition Width="Auto"/>
                                                     </Grid.ColumnDefinitions>
                                                     <Grid.RowDefinitions>
                                                         <RowDefinition Height="Auto"/>
                                                         <RowDefinition Height="Auto"/>
                                                     </Grid.RowDefinitions>
-                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                    <TextBlock Grid.Row="0"
+                                                               Text="Calibration"
+                                                               FontWeight="SemiBold"
+                                                               VerticalAlignment="Center"/>
+                                                    <TextBox Grid.Row="0"
+                                                             Grid.Column="1"
+                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Reference [mA]"
-                                                             Text="{Binding CurrentReference}"
-                                                             Width="140" Margin="0,0,8,0"/>
-                                                    <TextBox Grid.Column="1"
+                                                             Text="{Binding CurrentReference}"/>
+                                                    <TextBox Grid.Row="0"
+                                                             Grid.Column="2"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding CurrentResult}"
-                                                             Width="140" Margin="0,0,8,0"/>
-                                                    <Button Grid.Column="2"
+                                                             Text="{Binding CurrentResult}"/>
+                                                    <Button Grid.Row="0"
+                                                            Grid.Column="3"
                                                             Content="Calibrate"
-                                                            Width="100"
+                                                            Width="120"
                                                             Style="{StaticResource SecondaryActionButton}"/>
+                                                    <TextBlock Grid.Row="1"
+                                                               Text="Discharge"
+                                                               FontWeight="SemiBold"
+                                                               VerticalAlignment="Center"/>
                                                     <Button Grid.Row="1"
-                                                            Grid.Column="2"
+                                                            Grid.Column="3"
                                                             Content="Discharge"
-                                                            Width="100"
-                                                            Margin="0,8,0,0"
+                                                            Width="120"
                                                             Style="{StaticResource SecondaryActionButton}"/>
                                                 </Grid>
-                                            </StackPanel>
+                                            </Grid>
                                         </materialDesign:Card>
 
                                         <!-- Temperature card -->
                                         <materialDesign:Card Padding="16">
-                                            <StackPanel>
+                                            <Grid materialDesign:GridAssist.RowSpacing="16">
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="Auto"/>
+                                                    <RowDefinition Height="Auto"/>
+                                                </Grid.RowDefinitions>
                                                 <TextBlock Text="Temperature"
-                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                                                           Margin="0,0,0,8"/>
-                                                <Grid Margin="0,16,0,0">
+                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"/>
+                                                <Grid Grid.Row="1"
+                                                      materialDesign:GridAssist.ColumnSpacing="12">
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="160"/>
+                                                        <ColumnDefinition Width="160"/>
                                                         <ColumnDefinition Width="Auto"/>
                                                     </Grid.ColumnDefinitions>
-                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                             materialDesign:HintAssist.Hint="Reference [°C]"
-                                                             Text="{Binding TemperatureReference}"
-                                                             Width="140" Margin="0,0,8,0"/>
+                                                    <TextBlock Grid.Column="0"
+                                                               Text="Calibration"
+                                                               FontWeight="SemiBold"
+                                                               VerticalAlignment="Center"/>
                                                     <TextBox Grid.Column="1"
                                                              Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                             materialDesign:HintAssist.Hint="Reference [°C]"
+                                                             Text="{Binding TemperatureReference}"/>
+                                                    <TextBox Grid.Column="2"
+                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
-                                                             Text="{Binding TemperatureResult}"
-                                                             Width="140" Margin="0,0,8,0"/>
-                                                    <Button Grid.Column="2"
+                                                             Text="{Binding TemperatureResult}"/>
+                                                    <Button Grid.Column="3"
                                                             Content="Set Temp"
-                                                            Width="100"
+                                                            Width="120"
                                                             Style="{StaticResource SecondaryActionButton}"/>
                                                 </Grid>
-                                            </StackPanel>
+                                            </Grid>
                                         </materialDesign:Card>
                                     </StackPanel>
                                 </StackPanel>

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -82,23 +82,82 @@
                                                Style="{StaticResource MaterialDesignHeadline6TextBlock}"
                                                Margin="0,0,0,16"/>
                                     <StackPanel>
+                                        <!-- ADC readings -->
+                                        <materialDesign:Card Padding="16" Margin="0,0,0,16">
+                                            <StackPanel>
+                                                <TextBlock Text="ADC Readings"
+                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                                                           Margin="0,0,0,8"/>
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <Grid Grid.Column="0">
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="Auto"/>
+                                                            <ColumnDefinition Width="*"/>
+                                                        </Grid.ColumnDefinitions>
+                                                        <Grid.RowDefinitions>
+                                                            <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="Auto"/>
+                                                        </Grid.RowDefinitions>
+                                                        <TextBlock Grid.Row="0"
+                                                                   Text="Voltage"
+                                                                   FontWeight="SemiBold"
+                                                                   VerticalAlignment="Center"
+                                                                   Margin="0,0,12,0"/>
+                                                        <TextBox Grid.Row="0"
+                                                                 Grid.Column="1"
+                                                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                 materialDesign:HintAssist.Hint="ADC"
+                                                                 Text="{Binding VoltageAdcValue}"
+                                                                 Width="160"
+                                                                 IsReadOnly="True"/>
+                                                        <TextBlock Grid.Row="1"
+                                                                   Text="Current"
+                                                                   FontWeight="SemiBold"
+                                                                   VerticalAlignment="Center"
+                                                                   Margin="0,12,12,0"/>
+                                                        <TextBox Grid.Row="1"
+                                                                 Grid.Column="1"
+                                                                 Margin="0,12,0,0"
+                                                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                 materialDesign:HintAssist.Hint="ADC"
+                                                                 Text="{Binding CurrentAdcValue}"
+                                                                 Width="160"
+                                                                 IsReadOnly="True"/>
+                                                        <TextBlock Grid.Row="2"
+                                                                   Text="Temperature"
+                                                                   FontWeight="SemiBold"
+                                                                   VerticalAlignment="Center"
+                                                                   Margin="0,12,12,0"/>
+                                                        <TextBox Grid.Row="2"
+                                                                 Grid.Column="1"
+                                                                 Margin="0,12,0,0"
+                                                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                                 materialDesign:HintAssist.Hint="ADC"
+                                                                 Text="{Binding TemperatureAdcValue}"
+                                                                 Width="160"
+                                                                 IsReadOnly="True"/>
+                                                    </Grid>
+                                                    <Button Grid.Column="1"
+                                                            Content="Read"
+                                                            Width="100"
+                                                            Margin="16,0,0,0"
+                                                            Command="{Binding ReadAdcValuesCommand}"
+                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                </Grid>
+                                            </StackPanel>
+                                        </materialDesign:Card>
+
                                         <!-- Voltage card -->
                                         <materialDesign:Card Padding="16" Margin="0,0,0,16">
                                             <StackPanel>
                                                 <TextBlock Text="Voltage"
                                                            Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
                                                            Margin="0,0,0,8"/>
-                                                <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
-                                                    <TextBlock Text="ADC"
-                                                               FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"
-                                                               Width="80"/>
-                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                             materialDesign:HintAssist.Hint="Value"
-                                                             Text="{Binding VoltageAdcValue}"
-                                                             Width="160"
-                                                             IsReadOnly="True"/>
-                                                </StackPanel>
                                                 <TextBlock Text="Low Side" FontWeight="Bold" Margin="0,16,0,0"/>
                                                 <Grid Margin="0,4,0,0">
                                                     <Grid.ColumnDefinitions>
@@ -147,85 +206,68 @@
                                         <!-- Current card -->
                                         <materialDesign:Card Padding="16" Margin="0,0,0,16">
                                             <StackPanel>
-                                                <Grid>
+                                                <TextBlock Text="Current"
+                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                                                           Margin="0,0,0,8"/>
+                                                <Grid Margin="0,16,0,0">
                                                     <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
                                                         <ColumnDefinition Width="Auto"/>
                                                     </Grid.ColumnDefinitions>
-                                                    <TextBlock Text="Current"
-                                                               Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                                                               Margin="0,0,8,0"/>
-                                                    <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="16,0,0,0">
-                                                        <Button Content="Calibrate"
-                                                                Width="100"
-                                                                Margin="0,0,8,0"
-                                                                Style="{StaticResource SecondaryActionButton}"/>
-                                                        <Button Content="Discharge"
-                                                                Width="100"
-                                                                Style="{StaticResource SecondaryActionButton}"/>
-                                                    </StackPanel>
-                                                </Grid>
-                                                <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
-                                                    <TextBlock Text="ADC"
-                                                               FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"
-                                                               Width="80"/>
-                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                             materialDesign:HintAssist.Hint="Value"
-                                                             Text="{Binding CurrentAdcValue}"
-                                                             Width="160"
-                                                             IsReadOnly="True"/>
-                                                </StackPanel>
-                                                <StackPanel Orientation="Horizontal" Margin="0,16,0,0">
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                    </Grid.RowDefinitions>
                                                     <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Reference [mA]"
                                                              Text="{Binding CurrentReference}"
                                                              Width="140" Margin="0,0,8,0"/>
-                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                    <TextBox Grid.Column="1"
+                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
                                                              Text="{Binding CurrentResult}"
-                                                             Width="140"/>
-                                                </StackPanel>
+                                                             Width="140" Margin="0,0,8,0"/>
+                                                    <Button Grid.Column="2"
+                                                            Content="Calibrate"
+                                                            Width="100"
+                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                    <Button Grid.Row="1"
+                                                            Grid.Column="2"
+                                                            Content="Discharge"
+                                                            Width="100"
+                                                            Margin="0,8,0,0"
+                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                </Grid>
                                             </StackPanel>
                                         </materialDesign:Card>
 
                                         <!-- Temperature card -->
                                         <materialDesign:Card Padding="16">
                                             <StackPanel>
-                                                <Grid>
+                                                <TextBlock Text="Temperature"
+                                                           Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
+                                                           Margin="0,0,0,8"/>
+                                                <Grid Margin="0,16,0,0">
                                                     <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
                                                         <ColumnDefinition Width="Auto"/>
                                                     </Grid.ColumnDefinitions>
-                                                    <TextBlock Text="Temperature"
-                                                               Style="{StaticResource MaterialDesignSubtitle1TextBlock}"
-                                                               Margin="0,0,8,0"/>
-                                                    <Button Grid.Column="1"
-                                                            Content="Set Temp"
-                                                            Width="100"
-                                                            Style="{StaticResource SecondaryActionButton}"/>
-                                                </Grid>
-                                                <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
-                                                    <TextBlock Text="ADC"
-                                                               FontWeight="SemiBold"
-                                                               VerticalAlignment="Center"
-                                                               Width="80"/>
-                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                                             materialDesign:HintAssist.Hint="Value"
-                                                             Text="{Binding TemperatureAdcValue}"
-                                                             Width="160"
-                                                             IsReadOnly="True"/>
-                                                </StackPanel>
-                                                <StackPanel Orientation="Horizontal" Margin="0,16,0,0">
                                                     <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Reference [°C]"
                                                              Text="{Binding TemperatureReference}"
                                                              Width="140" Margin="0,0,8,0"/>
-                                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                    <TextBox Grid.Column="1"
+                                                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
                                                              materialDesign:HintAssist.Hint="Result"
                                                              Text="{Binding TemperatureResult}"
-                                                             Width="140"/>
-                                                </StackPanel>
+                                                             Width="140" Margin="0,0,8,0"/>
+                                                    <Button Grid.Column="2"
+                                                            Content="Set Temp"
+                                                            Width="100"
+                                                            Style="{StaticResource SecondaryActionButton}"/>
+                                                </Grid>
                                             </StackPanel>
                                         </materialDesign:Card>
                                     </StackPanel>


### PR DESCRIPTION
## Summary
- stack the board calibration cards vertically and reposition their action buttons for clarity
- add ADC value display fields for voltage, current, and temperature along with calibrate controls for each voltage side
- expose placeholder ADC value properties in the settings view model for the new UI bindings

## Testing
- dotnet build *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df4ad7b9708323a5a8082b466470e9