### PR TITLE
Add firmware update tab to settings

### DIFF
--- a/CellManager/CellManager/ViewModels/SettingsViewModel.cs
+++ b/CellManager/CellManager/ViewModels/SettingsViewModel.cs
@@ -109,6 +109,12 @@ namespace CellManager.ViewModels
         [ObservableProperty]
         private string _firmwareVersion = "1.0";
 
+        [ObservableProperty]
+        private string _firmwareSubVersion = string.Empty;
+
+        [ObservableProperty]
+        private string _firmwareChecksum = string.Empty;
+
         public ObservableCollection<BoardDataSetting> BoardDataSettings { get; } = new();
 
         public ObservableCollection<ProtectionSetting> ProtectionSettings { get; } = new();

--- a/CellManager/CellManager/Views/Settings/SettingsView.xaml
+++ b/CellManager/CellManager/Views/Settings/SettingsView.xaml
@@ -696,23 +696,47 @@
                     </ScrollViewer>
                 </TabItem>
 
-                <TabItem Header="Paths">
+                <TabItem Header="FW Update">
                     <ScrollViewer>
                         <StackPanel Margin="16">
                             <materialDesign:Card Margin="0,0,0,16" Padding="16">
                                 <StackPanel>
-                                    <TextBlock Text="Paths"
+                                    <TextBlock Text="Firmware Update"
                                                Style="{StaticResource MaterialDesignHeadline6TextBlock}"
                                                Margin="0,0,0,16"/>
-                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                             materialDesign:HintAssist.Hint="Data Export Path"
-                                             Text="{Binding DataExportPath}"
-                                             Margin="0,0,0,8"
-                                             HorizontalAlignment="Stretch"/>
-                                    <TextBox Style="{StaticResource MaterialDesignOutlinedTextBox}"
-                                             materialDesign:HintAssist.Hint="Profile Path"
-                                             Text="{Binding ProfilePath}"
-                                             HorizontalAlignment="Stretch"/>
+                                    <TextBlock Text="Provide the firmware metadata before starting an update."
+                                               Style="{StaticResource MaterialDesignBody2TextBlock}"
+                                               Margin="0,0,0,16"/>
+                                    <Grid Margin="0,0,0,8">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+
+                                        <TextBox Grid.Row="0"
+                                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                 materialDesign:HintAssist.Hint="Firmware Version"
+                                                 Text="{Binding FirmwareVersion}"
+                                                 Margin="0,0,0,8"
+                                                 HorizontalAlignment="Stretch"/>
+
+                                        <TextBox Grid.Row="1"
+                                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                 materialDesign:HintAssist.Hint="Firmware Sub Version"
+                                                 Text="{Binding FirmwareSubVersion}"
+                                                 Margin="0,0,0,8"
+                                                 HorizontalAlignment="Stretch"/>
+
+                                        <TextBox Grid.Row="2"
+                                                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                                                 materialDesign:HintAssist.Hint="Firmware Checksum"
+                                                 Text="{Binding FirmwareChecksum}"
+                                                 HorizontalAlignment="Stretch"/>
+                                    </Grid>
                                 </StackPanel>
                             </materialDesign:Card>
                         </StackPanel>


### PR DESCRIPTION
## Summary
- replace the Paths settings tab with a new FW Update tab focused on firmware metadata
- bind firmware version, sub version, and checksum fields in the settings view model

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df5d48ed888323b0a7b445017860b3