### PR TITLE
Add import/export controls to board and protection settings

### DIFF
--- a/CellManager/CellManager/ViewModels/SettingsViewModel.cs
+++ b/CellManager/CellManager/ViewModels/SettingsViewModel.cs
@@ -115,8 +115,12 @@ namespace CellManager.ViewModels
 
         public RelayCommand ReadProtectionCommand { get; }
         public RelayCommand WriteProtectionCommand { get; }
+        public RelayCommand ImportProtectionCommand { get; }
+        public RelayCommand ExportProtectionCommand { get; }
         public RelayCommand ReadBoardDataCommand { get; }
         public RelayCommand WriteBoardDataCommand { get; }
+        public RelayCommand ImportBoardDataCommand { get; }
+        public RelayCommand ExportBoardDataCommand { get; }
         public RelayCommand ReadAdcValuesCommand { get; }
 
         private readonly Dictionary<string, List<ProtectionSetting>> _profiles = new();
@@ -129,6 +133,10 @@ namespace CellManager.ViewModels
             WriteProtectionCommand = new RelayCommand(WriteProtectionSettings, CanReadWriteProtection);
             ReadBoardDataCommand = new RelayCommand(ReadBoardDataSettings);
             WriteBoardDataCommand = new RelayCommand(WriteBoardDataSettings);
+            ImportBoardDataCommand = new RelayCommand(ImportBoardDataSettings);
+            ExportBoardDataCommand = new RelayCommand(ExportBoardDataSettings);
+            ImportProtectionCommand = new RelayCommand(ImportProtectionSettings, CanReadWriteProtection);
+            ExportProtectionCommand = new RelayCommand(ExportProtectionSettings, CanReadWriteProtection);
             ReadAdcValuesCommand = new RelayCommand(ReadAdcValues);
             ReadProtectionSettings();
             ReadBoardDataSettings();
@@ -166,15 +174,49 @@ namespace CellManager.ViewModels
             // Placeholder for writing logic
         }
 
+        private void ImportProtectionSettings()
+        {
+            if (!CanReadWriteProtection())
+            {
+                MessageBox.Show($"Unsupported firmware version. Supported versions: {string.Join(", ", SupportedFirmwareVersions)}");
+                return;
+            }
+
+            // Placeholder for import logic
+        }
+
+        private void ExportProtectionSettings()
+        {
+            if (!CanReadWriteProtection())
+            {
+                MessageBox.Show($"Unsupported firmware version. Supported versions: {string.Join(", ", SupportedFirmwareVersions)}");
+                return;
+            }
+
+            // Placeholder for export logic
+        }
+
         private void ReadAdcValues()
         {
             // Placeholder for reading ADC values from hardware
+        }
+
+        private void ImportBoardDataSettings()
+        {
+            // Placeholder for import logic
+        }
+
+        private void ExportBoardDataSettings()
+        {
+            // Placeholder for export logic
         }
 
         partial void OnFirmwareVersionChanged(string value)
         {
             ReadProtectionCommand.NotifyCanExecuteChanged();
             WriteProtectionCommand.NotifyCanExecuteChanged();
+            ImportProtectionCommand.NotifyCanExecuteChanged();
+            ExportProtectionCommand.NotifyCanExecuteChanged();
         }
     }
 

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -448,6 +448,57 @@
                                     <TextBlock Text="Board Settings Data"
                                                Style="{StaticResource MaterialDesignHeadline6TextBlock}"
                                                Margin="0,0,0,16"/>
+                                    <StackPanel Orientation="Horizontal"
+                                                HorizontalAlignment="Right"
+                                                Margin="0,0,0,16">
+                                        <Button Command="{Binding ReadBoardDataCommand}"
+                                                MinWidth="120"
+                                                Margin="0,0,8,0"
+                                                Style="{StaticResource SecondaryActionButton}">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <materialDesign:PackIcon Kind="Download"
+                                                                         Width="20"
+                                                                         Height="20"
+                                                                         Margin="0,0,8,0"/>
+                                                <TextBlock Text="Read"/>
+                                            </StackPanel>
+                                        </Button>
+                                        <Button Command="{Binding WriteBoardDataCommand}"
+                                                MinWidth="120"
+                                                Margin="0,0,8,0"
+                                                Style="{StaticResource SecondaryActionButton}">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <materialDesign:PackIcon Kind="Upload"
+                                                                         Width="20"
+                                                                         Height="20"
+                                                                         Margin="0,0,8,0"/>
+                                                <TextBlock Text="Write"/>
+                                            </StackPanel>
+                                        </Button>
+                                        <Button Command="{Binding ImportBoardDataCommand}"
+                                                MinWidth="120"
+                                                Margin="0,0,8,0"
+                                                Style="{StaticResource SecondaryActionButton}">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <materialDesign:PackIcon Kind="FileImport"
+                                                                         Width="20"
+                                                                         Height="20"
+                                                                         Margin="0,0,8,0"/>
+                                                <TextBlock Text="Import"/>
+                                            </StackPanel>
+                                        </Button>
+                                        <Button Command="{Binding ExportBoardDataCommand}"
+                                                MinWidth="120"
+                                                Style="{StaticResource SecondaryActionButton}">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <materialDesign:PackIcon Kind="FileExport"
+                                                                         Width="20"
+                                                                         Height="20"
+                                                                         Margin="0,0,8,0"/>
+                                                <TextBlock Text="Export"/>
+                                            </StackPanel>
+                                        </Button>
+                                    </StackPanel>
                                     <DataGrid ItemsSource="{Binding Source={StaticResource BoardDataSettingsGrouped}}"
                                               AutoGenerateColumns="False"
                                               HeadersVisibility="Column"
@@ -498,17 +549,6 @@
                                             </GroupStyle>
                                         </DataGrid.GroupStyle>
                                     </DataGrid>
-                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                        <Button Content="Read"
-                                                Command="{Binding ReadBoardDataCommand}"
-                                                Width="80"
-                                                Margin="0,0,8,0"
-                                                Style="{StaticResource SecondaryActionButton}"/>
-                                        <Button Content="Write"
-                                                Command="{Binding WriteBoardDataCommand}"
-                                                Width="80"
-                                                Style="{StaticResource SecondaryActionButton}"/>
-                                    </StackPanel>
                                 </StackPanel>
                             </materialDesign:Card>
                         </StackPanel>
@@ -530,6 +570,57 @@
                                     <TextBlock Text="Protection Settings Data"
                                                Style="{StaticResource MaterialDesignHeadline6TextBlock}"
                                                Margin="0,0,0,16"/>
+                                    <StackPanel Orientation="Horizontal"
+                                                HorizontalAlignment="Right"
+                                                Margin="0,0,0,16">
+                                        <Button Command="{Binding ReadProtectionCommand}"
+                                                MinWidth="120"
+                                                Margin="0,0,8,0"
+                                                Style="{StaticResource SecondaryActionButton}">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <materialDesign:PackIcon Kind="Download"
+                                                                         Width="20"
+                                                                         Height="20"
+                                                                         Margin="0,0,8,0"/>
+                                                <TextBlock Text="Read"/>
+                                            </StackPanel>
+                                        </Button>
+                                        <Button Command="{Binding WriteProtectionCommand}"
+                                                MinWidth="120"
+                                                Margin="0,0,8,0"
+                                                Style="{StaticResource SecondaryActionButton}">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <materialDesign:PackIcon Kind="Upload"
+                                                                         Width="20"
+                                                                         Height="20"
+                                                                         Margin="0,0,8,0"/>
+                                                <TextBlock Text="Write"/>
+                                            </StackPanel>
+                                        </Button>
+                                        <Button Command="{Binding ImportProtectionCommand}"
+                                                MinWidth="120"
+                                                Margin="0,0,8,0"
+                                                Style="{StaticResource SecondaryActionButton}">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <materialDesign:PackIcon Kind="FileImport"
+                                                                         Width="20"
+                                                                         Height="20"
+                                                                         Margin="0,0,8,0"/>
+                                                <TextBlock Text="Import"/>
+                                            </StackPanel>
+                                        </Button>
+                                        <Button Command="{Binding ExportProtectionCommand}"
+                                                MinWidth="120"
+                                                Style="{StaticResource SecondaryActionButton}">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <materialDesign:PackIcon Kind="FileExport"
+                                                                         Width="20"
+                                                                         Height="20"
+                                                                         Margin="0,0,8,0"/>
+                                                <TextBlock Text="Export"/>
+                                            </StackPanel>
+                                        </Button>
+                                    </StackPanel>
                                     <DataGrid ItemsSource="{Binding Source={StaticResource ProtectionSettingsGrouped}}"
                                               AutoGenerateColumns="False"
                                               HeadersVisibility="Column"
@@ -581,17 +672,6 @@
                                             </GroupStyle>
                                         </DataGrid.GroupStyle>
                                     </DataGrid>
-                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                        <Button Content="Read"
-                                                Command="{Binding ReadProtectionCommand}"
-                                                Width="80"
-                                                Margin="0,0,8,0"
-                                                Style="{StaticResource SecondaryActionButton}"/>
-                                        <Button Content="Write"
-                                                Command="{Binding WriteProtectionCommand}"
-                                                Width="80"
-                                                Style="{StaticResource SecondaryActionButton}"/>
-                                    </StackPanel>
                                 </StackPanel>
                             </materialDesign:Card>
                         </StackPanel>


### PR DESCRIPTION
## Summary
- move board data and protection action buttons above their grids and add icons for clarity
- add import/export actions alongside read/write with bindings to new placeholder commands
- expose new commands in the settings view model with firmware-aware enablement hooks

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68df5b9c6e548323a3563b908cd13594